### PR TITLE
[Net] Raise the speed returned by XNetQosServiceLookup

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -923,8 +923,8 @@ dword_result_t NetDll_XNetQosServiceLookup_entry(dword_t caller, dword_t flags,
     qos->info[0].data_ptr = *(uint8_t*)"A";
     qos->info[0].rtt_min_in_msecs = 4;
     qos->info[0].rtt_med_in_msecs = 10;
-    qos->info[0].up_bits_per_sec = 20 * 1024;
-    qos->info[0].down_bits_per_sec = 20 * 1024;
+    qos->info[0].up_bits_per_sec = 1024 * 1024;
+    qos->info[0].down_bits_per_sec = 1024 * 1024;
     qos->info[0].flags = XNET_XNQOSINFO::COMPLETE |
                          XNET_XNQOSINFO::TARGET_CONTACTED |
                          XNET_XNQOSINFO::DATA_RECEIVED;


### PR DESCRIPTION
This increases the up and down speeds returned by XNetQosServiceLookup from 20 kbit/sec (very low) to 1024 kbit/sec. This is needed for Team Fortress 2 (The Orange Box) as it needs at least 840 kbit/sec up speed to support a 16 player lobby - TU5 hard limits lobby size if the reported up speed is too low.