### PR TITLE
Add configuration variable to enable XLink Kai systemlink hack

### DIFF
--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -33,6 +33,10 @@ DEFINE_bool(log_mask_ips, true, "Do not include P2P IPs inside the log",
 DEFINE_bool(offline_mode, false, "Offline Mode e.g. not connected to a LAN",
             "Live");
 
+DEFINE_bool(xlink_kai_systemlink_hack, false,
+            "Enable hacks for XLink Kai support. May break some games. See: https://www.teamxlink.co.uk/wiki/Xenia_Support", "Live");
+
+
 DEFINE_string(network_guid, "", "Network Interface GUID", "Live");
 
 DECLARE_string(upnp_root);

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -46,6 +46,8 @@ DECLARE_bool(log_mask_ips);
 
 DECLARE_bool(offline_mode);
 
+DECLARE_bool(xlink_kai_systemlink_hack);
+
 enum XNET_QOS {
   LISTEN_ENABLE = 0x01,
   LISTEN_DISABLE = 0x02,
@@ -1470,6 +1472,11 @@ dword_result_t NetDll_bind_entry(dword_t caller, dword_t socket_handle,
   if (!socket) {
     XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
     return -1;
+  }
+
+  if (!XLiveAPI::adapter_has_wan_routing && cvars::xlink_kai_systemlink_hack) {
+    // Force socket to bind to the IP of the selected interface
+    name->address_ip = XLiveAPI::LocalIP().sin_addr;
   }
 
   X_STATUS status = socket->Bind(name, namelen);


### PR DESCRIPTION
This is the only remaining change needed for XLink Kai support but this is an interim solution until a better approach is found as this breaks some games. (CS GO)

This change forces sockets to bind to the selected interface but only when that interface does not have valid IP routing. That makes it specific to XLink Kai support as [kaiLoopbackBridge](https://www.teamxlink.co.uk/wiki/KaiLoopbackBridge) will provide a network interface with no routing.