### PR TITLE
[XLiveBase] Implemented XStringVerify

### DIFF
--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -1176,12 +1176,106 @@ X_HRESULT XLiveBaseApp::XStringVerify(uint32_t buffer_ptr,
     return X_E_INVALIDARG;
   }
 
-  uint32_t* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint32_t*>(buffer_ptr);
+  XStringVerify_Marshalled_Data* data_ptr =
+      kernel_state_->memory()->TranslateVirtual<XStringVerify_Marshalled_Data*>(
+          buffer_ptr);
 
-  // TODO(Gliniak): Figure out structure after marshaling.
-  // Based on what game does there must be some structure that
-  // checks if string is proper.
+  Internal_Marshalled_Data* internal_data_ptr =
+      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
+          data_ptr->internal_data_ptr);
+
+  uint8_t* args_stream_ptr =
+      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
+          internal_data_ptr->start_args_ptr);
+
+  STRING_VERIFY_RESPONSE* responses_ptr =
+      kernel_state_->memory()->TranslateVirtual<STRING_VERIFY_RESPONSE*>(
+          internal_data_ptr->results_ptr);
+
+  if (!data_ptr->internal_data_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!internal_data_ptr->start_args_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!internal_data_ptr->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  memset(responses_ptr, 0, internal_data_ptr->results_size);
+
+  uint16_t* locale_size_ptr =
+      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
+          data_ptr->locale_size_ptr);
+  uint16_t* num_strings_ptr =
+      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
+          data_ptr->num_strings_ptr);
+  uint16_t* last_entry_ptr =
+      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
+          data_ptr->last_entry_ptr);
+
+  uint16_t locale_size = *locale_size_ptr;
+  uint16_t num_strings = *num_strings_ptr;
+
+  if (locale_size > X_ONLINE_MAX_XSTRING_VERIFY_LOCALE) {
+    return X_E_INVALIDARG;
+  }
+
+  if (num_strings > X_ONLINE_MAX_XSTRING_VERIFY_STRING_DATA) {
+    return X_E_INVALIDARG;
+  }
+
+  xe::be<uint32_t> title_id = *reinterpret_cast<uint32_t*>(args_stream_ptr);
+
+  xe::be<uint32_t> flags =
+      *reinterpret_cast<uint32_t*>(args_stream_ptr + sizeof(uint32_t));
+
+  char* locale_string_ptr = kernel_state_->memory()->TranslateVirtual<char*>(
+      data_ptr->num_strings_ptr + sizeof(uint16_t));
+
+  std::string locale = std::string(locale_string_ptr, locale_size);
+
+  char* string_data = locale_string_ptr + locale_size;
+
+  std::vector<std::string> strings_to_verify;
+
+  uint32_t string_data_offset = 0;
+
+  for (uint32_t i = 0; i < num_strings; i++) {
+    uint16_t size = 0;
+    memcpy(&size, string_data + string_data_offset, sizeof(uint16_t));
+
+    string_data_offset += sizeof(uint16_t);
+
+    // Unicode is represented as UTF-8 array
+    char* string_data_ptr = string_data + string_data_offset;
+
+    std::string input_string = std::string(string_data_ptr, size);
+
+    string_data_offset += size;
+
+    strings_to_verify.push_back(input_string);
+
+    XELOGI("{}: {}", __func__, input_string);
+  }
+
+  uint32_t response_result_address =
+      kernel_state_->memory()->HostToGuestVirtual(
+          std::to_address(responses_ptr + 1));
+
+  HRESULT* response_results_ptr =
+      kernel_state_->memory()->TranslateVirtual<HRESULT*>(
+          response_result_address);
+
+  for (uint32_t i = 0; i < num_strings; i++) {
+    response_results_ptr[i] = X_E_SUCCESS;
+  }
+
+  responses_ptr->num_strings = num_strings;
+  responses_ptr->string_result_ptr = response_result_address;
+
   return X_E_SUCCESS;
 }
 

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -41,6 +41,10 @@ namespace xe {
 #define X_ONLINE_E_SESSION_JOIN_ILLEGAL                     static_cast<X_HRESULT>(0x8015520AL)
 #define X_ONLINE_E_SESSION_NOT_FOUND                        static_cast<X_HRESULT>(0x80155200L)
 #define X_ONLINE_E_SESSION_FULL                             static_cast<X_HRESULT>(0x80155202L)
+#define X_ONLINE_STRING_TOO_LONG                            static_cast<X_HRESULT>(0x80157101L)
+#define X_ONLINE_STRING_OFFENSIVE_TEXT                      static_cast<X_HRESULT>(0x80157102L)
+#define X_ONLINE_STRING_NO_DEFAULT_STRING                   static_cast<X_HRESULT>(0x80157103L)
+#define X_ONLINE_STRING_INVALID_LANGUAGE                    static_cast<X_HRESULT>(0x80157104L)
 #define X_ONLINE_E_STORAGE_INVALID_FACILITY                 static_cast<X_HRESULT>(0x8015C009L)
 #define X_ONLINE_E_STORAGE_FILE_NOT_FOUND                   static_cast<X_HRESULT>(0x8015C004L)
 #define X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH             static_cast<X_HRESULT>(0x8015C008L)
@@ -68,6 +72,8 @@ namespace xe {
 #define X_ONLINE_MAX_PATHNAME_LENGTH                255
 #define X_STORAGE_MAX_MEMORY_BUFFER_SIZE            100000000
 #define X_STORAGE_MAX_RESULTS_TO_RETURN             256
+#define X_ONLINE_MAX_XSTRING_VERIFY_LOCALE          512
+#define X_ONLINE_MAX_XSTRING_VERIFY_STRING_DATA     10
 
 #define X_CONTEXT_PRESENCE                          0x00008001
 #define X_CONTEXT_GAME_TYPE                         0x0000800A
@@ -359,6 +365,11 @@ struct X_STORAGE_ENUMERATE_RESULTS {
   xe::be<uint32_t> num_items_returned;
   xe::be<uint32_t> items_ptr;
 };
+struct STRING_VERIFY_RESPONSE {
+  xe::be<uint16_t> num_strings;
+  xe::be<uint32_t> string_result_ptr;
+};
+static_assert_size(STRING_VERIFY_RESPONSE, 0x6);
 
 #pragma pack(pop)
 
@@ -376,6 +387,18 @@ struct XStorageDelete_Marshalled_Data {
   xe::be<uint32_t> unkn1_ptr;
   uint8_t unkn2_data[24];
   xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
+};
+
+struct XStringVerify_Marshalled_Data {
+  xe::be<uint32_t> internal_data_ptr;
+  uint8_t unkn1_data[44];
+  xe::be<uint32_t> unkn1_ptr;
+  uint8_t unkn2_data[24];
+  xe::be<uint32_t> locale_size_ptr;
+  uint8_t unkn3_data[12];
+  xe::be<uint32_t> num_strings_ptr;
+  uint8_t unkn4_data[12];
+  xe::be<uint32_t> last_entry_ptr;
 };
 
 struct XStorageDownloadToMemory_Marshalled_Data {
@@ -404,6 +427,11 @@ struct XStorageEnumerate_Marshalled_Data {
   xe::be<uint32_t> unkn1_ptr;
   uint8_t unkn2_data[24];
   xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
+  xe::be<uint32_t> locale_size_ptr;
+  uint8_t unkn3_data[12];
+  xe::be<uint32_t> num_strings_ptr;
+  uint8_t unkn4_data[12];
+  xe::be<uint32_t> last_entry_ptr;
 };
 
 struct X_DATA_58024 {


### PR DESCRIPTION
Fixed input strings for:
  - Forza Motorsport 4 (Race Title)
  - Halo 3 (Service Tag)
  - Halo 4 (Service Tag)
  - Armored Core V (Pilot name shown in sessions & custom comment)
  - Call of Duty: Black Ops III  (Clan Tag)
  - Call of Duty: Modern Warfare 2 (Clan Tag)
  - Bionic Commando (Clan Tag)
  - Tom Clancy's H.A.W.X (Clan Tag)
  - Tom Clancy's H.A.W.X 2 (Clan Tag)
  - Homefront (Untested) (Clan Tag)
  - Quake 4 (Verifies own gamertag)
  - Football Manager 2008 (Competition Name)
  - Blacklight: Tango Down (Clan Tag)
  - Earth Defense Force 2025 (Custom Session Message)
  - Viva Piñata: TIP
  - Dynasty Warriors: Strikeforce
 
Fixed Tom Clancy's H.A.W.X and Tom Clancy's H.A.W.X 2 from accessing xbox live menus