### PR TITLE
[NET] Improve XHttp & XAuth shutdown

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -1274,19 +1274,48 @@ dword_result_t NetDll_XNetQosGetListenStats_entry(
 DECLARE_XAM_EXPORT1(NetDll_XNetQosGetListenStats, kNetworking, kImplemented);
 
 dword_result_t XampXAuthStartup_entry(pointer_t<XAUTH_SETTINGS> setttings) {
+  if (setttings->SizeOfStruct != sizeof(XAUTH_SETTINGS)) {
+    return 0x80158401;
+  }
+
   return X_ERROR_SUCCESS;
 }
 DECLARE_XAM_EXPORT1(XampXAuthStartup, kNetworking, kStub);
 
+void XampXAuthShutdown_entry(lpdword_t unkn) {
+  *unkn = 1;
+
+  // Causes a call to XampXAuthGetTitleBuffer
+  // *unkn = 0;
+}
+DECLARE_XAM_EXPORT1(XampXAuthShutdown, kNetworking, kStub);
+
+dword_result_t XampXAuthGetTitleBuffer_entry() {
+  // pointer? - non-zero causes crash
+  return 0;
+}
+DECLARE_XAM_EXPORT1(XampXAuthGetTitleBuffer, kNetworking, kStub);
+
 dword_result_t NetDll_XHttpStartup_entry(dword_t caller, dword_t reserved,
                                          dword_t reserved_ptr) {
+  if (kernel_state()->emulator()->title_id() == kDashboardID) {
+    return 1;
+  }
+
+  // 584111F7 - Prevents Minecraft from loading
+  // We're suppose to set error code if we fail function
+  // XThread::SetLastError(XHTTP_ERROR_CONNECTION_ERROR);
   return 0;
 }
 DECLARE_XAM_EXPORT1(NetDll_XHttpStartup, kNetworking, kStub);
 
+void NetDll_XHttpShutdown_entry(dword_t caller) {}
+DECLARE_XAM_EXPORT1(NetDll_XHttpShutdown, kNetworking, kStub);
+
 dword_result_t NetDll_XHttpDoWork_entry(dword_t caller, dword_t handle,
                                         dword_t unk) {
-  XThread::SetLastError(0);
+  XThread::SetLastError(X_ERROR_SUCCESS);
+
   return 0;
 }
 DECLARE_XAM_EXPORT1(NetDll_XHttpDoWork, kNetworking, kStub);
@@ -1336,6 +1365,14 @@ dword_result_t NetDll_XHttpSendRequest_entry(dword_t caller, dword_t hrequest,
   return false;
 }
 DECLARE_XAM_EXPORT1(NetDll_XHttpSendRequest, kNetworking, kStub);
+
+dword_result_t NetDll_XHttpConnect_entry(dword_t caller, dword_t hSession,
+                                         lpstring_t host, dword_t port,
+                                         dword_t flags) {
+  // XThread::SetLastError(XHTTP_ERROR_CONNECTION_ERROR);
+  return 0;
+}
+DECLARE_XAM_EXPORT1(NetDll_XHttpConnect, kNetworking, kStub);
 
 dword_result_t NetDll_inet_addr_entry(lpstring_t addr_ptr) {
   if (!addr_ptr) {

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -58,6 +58,23 @@ namespace xe {
 
 #define X_PARTY_E_NOT_IN_PARTY                              static_cast<X_HRESULT>(0x807D0003L)
 
+#define XHTTP_ERROR_BASE                                    12000
+
+#define XHTTP_ERROR_TIMEOUT                                 (XHTTP_ERROR_BASE + 2)
+#define XHTTP_ERROR_INTERNAL_ERROR                          (XHTTP_ERROR_BASE + 4)
+#define XHTTP_ERROR_UNRECOGNIZED_SCHEME                     (XHTTP_ERROR_BASE + 6)
+#define XHTTP_ERROR_NAME_NOT_RESOLVED                       (XHTTP_ERROR_BASE + 7)
+#define XHTTP_ERROR_INVALID_OPTION                          (XHTTP_ERROR_BASE + 9)
+#define XHTTP_ERROR_OPTION_NOT_SETTABLE                     (XHTTP_ERROR_BASE + 11)
+#define XHTTP_ERROR_INCORRECT_HANDLE_TYPE                   (XHTTP_ERROR_BASE + 18)
+#define XHTTP_ERROR_INCORRECT_HANDLE_STATE                  (XHTTP_ERROR_BASE + 19)
+#define XHTTP_ERROR_CONNECTION_ERROR                        (XHTTP_ERROR_BASE + 30)
+#define XHTTP_ERROR_HEADER_NOT_FOUND                        (XHTTP_ERROR_BASE + 150)
+#define XHTTP_ERROR_INVALID_SERVER_RESPONSE                 (XHTTP_ERROR_BASE + 152)
+#define XHTTP_ERROR_REDIRECT_FAILED                         (XHTTP_ERROR_BASE + 156)
+#define XHTTP_ERROR_NOT_INITIALIZED                         (XHTTP_ERROR_BASE + 172)
+#define XHTTP_ERROR_SECURE_FAILURE                          (XHTTP_ERROR_BASE + 175)
+
 #define X_ONLINE_FRIENDSTATE_FLAG_NONE              0x00000000
 #define X_ONLINE_FRIENDSTATE_FLAG_ONLINE            0x00000001
 #define X_ONLINE_FRIENDSTATE_FLAG_PLAYING           0x00000002


### PR DESCRIPTION
PR in relation to: https://github.com/AdrianCassar/xenia-canary/pull/57

Fixed Games:
 - Dead or Alive 5 Ultimate
 - Monopoly Plus
 - XNE Dashboard (always enable XHttp for dash)

Unchanged:
 - Tomb Raider
 - Advanced Warfare
 - Minecraft