### PR TITLE
[XAM] Implemented XLiveBase Unmarshaller

### DIFF
--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -94,8 +94,6 @@ static_assert_size(XGI_XUSER_STATS_RESET, 0x8);
 
 XgiApp::XgiApp(KernelState* kernel_state) : App(kernel_state, 0xFB) {}
 
-// http://mb.mirage.org/bugzilla/xliveless/main.c
-
 X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                                       uint32_t buffer_length) {
   // NOTE: buffer_length may be zero or valid.
@@ -718,6 +716,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       return XSession::GetWeightedSessions(kernel_state_, data, num_users);
     }
     case 0x000B0026: {
+      // 4D5307EA
       assert_true(!buffer_length || buffer_length == sizeof(XGI_STATS_WRITE));
 
       XGI_STATS_WRITE* data = reinterpret_cast<XGI_STATS_WRITE*>(buffer);

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2021 Ben Vanik. All rights reserved.                             *
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -10,13 +10,25 @@
 #include <span>
 
 #include "xenia/kernel/xam/apps/xlivebase_app.h"
-#include "xenia/kernel/xenumerator.h"
 
 #include "xenia/base/logging.h"
 #include "xenia/base/threading.h"
 #include "xenia/emulator.h"
 #include "xenia/kernel/XLiveAPI.h"
 #include "xenia/kernel/util/shim_utils.h"
+#include "xenia/kernel/xam/unmarshaller/generic_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xlivebase_task.h"
+#include "xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.h"
+#include "xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.h"
+#include "xenia/kernel/xenumerator.h"
 #include "xenia/kernel/xnet.h"
 #include "xenia/ui/imgui_host_notification.h"
 
@@ -42,129 +54,178 @@ namespace kernel {
 namespace xam {
 namespace apps {
 
+// TODO(Adrian): Determine the correct function during runtime, the schema index
+// can change depending on schema data version.
 XLiveBaseApp::XLiveBaseApp(KernelState* kernel_state)
     : App(kernel_state, 0xFC) {}
 
-// http://mb.mirage.org/bugzilla/xliveless/main.c
-
+/// <param name="buffer_ptr"> - Generic param1 could be anything.</param>
+/// <param name="buffer_length"> - Generic param2 could be anything.</param>
 X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
                                             uint32_t buffer_ptr,
                                             uint32_t buffer_length) {
   // NOTE: buffer_length may be zero or valid.
-  auto buffer = memory_->TranslateVirtual(buffer_ptr);
+  uint8_t* buffer = memory_->TranslateVirtual<uint8_t*>(buffer_ptr);
 
   switch (message) {
     case 0x00050002: {
-      // Current session must have PRESENCE flag.
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
       XELOGD("XInviteSend({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return GenericMarshalled(buffer_ptr);
-    }
-    case 0x00058003: {
-      // Called on startup of dashboard (netplay build)
-      XELOGD("XLiveBaseLogonGetHR({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return X_ONLINE_S_LOGON_CONNECTION_ESTABLISHED;
-    }
-    case 0x0005008C: {
-      XELOGD("XLiveBaseUnk5008C({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return Unkn5008C(buffer_ptr);
-    }
-    case 0x00050094: {
-      // Called on startup of blades dashboard v4532 to v4552
-      XELOGD("XLiveBaseUnk50094({:08x}, {:08x}) unimplemented", buffer_ptr,
-             buffer_length);
-      return GenericMarshalled(buffer_ptr);
+      return XInviteSend(buffer_ptr);
     }
     case 0x00050008: {
-      // Required to be successful for 534507D4
-      XELOGD("XStorageDelete({:08x}, {:08x})", buffer_ptr, buffer_length);
-      return XStorageDelete(buffer_ptr);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // Default to XStorageDownloadToMemory instead of XStorageDelete since
+      // it's used more.
+
+      // 534507D4, 555307D7, 545107D1 - XStorageDownloadToMemory
+      XELOGD("XStorageDownloadToMemory({:08X}, {:08X})", buffer_ptr,
+             buffer_length);
+      return XStorageDownloadToMemory(buffer_ptr);
+
+      // XELOGD("XStorageDelete({:08X}, {:08X})", buffer_ptr, buffer_length);
+      // return XStorageDelete(buffer_ptr);
     }
     case 0x00050009: {
-      // Fixes Xbox Live error for 513107D9
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 555307D7 - XStorageEnumerate
       XELOGD("XStorageDownloadToMemory({:08X}, {:08X})", buffer_ptr,
              buffer_length);
       return XStorageDownloadToMemory(buffer_ptr);
     }
     case 0x0005000A: {
-      // 4D5307D3, 415607F7, 584108F0
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 534507D4 - XStorageUploadFromMemory
+      // 4D5307D3, 415607F7, 584108F0, 5454082B, 545407F8, 575207FD
       XELOGD("XStorageEnumerate({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XStorageEnumerate(buffer_ptr);
     }
     case 0x0005000B: {
-      // Fixes Xbox Live error for 43430821
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 43430821
       XELOGD("XStorageUploadFromMemory({:08X}, {:08X})", buffer_ptr,
              buffer_length);
       return XStorageUploadFromMemory(buffer_ptr);
     }
     case 0x0005000C: {
-      XELOGD("XStringVerify({:08X} {:08X})", buffer_ptr, buffer_length);
-      return XStringVerify(buffer_ptr);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 454107F1 - XAccountGetUserInfo
+      // 4E4D07D3 - XStorageUploadFromMemory (-1 schema index offset)
+      // 57520829, 4156081C - XStringVerify (+1 schema index offset)
+      XELOGD("GenericTask({:08X} {:08X})", buffer_ptr, buffer_length);
+      return GenericMarshalled(buffer_ptr);
     }
     case 0x0005000D: {
-      // Fixes hang when leaving session for 545107D5
-      // 415607D2 says this is XStringVerify
-      XELOGD("XStringVerify({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return XStringVerify(buffer_ptr);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // Usually XStringVerify
+      // 4D5307EA, 58410889 - XUserEstimateRankForRating
+      XELOGD("GenericTask({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return GenericMarshalled(buffer_ptr);
     }
     case 0x0005000E: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
       XELOGD("XUserFindUsers({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XUserFindUsers(buffer_ptr);
     }
     case 0x0005000F: {
-      XELOGD("_XAccountGetUserInfo({:08X}, {:08X})", buffer_ptr, buffer_length);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("XAccountGetUserInfo({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XAccountGetUserInfo(buffer_ptr);
     }
     case 0x00050010: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
       XELOGD("XAccountGetUserInfo({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XAccountGetUserInfo(buffer_ptr);
     }
     case 0x00050036: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
       // 534507D4
       XELOGD("XOnlineQuerySearch({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XOnlineQuerySearch(buffer_ptr);
     }
     case 0x00050038: {
-      // 4D5307D3, 4D5307D1
-      XELOGD("XOnlineQuerySearch({:08X}, {:08X}) unimplemented", buffer_ptr,
-             buffer_length);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 4D5307D3, 4D5307D1, 545407E2, 545407E3, 545407D2, 545407D3
+      XELOGD("XOnlineQuerySearch({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XOnlineQuerySearch(buffer_ptr);
     }
     case 0x00050077: {
-      XELOGD("XAccountGetPointsBalance({:08X}, {:08X}) Stubbed", buffer_ptr,
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("XAccountGetPointsBalance({:08X}, {:08X})", buffer_ptr,
              buffer_length);
       return XAccountGetPointsBalance(buffer_ptr);
     }
     case 0x00050079: {
-      // Fixes Xbox Live error for 454107DB
-      XELOGD("XLiveBaseUnk50079({:08X}, {:08X}) unimplemented", buffer_ptr,
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // 454107DB
+      XELOGD("XAccountGetUserInfo({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return XAccountGetUserInfo(buffer_ptr);
+    }
+    case 0x0005008B: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("GetBannerListHot({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return GetBannerListHot(buffer_ptr);
+    }
+    case 0x0005008C: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("GetBannerList({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return GetBannerList(buffer_ptr);
+    }
+    case 0x0005008F: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("ContentEnumerate({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return ContentEnumerate(buffer_ptr);
+    }
+    case 0x00050090: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("GenresEnumerate({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return GenresEnumerate(buffer_ptr);
+    }
+    case 0x00050091: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("EnumerateTitlesByFilter({:08X}, {:08X})", buffer_ptr,
+             buffer_length);
+      return EnumerateTitlesByFilter(buffer_ptr);
+    }
+    case 0x00050094: {
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      // Called on startup of blades dashboard v4532 to v4552
+      XELOGD("XLiveBaseUnk50094({:08X}, {:08X}) Stubbed", buffer_ptr,
              buffer_length);
       return GenericMarshalled(buffer_ptr);
     }
-    case 0x0005008B: {
-      XELOGD("XLiveBaseUnk5008B({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return Unkn5008B(buffer_ptr);
-    }
-    case 0x0005008F: {
-      XELOGD("XLiveBaseUnk5008F({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return Unkn5008F(buffer_ptr);
-    }
-    case 0x00050090: {
-      XELOGD("XLiveBaseUnk50090({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return Unkn50090(buffer_ptr);
-    }
-    case 0x00050091: {
-      XELOGD("XLiveBaseUnk50091({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return Unkn50091(buffer_ptr);
-    }
     case 0x00050097: {
-      XELOGD("XLiveBaseUnk50097({:08X}, {:08X}) Stubbed", buffer_ptr,
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_ASYNC_MESSAGE));
+      XELOGD("SubscriptionEnumerate({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return Unkn50097(buffer_ptr);
+      return SubscriptionEnumerate(buffer_ptr);
+    }
+    case 0x00058003: {
+      assert_true(!buffer_ptr || !buffer_length);
+      // Called on startup of dashboard
+      XELOGD("XLiveBaseLogonGetHR({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return X_ONLINE_S_LOGON_CONNECTION_ESTABLISHED;
     }
     case 0x00058004: {
       assert_true(!buffer_length || buffer_length == sizeof(uint32_t));
@@ -184,107 +245,106 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
       return XOnlineGetServiceInfo(buffer_ptr, buffer_length);
     }
     case 0x00058009: {
-      assert_true(!buffer_length || buffer_length == 0x10);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(X_CONTENT_GET_MARKETPLACE_COUNTS));
       XELOGD("XContentGetMarketplaceCounts({:08X}, {:08X})", buffer_ptr,
              buffer_length);
       return XContentGetMarketplaceCounts(buffer_ptr);
     }
     case 0x0005800A: {
-      assert_true(!buffer_length || buffer_length == 12);
-      XELOGD("XUpdateAccessTimes({:08X}, {:08X}) unimplemented", buffer_ptr,
-             buffer_length);
+      assert_true(!buffer_length ||
+                  buffer_length == sizeof(XLIVEBASE_UPDATE_ACCESS_TIMES));
+      XELOGD("XUpdateAccessTimes({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XUpdateAccessTimes(buffer_ptr);
     }
     case 0x0005800C: {
+      assert_true(!buffer_length);
       // 464F0800
       XELOGD("XUserMuteListAdd({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XUserMuteListAdd(buffer_ptr);
     }
     case 0x0005800D: {
+      assert_true(!buffer_length);
       // 464F0800
       XELOGD("XUserMuteListRemove({:08X}, {:08X})", buffer_ptr, buffer_length);
       return XUserMuteListRemove(buffer_ptr);
     }
     case 0x0005800E: {
-      // Fixes Xbox Live error for 513107D9
-      XELOGD("XUserMuteListQuery({:08X}, {:08X}) unimplemented", buffer_ptr,
-             buffer_length);
-      return X_E_SUCCESS;
+      // 513107D9
+      XELOGD("XUserMuteListQuery({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return XUserMuteListQuery(buffer_ptr, buffer_length);
     }
     case 0x00058017: {
-      XELOGD("XUserFindUsersUnkn58017({:08X}, {:08X})", buffer_ptr,
+      assert_true(!buffer_length);
+      XELOGD("GetNextSequenceMessage({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return XUserFindUsersUnkn58017(buffer_ptr);
+      return GetNextSequenceMessage(buffer_ptr);
     }
     case 0x00058019: {
       // 54510846
       XELOGD("XPresenceCreateEnumerator({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return XPresenceCreateEnumerator(buffer_length);
+      return XPresenceCreateEnumerator(buffer_ptr, buffer_length);
     }
     case 0x0005801C: {
-      XELOGD("XPresenceGetState({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return XPresenceGetState(buffer_length);
+      XELOGD("XPresenceGetState({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return XPresenceGetState(buffer_ptr, buffer_length);
     }
     case 0x0005801E: {
       // 54510846
       XELOGD("XPresenceSubscribe({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return XPresenceSubscribe(buffer_length);
+      return XPresenceSubscribe(buffer_ptr, buffer_length);
     }
     case 0x0005801F: {
       // 545107D1
       XELOGD("XPresenceUnsubscribe({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return XPresenceUnsubscribe(buffer_length);
+      return XPresenceUnsubscribe(buffer_ptr, buffer_length);
     }
     case 0x00058020: {
-      // 0x00058004 is called right before this.
-      // buffer_length seems to be the same ptr sent to 0x00058004.
       XELOGD("XFriendsCreateEnumerator({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return XFriendsCreateEnumerator(buffer_length);
+      return XFriendsCreateEnumerator(buffer_ptr, buffer_length);
     }
     case 0x00058023: {
       // 584107D7
       // 5841091C expects xuid_invitee
-      XELOGD(
-          "CXLiveMessaging::XMessageGameInviteGetAcceptedInfo({:08X}, {:08X})",
-          buffer_ptr, buffer_length);
-      return XInviteGetAcceptedInfo(buffer_length);
+      XELOGD("XInviteGetAcceptedInfo({:08X}, {:08X})", buffer_ptr,
+             buffer_length);
+      return XInviteGetAcceptedInfo(buffer_ptr, buffer_length);
     }
     case 0x00058024: {
-      XELOGD("XMessageEnumerate({:08X}, {:08X}) Stubbed", buffer_ptr,
-             buffer_length);
-      return XMessageEnumerate(buffer_length);
+      XELOGD("XMessageEnumerate({:08X}, {:08X})", buffer_ptr, buffer_length);
+      return XMessageEnumerate(buffer_ptr, buffer_length);
     }
     case 0x00058032: {
+      assert_true(!buffer_length);
       XELOGD("XOnlineGetTaskProgress({:08X}, {:08X})", buffer_ptr,
              buffer_length);
       return XOnlineGetTaskProgress(buffer_ptr);
     }
     case 0x00058035: {
-      // Fixes Xbox Live error for 513107D9
-      // Required for 534507D4
+      assert_true(!buffer_length);
       XELOGD("XStorageBuildServerPath({:08X}, {:08X})", buffer_ptr,
              buffer_length);
+      // 4D5307EA, 4E4D07D3 (Builds Clip Path)
       return XStorageBuildServerPath(buffer_ptr);
     }
     case 0x00058037: {
       // Used in older games such as Crackdown, FM2, Saints Row 1
       XELOGD("XPresenceInitializeLegacy({:08X}, {:08X})", buffer_ptr,
              buffer_length);
-      return XPresenceInitialize(buffer_length);
+      return XPresenceInitialize(buffer_ptr, buffer_length);
     }
     case 0x00058044: {
       XELOGD("XPresenceUnsubscribe({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return XPresenceUnsubscribe(buffer_length);
+      return XPresenceUnsubscribe(buffer_ptr, buffer_length);
     }
     case 0x00058046: {
       // Used in newer games such as Forza 4, MW3, FH2
       //
       // Required to be successful for 4D530910 to detect signed-in profile
       XELOGD("XPresenceInitialize({:08X}, {:08X})", buffer_ptr, buffer_length);
-      return XPresenceInitialize(buffer_length);
+      return XPresenceInitialize(buffer_ptr, buffer_length);
     }
   }
 
@@ -302,10 +362,13 @@ X_HRESULT XLiveBaseApp::DispatchMessageSync(uint32_t message,
 uint32_t MAX_TITLE_SUBSCRIPTIONS = 0;
 uint32_t ACTIVE_TITLE_SUBSCRIPTIONS = 0;
 
-X_HRESULT XLiveBaseApp::XPresenceInitialize(uint32_t buffer_length) {
-  if (!buffer_length) {
+X_HRESULT XLiveBaseApp::XPresenceInitialize(uint32_t buffer_ptr,
+                                            uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 
@@ -333,11 +396,14 @@ X_HRESULT XLiveBaseApp::XPresenceInitialize(uint32_t buffer_length) {
 }
 
 // Presence information for peers will be registered if they're not friends and
-// will be retuned in XPresenceCreateEnumerator.
-X_HRESULT XLiveBaseApp::XPresenceSubscribe(uint32_t buffer_length) {
-  if (!buffer_length) {
+// will be returned in XPresenceCreateEnumerator.
+X_HRESULT XLiveBaseApp::XPresenceSubscribe(uint32_t buffer_ptr,
+                                           uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 
@@ -405,12 +471,15 @@ X_HRESULT XLiveBaseApp::XPresenceSubscribe(uint32_t buffer_length) {
   return X_E_SUCCESS;
 }
 
-// Presence information for peers will not longer be retuned in
+// Presence information for peers will not longer be returned in
 // XPresenceCreateEnumerator unless they're friends.
-X_HRESULT XLiveBaseApp::XPresenceUnsubscribe(uint32_t buffer_length) {
-  if (!buffer_length) {
+X_HRESULT XLiveBaseApp::XPresenceUnsubscribe(uint32_t buffer_ptr,
+                                             uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 
@@ -477,10 +546,13 @@ X_HRESULT XLiveBaseApp::XPresenceUnsubscribe(uint32_t buffer_length) {
 }
 
 // Return presence information for a user's friends and subscribed peers.
-X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_length) {
-  if (!buffer_length) {
+X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
+                                                  uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 
@@ -596,39 +668,174 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_length) {
   return X_E_SUCCESS;
 }
 
+// Backwards compatible XLSP
 X_HRESULT XLiveBaseApp::XOnlineQuerySearch(uint32_t buffer_ptr) {
-  // Usually called after success returned from GetServiceInfo.
+  // Usually called after success returned from XOnlineGetServiceInfo.
 
   if (!buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XOnlineQuerySearch_Marshalled_Data* data_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<XOnlineQuerySearch_Marshalled_Data*>(buffer_ptr);
+  XQuerySearchUnmarshaller* unmarshaller =
+      new XQuerySearchUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  XOnlineQuerySearch_Args* args_online_query_search =
-      kernel_state_->memory()->TranslateVirtual<XOnlineQuerySearch_Args*>(
-          internal_data_ptr->start_args_ptr);
+  if (deserialize_result) {
+    return deserialize_result;
+  }
 
-  QUERY_SEARCH_RESULT* query_search_results_ptr =
-      kernel_state_->memory()->TranslateVirtual<QUERY_SEARCH_RESULT*>(
-          internal_data_ptr->results_ptr);
+  unmarshaller->PrettyPrintAttributesSpec();
 
-  memset(query_search_results_ptr, 0, internal_data_ptr->results_size);
+  unmarshaller->ZeroResults();
 
-  XELOGI("{}: Title ID: {:08X}, Procedure Index: {}, Dataset ID: {:08X}",
-         __func__, args_online_query_search->title_id,
-         args_online_query_search->proc_index,
-         args_online_query_search->dataset_id);
+  QUERY_SEARCH_RESULT* results_ptr =
+      unmarshaller->Results<QUERY_SEARCH_RESULT>();
+
+  const auto services = XLiveAPI::GetServices();
+
+  results_ptr->total_results =
+      static_cast<uint32_t>(services->QuerySearchResults().size());
+  results_ptr->returned_results =
+      static_cast<uint32_t>(services->QuerySearchResults().size());
+  results_ptr->num_result_attributes = static_cast<uint32_t>(
+      unmarshaller->SpecAttributes().size() * results_ptr->returned_results);
+
+  X_ONLINE_QUERY_ATTRIBUTE* attributes_ptr =
+      reinterpret_cast<X_ONLINE_QUERY_ATTRIBUTE*>(results_ptr + 1);
+
+  uint32_t attributes_address = kernel_state_->memory()->HostToGuestVirtual(
+      std::to_address(attributes_ptr));
+
+  results_ptr->attributes_ptr = attributes_address;
+
+  for (uint32_t gateway_index = 0;
+       const auto& gateway : services->QuerySearchResults()) {
+    uint32_t attribute_index = static_cast<uint32_t>(
+        (gateway_index * unmarshaller->SpecAttributes().size()));
+
+    uint8_t* binary_alloc_ptr = reinterpret_cast<uint8_t*>(
+        attributes_ptr + results_ptr->num_result_attributes);
+
+    for (auto const& attribute : unmarshaller->SpecAttributes()) {
+      switch (attribute.type) {
+        case X_ONLINE_LSP_ATTRIBUTE_TSADDR: {
+          assert_false(attribute.length != sizeof(TSADDR));
+
+          // TODO(Adrian): Instead of allocating use title allocated buffer
+          // results_ptr.
+          uint32_t TSADDR_adderess =
+              kernel_state()->memory()->SystemHeapAlloc(sizeof(TSADDR));
+
+          TSADDR* TSADDR_ptr =
+              kernel_state()->memory()->TranslateVirtual<TSADDR*>(
+                  TSADDR_adderess);
+
+          *TSADDR_ptr = gateway;
+
+          attributes_ptr[attribute_index].attribute_id =
+              X_ONLINE_LSP_ATTRIBUTE_TSADDR;
+          attributes_ptr[attribute_index].info.blob.length = sizeof(TSADDR);
+          attributes_ptr[attribute_index].info.blob.value_ptr = TSADDR_adderess;
+        } break;
+        case X_ONLINE_LSP_ATTRIBUTE_XNKID: {
+          assert_false(attribute.length != sizeof(XNKID));
+
+          uint32_t XNKID_adderess =
+              kernel_state()->memory()->SystemHeapAlloc(sizeof(XNKID));
+
+          XNKID* XNKID_ptr = kernel_state()->memory()->TranslateVirtual<XNKID*>(
+              XNKID_adderess);
+
+          xe::be<uint64_t> session_id = GenerateSessionId(XNKID_SERVER);
+
+          std::memcpy(XNKID_ptr, &session_id, sizeof(XNKID));
+
+          attributes_ptr[attribute_index].attribute_id =
+              X_ONLINE_LSP_ATTRIBUTE_XNKID;
+          attributes_ptr[attribute_index].info.blob.length = sizeof(XNKID);
+          attributes_ptr[attribute_index].info.blob.value_ptr = XNKID_adderess;
+        } break;
+        case X_ONLINE_LSP_ATTRIBUTE_KEY: {
+          assert_false(attribute.length != sizeof(XNKEY));
+
+          uint32_t XNKEY_adderess =
+              kernel_state()->memory()->SystemHeapAlloc(sizeof(XNKEY));
+
+          XNKEY* XNKEY_ptr = kernel_state()->memory()->TranslateVirtual<XNKEY*>(
+              XNKEY_adderess);
+
+          GenerateIdentityExchangeKey(XNKEY_ptr);
+
+          attributes_ptr[attribute_index].attribute_id =
+              X_ONLINE_LSP_ATTRIBUTE_KEY;
+          attributes_ptr[attribute_index].info.blob.length = sizeof(XNKEY);
+          attributes_ptr[attribute_index].info.blob.value_ptr = XNKEY_adderess;
+        } break;
+        case X_ONLINE_LSP_ATTRIBUTE_USER:
+          attributes_ptr[attribute_index].attribute_id =
+              X_ONLINE_LSP_ATTRIBUTE_USER;
+          break;
+        case X_ONLINE_LSP_ATTRIBUTE_PARAM_USER:
+          attributes_ptr[attribute_index].attribute_id =
+              X_ONLINE_LSP_ATTRIBUTE_PARAM_USER;
+          break;
+        case X_ATTRIBUTE_DATATYPE_INTEGER:
+          attributes_ptr[attribute_index].attribute_id =
+              X_ATTRIBUTE_DATATYPE_INTEGER;
+          attributes_ptr[attribute_index].info.integer.length = 0;
+          attributes_ptr[attribute_index].info.integer.value = 0;
+          break;
+        case X_ATTRIBUTE_DATATYPE_STRING: {
+          // PGR3 & PDZ use X_ATTRIBUTE_DATATYPE_STRING
+
+          // PGR3
+          std::u16string filter = u"VINCE";
+
+          uint32_t size = static_cast<uint32_t>(
+              xe::string_util::size_in_bytes(filter, true));
+
+          // LSP Filter?
+          uint32_t string_adderess =
+              kernel_state()->memory()->SystemHeapAlloc(size);
+
+          char16_t* string_ptr =
+              kernel_state()->memory()->TranslateVirtual<char16_t*>(
+                  string_adderess);
+
+          xe::string_util::copy_and_swap_truncating(string_ptr, filter.c_str(),
+                                                    filter.size() + 1);
+
+          attributes_ptr[attribute_index].attribute_id =
+              X_ATTRIBUTE_DATATYPE_STRING;
+          attributes_ptr[attribute_index].info.string.length =
+              static_cast<uint32_t>(filter.size() + 1);
+          attributes_ptr[attribute_index].info.string.value_ptr =
+              string_adderess;
+        } break;
+        case X_ATTRIBUTE_DATATYPE_BLOB:
+          attributes_ptr[attribute_index].attribute_id =
+              X_ATTRIBUTE_DATATYPE_BLOB;
+          break;
+        default:
+          assert_always();
+          break;
+      }
+
+      attribute_index++;
+    }
+
+    gateway_index++;
+  }
+
+  XELOGI("{}: Total Gateways: {}, Returned Gateways: {}, Attributes: {}",
+         __func__, results_ptr->total_results.get(),
+         results_ptr->returned_results.get(), unmarshaller->NumAttributes());
 
   return X_E_SUCCESS;
 }
 
+// Check whether XLSP services are available
 X_HRESULT XLiveBaseApp::XOnlineGetServiceInfo(uint32_t serviceid,
                                               uint32_t serviceinfo) {
   if (!XLiveAPI::IsConnectedToServer()) {
@@ -656,22 +863,25 @@ X_HRESULT XLiveBaseApp::XOnlineGetServiceInfo(uint32_t serviceid,
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr) {
-  if (!buffer_ptr) {
+X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr,
+                                                 uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
 
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
+
   Memory* memory = kernel_state_->memory();
 
-  X_ARGUMENT_LIST* args_list =
-      memory->TranslateVirtual<X_ARGUMENT_LIST*>(buffer_ptr);
+  const X_ARGUMENT_LIST* args_list =
+      memory->TranslateVirtual<X_ARGUMENT_LIST*>(buffer_length);
 
   if (args_list->argument_count != 5) {
     assert_always(fmt::format("{} - Invalid argument count!", __func__));
   }
 
   X_CREATE_FRIENDS_ENUMERATOR* friends_enumerator =
-      memory->TranslateVirtual<X_CREATE_FRIENDS_ENUMERATOR*>(buffer_ptr);
+      memory->TranslateVirtual<X_CREATE_FRIENDS_ENUMERATOR*>(buffer_length);
 
   const uint32_t user_index = xe::load_and_swap<uint32_t>(
       memory->TranslateVirtual(static_cast<uint32_t>(
@@ -795,7 +1005,37 @@ void XLiveBaseApp::UpdatePresenceXUIDs(const std::vector<uint64_t>& xuids,
   }
 }
 
-X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_length) {
+X_HRESULT XLiveBaseApp::XInviteSend(uint32_t buffer_ptr) {
+  if (!buffer_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  // Current session must have PRESENCE flag.
+
+  XInviteSendUnmarshaller* unmarshaller =
+      new XInviteSendUnmarshaller(buffer_ptr);
+
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
+
+  if (deserialize_result) {
+    return deserialize_result;
+  }
+
+  new xe::ui::HostNotificationWindow(
+      kernel_state()->emulator()->imgui_drawer(), "Invites aren't supported!",
+      xe::to_utf8(unmarshaller->DisplayString()), 0);
+
+  return X_E_SUCCESS;
+}
+
+X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_ptr,
+                                               uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
+    return X_E_INVALIDARG;
+  }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
+
   Memory* memory = kernel_state_->memory();
 
   const X_ARGUMENT_LIST* args_list =
@@ -805,16 +1045,16 @@ X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_length) {
     assert_always(fmt::format("{} - Invalid argument count!", __func__));
   }
 
-  X_INVITE_GET_ACCEPTED_INFO* AcceptedInfo =
+  const X_INVITE_GET_ACCEPTED_INFO* accepted_info =
       memory->TranslateVirtual<X_INVITE_GET_ACCEPTED_INFO*>(buffer_length);
 
   const uint32_t user_index =
       xe::load_and_swap<uint32_t>(memory_->TranslateVirtual(
-          static_cast<uint32_t>(AcceptedInfo->user_index.argument_value_ptr)));
+          static_cast<uint32_t>(accepted_info->user_index.argument_value_ptr)));
 
-  X_INVITE_INFO* invite_info =
-      reinterpret_cast<X_INVITE_INFO*>(memory_->TranslateVirtual(
-          static_cast<uint32_t>(AcceptedInfo->invite_info.argument_value_ptr)));
+  X_INVITE_INFO* invite_info = reinterpret_cast<X_INVITE_INFO*>(
+      memory_->TranslateVirtual(static_cast<uint32_t>(
+          accepted_info->invite_info.argument_value_ptr)));
 
   if (!kernel_state()->xam_state()->IsUserSignedIn(user_index)) {
     return X_E_FAIL;
@@ -888,35 +1128,78 @@ X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_length) {
 }
 
 X_HRESULT XLiveBaseApp::GenericMarshalled(uint32_t buffer_ptr) {
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
-
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
-
-  uint8_t* results_ptr = nullptr;
-
-  uint8_t* args_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->start_args_ptr);
-
-  if (!data_ptr->internal_data_ptr) {
+  if (!buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  if (!internal_data_ptr->start_args_ptr) {
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
+
+  const std::string_view task_url = unmarshaller->GetAsyncTask()->GetTaskUrl();
+
+  // Determine function via it's URL, some functions don't have a URL if the url
+  // index is 0.
+  const std::string_view string_verify_url = "/msgserver/vetstring2.ashx";
+  const std::string_view account_get_user_info_url =
+      "/xuacs/XeGetUserInfo.ashx";
+  const std::string_view estimate_rank_for_rating_url =
+      "/xstats/xstatestimaterankforratings.ashx";
+
+  if (string_verify_url == task_url) {
+    return XStringVerify(buffer_ptr);
+  }
+
+  if (account_get_user_info_url == task_url) {
+    return XAccountGetUserInfo(buffer_ptr);
+  }
+
+  if (estimate_rank_for_rating_url == task_url) {
+    return XUserEstimateRankForRating(buffer_ptr);
+  }
+
+  XELOGI("{}:: URL: {}", __func__, task_url);
+
+  uint8_t* args_ptr = unmarshaller->DeserializeReinterpret<uint8_t>();
+
+  if (!args_ptr) {
     return X_E_INVALIDARG;
   }
 
-  if (!internal_data_ptr->results_ptr) {
+  unmarshaller->ZeroResults();
+
+  uint8_t* results_ptr = unmarshaller->Results<uint8_t>();
+
+  return X_E_SUCCESS;
+}
+
+X_HRESULT XLiveBaseApp::XUserMuteListQuery(uint32_t buffer_ptr,
+                                           uint32_t buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
 
-  results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
+  X_MUTE_SET_STATE* remote_player_ptr =
+      memory_->TranslateVirtual<X_MUTE_SET_STATE*>(buffer_ptr);
 
-  std::fill_n(results_ptr, internal_data_ptr->results_size, 0);
+  if (remote_player_ptr->user_index >= XUserMaxUserCount) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!IsOnlineXUID(remote_player_ptr->remote_xuid)) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!kernel_state()->xam_state()->IsUserSignedIn(
+          remote_player_ptr->user_index)) {
+    return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+  }
+
+  auto user_profile = kernel_state()->xam_state()->GetUserProfile(
+      remote_player_ptr->user_index);
+
+  xe::be<uint32_t>* mute_list_ptr =
+      memory_->TranslateVirtual<xe::be<uint32_t>*>(buffer_length);
+
+  *mute_list_ptr = user_profile->IsPlayerMuted(remote_player_ptr->remote_xuid);
 
   return X_E_SUCCESS;
 }
@@ -925,8 +1208,27 @@ X_HRESULT XLiveBaseApp::XUserMuteListAdd(uint32_t buffer_ptr) {
   X_MUTE_SET_STATE* remote_player_ptr =
       memory_->TranslateVirtual<X_MUTE_SET_STATE*>(buffer_ptr);
 
+  if (remote_player_ptr->user_index >= XUserMaxUserCount) {
+    return X_E_INVALIDARG;
+  }
+
   if (!IsOnlineXUID(remote_player_ptr->remote_xuid)) {
     return X_E_INVALIDARG;
+  }
+
+  if (!kernel_state()->xam_state()->IsUserSignedIn(
+          remote_player_ptr->user_index)) {
+    return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+  }
+
+  auto user_profile = kernel_state()->xam_state()->GetUserProfile(
+      remote_player_ptr->user_index);
+
+  bool muted = user_profile->MutePlayer(remote_player_ptr->remote_xuid);
+
+  if (muted) {
+    kernel_state()->BroadcastNotification(kXNotificationSystemMuteListChanged,
+                                          0);
   }
 
   return X_E_SUCCESS;
@@ -936,69 +1238,55 @@ X_HRESULT XLiveBaseApp::XUserMuteListRemove(uint32_t buffer_ptr) {
   X_MUTE_SET_STATE* remote_player_ptr =
       memory_->TranslateVirtual<X_MUTE_SET_STATE*>(buffer_ptr);
 
+  if (remote_player_ptr->user_index >= XUserMaxUserCount) {
+    return X_E_INVALIDARG;
+  }
+
   if (!IsOnlineXUID(remote_player_ptr->remote_xuid)) {
     return X_E_INVALIDARG;
+  }
+
+  if (!kernel_state()->xam_state()->IsUserSignedIn(
+          remote_player_ptr->user_index)) {
+    return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+  }
+
+  auto user_profile = kernel_state()->xam_state()->GetUserProfile(
+      remote_player_ptr->user_index);
+
+  bool unmuted = user_profile->UnmutePlayer(remote_player_ptr->remote_xuid);
+
+  if (unmuted) {
+    kernel_state()->BroadcastNotification(kXNotificationSystemMuteListChanged,
+                                          0);
   }
 
   return X_E_SUCCESS;
 }
 
 X_HRESULT XLiveBaseApp::XAccountGetUserInfo(uint32_t buffer_ptr) {
-  // Requires XEX_SYSTEM_ACCESS_PII privilege
+  // Requires privilege XEX_SYSTEM_ACCESS_PII (Personally Identifiable
+  // Information)
+  //
   // 41560855 (TU 7+), 4D530AA5
 
   if (!buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XAccountGetUserInfo_Marshalled_Data* data_ptr =
-      kernel_state()
-          ->memory()
-          ->TranslateVirtual<XAccountGetUserInfo_Marshalled_Data*>(buffer_ptr);
+  XAccountGetUserInfoUnmarshaller* unmarshaller =
+      new XAccountGetUserInfoUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
+  if (deserialize_result) {
+    return deserialize_result;
+  }
 
   X_GET_USER_INFO_RESPONSE* user_info_response_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_GET_USER_INFO_RESPONSE*>(
-          internal_data_ptr->results_ptr);
+      unmarshaller->Results<X_GET_USER_INFO_RESPONSE>();
 
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->results_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (internal_data_ptr->results_size < XAccountGetUserInfoResponseSize()) {
-    return X_ONLINE_E_ACCOUNTS_USER_GET_ACCOUNT_INFO_ERROR;
-  }
-
-  memset(user_info_response_ptr, 0, internal_data_ptr->results_size);
-
-  uint32_t offset = 0;
-
-  xe::be<uint64_t> xuid = *reinterpret_cast<uint64_t*>(args_stream_ptr);
-
-  offset += sizeof(uint64_t);
-
-  xe::be<uint64_t> machine_id =
-      *reinterpret_cast<uint64_t*>(args_stream_ptr + offset);
-
-  offset += sizeof(uint64_t);
-
-  xe::be<uint32_t> title_id =
-      *reinterpret_cast<uint32_t*>(args_stream_ptr + offset);
+  unmarshaller->ZeroResults();
 
   // Example usage
   std::u16string first_name = u"First Name";
@@ -1034,89 +1322,29 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XStorageEnumerate_Marshalled_Data* data_ptr =
-      kernel_state()
-          ->memory()
-          ->TranslateVirtual<XStorageEnumerate_Marshalled_Data*>(buffer_ptr);
+  XStorageEnumerateUnmarshaller* unmarshaller =
+      new XStorageEnumerateUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
-
-  X_STORAGE_ENUMERATE_RESULTS* results_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_STORAGE_ENUMERATE_RESULTS*>(
-          internal_data_ptr->results_ptr);
-
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->results_ptr) {
-    return X_E_INVALIDARG;
+  if (deserialize_result) {
+    return deserialize_result;
   }
 
   // Fixed 415607F7 from crashing.
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  unmarshaller->ZeroResults();
 
-  uint32_t offset = 0;
+  X_STORAGE_ENUMERATE_RESULTS* results_ptr =
+      unmarshaller->Results<X_STORAGE_ENUMERATE_RESULTS>();
 
-  xe::be<uint32_t> user_index = 0;
-  memcpy(&user_index, args_stream_ptr, sizeof(uint32_t));
+  auto user_profle =
+      kernel_state()->xam_state()->GetUserProfile(unmarshaller->UserIndex());
 
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> server_path_len = 0;
-  memcpy(&server_path_len, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  char16_t* arg_server_path_ptr =
-      reinterpret_cast<char16_t*>(args_stream_ptr + offset);
-
-  uint32_t server_path_size = server_path_len * sizeof(char16_t);
-
-  offset += server_path_size;
-
-  uint8_t* arg_starting_index_ptr = args_stream_ptr + offset;
-  uint32_t* starting_index_ptr =
-      reinterpret_cast<uint32_t*>(args_stream_ptr + offset);
-
-  offset += sizeof(uint32_t);
-
-  uint32_t* arg_max_results_to_return_ptr =
-      reinterpret_cast<uint32_t*>(args_stream_ptr + offset);
-
-  // Exclude null-terminator
-  server_path_len -= 1;
-
-  std::u16string server_path;
-  server_path.resize(server_path_len);
-
-  xe::copy_and_swap(server_path.data(), arg_server_path_ptr, server_path_len);
-
-  uint32_t starting_index = xe::load_and_swap<uint32_t>(arg_starting_index_ptr);
-  uint32_t max_results_to_return =
-      xe::load_and_swap<uint32_t>(arg_max_results_to_return_ptr);
-
-  if (server_path_len > X_ONLINE_MAX_PATHNAME_LENGTH) {
-    return X_E_FAIL;
-  }
-
-  auto user_profle = kernel_state()->xam_state()->GetUserProfile(user_index);
-
-  const std::string enumeration_path = xe::to_utf8(server_path);
+  const std::string enumeration_path = xe::to_utf8(unmarshaller->ServerPath());
 
   const uint32_t available_to_return_items =
       static_cast<uint32_t>(std::floor<uint32_t>(static_cast<uint32_t>(
-          (internal_data_ptr->results_size -
+          (unmarshaller->GetAsyncTask()->GetXLiveAsyncTask()->results_size -
            sizeof(X_STORAGE_ENUMERATE_RESULTS)) /
           (sizeof(X_STORAGE_FILE_INFO) +
            (X_ONLINE_MAX_PATHNAME_LENGTH * sizeof(char16_t))))));
@@ -1133,19 +1361,6 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
       reinterpret_cast<char16_t*>(items_array_ptr + available_to_return_items);
 
   X_STATUS result = X_E_SUCCESS;
-
-  if (server_path.empty()) {
-    XELOGI("{}: Empty Server Path", __func__);
-    return X_E_INVALIDARG;
-  }
-
-  if (max_results_to_return > X_STORAGE_MAX_RESULTS_TO_RETURN) {
-    return X_E_INVALIDARG;
-  }
-
-  if (starting_index >= X_STORAGE_MAX_RESULTS_TO_RETURN) {
-    return X_E_INVALIDARG;
-  }
 
   if (!available_to_return_items) {
     return X_E_INVALIDARG;
@@ -1174,9 +1389,8 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
   bool enumerated_backend = false;
 
   if (route_backend) {
-    uint32_t max_items = max_results_to_return < available_to_return_items
-                             ? max_results_to_return
-                             : available_to_return_items;
+    const uint32_t max_items = std::min<uint32_t>(
+        unmarshaller->MaxResultsToReturn(), available_to_return_items);
 
     const auto enumeration_result =
         XLiveAPI::XStorageEnumerate(enumeration_path, max_items);
@@ -1184,7 +1398,7 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
     const auto& enumerated_files = enumeration_result.first;
     enumerated_backend = enumeration_result.second;
 
-    for (uint32_t item_index = starting_index;
+    for (uint32_t item_index = unmarshaller->StartingIndex();
          const auto& entry : enumerated_files->Items()) {
       std::string filename = utf8::find_name_from_path(entry.FilePath(), '/');
 
@@ -1310,12 +1524,13 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
                 return entry_1->write_timestamp() > entry_2->write_timestamp();
               });
 
-    for (uint32_t item_index = starting_index; const auto entry : entries) {
+    for (uint32_t item_index = unmarshaller->StartingIndex();
+         const auto entry : entries) {
       std::string symlink_item_path =
           std::format("{}\\{}", item_parent, entry->name());
 
       // Path must use /
-      // Keep server return consitant with XStorageBuildServerPath
+      // Keep server return consistent with XStorageBuildServerPath
       std::u16string backend_storage_item_path =
           xe::to_utf16(ConvertXStorageSymlinkToServerPath(symlink_item_path));
 
@@ -1369,8 +1584,8 @@ X_HRESULT XLiveBaseApp::XStorageEnumerate(uint32_t buffer_ptr) {
       "{}: Available Items Space: {}, Storage Items: {}, Start Index: {}, Max "
       "Items: {}, Server Path: {}",
       __func__, available_to_return_items,
-      results_ptr->num_items_returned.get(), starting_index,
-      max_results_to_return, final_enumeration_path);
+      results_ptr->num_items_returned.get(), unmarshaller->StartingIndex(),
+      unmarshaller->MaxResultsToReturn(), final_enumeration_path);
 
   return result;
 }
@@ -1380,89 +1595,22 @@ X_HRESULT XLiveBaseApp::XStringVerify(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XStringVerify_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<XStringVerify_Marshalled_Data*>(
-          buffer_ptr);
+  XStringVerifyUnmarshaller* unmarshaller =
+      new XStringVerifyUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
+  if (deserialize_result) {
+    return deserialize_result;
+  }
+
+  unmarshaller->ZeroResults();
 
   STRING_VERIFY_RESPONSE* responses_ptr =
-      kernel_state_->memory()->TranslateVirtual<STRING_VERIFY_RESPONSE*>(
-          internal_data_ptr->results_ptr);
+      unmarshaller->Results<STRING_VERIFY_RESPONSE>();
 
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->results_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  memset(responses_ptr, 0, internal_data_ptr->results_size);
-
-  uint16_t* locale_size_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
-          data_ptr->locale_size_ptr);
-  uint16_t* num_strings_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
-          data_ptr->num_strings_ptr);
-  uint16_t* last_entry_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint16_t*>(
-          data_ptr->last_entry_ptr);
-
-  uint16_t locale_size = *locale_size_ptr;
-  uint16_t num_strings = *num_strings_ptr;
-
-  if (locale_size > X_ONLINE_MAX_XSTRING_VERIFY_LOCALE) {
-    return X_E_INVALIDARG;
-  }
-
-  if (num_strings > X_ONLINE_MAX_XSTRING_VERIFY_STRING_DATA) {
-    return X_E_INVALIDARG;
-  }
-
-  xe::be<uint32_t> title_id = *reinterpret_cast<uint32_t*>(args_stream_ptr);
-
-  xe::be<uint32_t> flags =
-      *reinterpret_cast<uint32_t*>(args_stream_ptr + sizeof(uint32_t));
-
-  char* locale_string_ptr = kernel_state_->memory()->TranslateVirtual<char*>(
-      data_ptr->num_strings_ptr + sizeof(uint16_t));
-
-  std::string locale = std::string(locale_string_ptr, locale_size);
-
-  char* string_data = locale_string_ptr + locale_size;
-
-  std::vector<std::string> strings_to_verify;
-
-  uint32_t string_data_offset = 0;
-
-  for (uint32_t i = 0; i < num_strings; i++) {
-    uint16_t size = 0;
-    memcpy(&size, string_data + string_data_offset, sizeof(uint16_t));
-
-    string_data_offset += sizeof(uint16_t);
-
-    // Unicode is represented as UTF-8 array
-    char* string_data_ptr = string_data + string_data_offset;
-
-    std::string input_string = std::string(string_data_ptr, size);
-
-    string_data_offset += size;
-
-    strings_to_verify.push_back(input_string);
-
-    XELOGI("{}: {}", __func__, input_string);
+  for (auto const& string_to_verify : unmarshaller->StringToVerify()) {
+    XELOGI("{}: {}", __func__, string_to_verify);
   }
 
   uint32_t response_result_address =
@@ -1473,12 +1621,48 @@ X_HRESULT XLiveBaseApp::XStringVerify(uint32_t buffer_ptr) {
       kernel_state_->memory()->TranslateVirtual<HRESULT*>(
           response_result_address);
 
-  for (uint32_t i = 0; i < num_strings; i++) {
+  for (uint32_t i = 0; i < unmarshaller->NumStrings(); i++) {
     response_results_ptr[i] = X_E_SUCCESS;
   }
 
-  responses_ptr->num_strings = num_strings;
+  responses_ptr->num_strings = unmarshaller->NumStrings();
   responses_ptr->string_result_ptr = response_result_address;
+
+  return X_E_SUCCESS;
+}
+
+X_HRESULT XLiveBaseApp::XUserEstimateRankForRating(uint32_t buffer_ptr) {
+  if (!buffer_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  XUserEstimateRankForRatingUnmarshaller* unmarshaller =
+      new XUserEstimateRankForRatingUnmarshaller(buffer_ptr);
+
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
+
+  if (deserialize_result) {
+    return deserialize_result;
+  }
+
+  unmarshaller->ZeroResults();
+
+  const uint32_t max_num_ranks_results =
+      (unmarshaller->GetAsyncTask()->GetXLiveAsyncTask()->results_size -
+       sizeof(X_USER_ESTIMATE_RANK_RESULTS)) /
+      sizeof(uint32_t);
+
+  X_USER_ESTIMATE_RANK_RESULTS* estimate_rank_results_ptr =
+      unmarshaller->Results<X_USER_ESTIMATE_RANK_RESULTS>();
+
+  xe::be<uint32_t>* ranks =
+      reinterpret_cast<xe::be<uint32_t>*>(estimate_rank_results_ptr + 1);
+
+  // 58410889 expects ptr even if num_ranks is 0.
+  estimate_rank_results_ptr->ranks_ptr =
+      kernel_state()->memory()->HostToGuestVirtual(std::to_address(ranks));
+
+  // XPROPERTY_ATTACHMENT_SIZE?
 
   return X_E_SUCCESS;
 }
@@ -1488,65 +1672,18 @@ X_HRESULT XLiveBaseApp::XStorageDelete(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XStorageDelete_Marshalled_Data* data_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<XStorageDelete_Marshalled_Data*>(buffer_ptr);
+  XStorageDeleteUnmarshaller* unmarshaller =
+      new XStorageDeleteUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
-
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
+  if (deserialize_result) {
+    return deserialize_result;
   }
 
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  uint32_t offset = 0;
-
-  xe::be<uint32_t> user_index = 0;
-  memcpy(&user_index, args_stream_ptr, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> server_path_len = 0;
-  memcpy(&server_path_len, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  char16_t* arg_server_path_ptr =
-      reinterpret_cast<char16_t*>(args_stream_ptr + offset);
-
-  uint32_t server_path_size = server_path_len * sizeof(char16_t);
-
-  offset += server_path_size;
-
-  const auto user_profile =
-      kernel_state()->xam_state()->GetUserProfile(user_index);
-
-  // Exclude null-terminator
-  server_path_len -= 1;
-
-  std::u16string server_path;
-  server_path.resize(server_path_len, 0);
-
-  xe::copy_and_swap(server_path.data(), arg_server_path_ptr,
-                    static_cast<uint32_t>(server_path_len));
-
-  std::string item_path = xe::to_utf8(server_path);
+  std::string item_path = xe::to_utf8(unmarshaller->ServerPath());
 
   X_STATUS result = X_E_FAIL;
-
-  if (item_path.empty()) {
-    XELOGI("{}: Empty Server Path", __func__);
-    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
-  }
 
   X_STORAGE_FACILITY facility_type =
       GetStorageFacilityTypeFromServerPath(item_path);
@@ -1592,82 +1729,24 @@ X_HRESULT XLiveBaseApp::XStorageDownloadToMemory(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XStorageDownloadToMemory_Marshalled_Data* data_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<XStorageDownloadToMemory_Marshalled_Data*>(
-              buffer_ptr);
+  XStorageDownloadToMemoryUnmarshaller* unmarshaller =
+      new XStorageDownloadToMemoryUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
+  if (deserialize_result) {
+    return deserialize_result;
+  }
+
+  unmarshaller->ZeroResults();
 
   X_STORAGE_DOWNLOAD_TO_MEMORY_RESULTS* download_results_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<X_STORAGE_DOWNLOAD_TO_MEMORY_RESULTS*>(
-              internal_data_ptr->results_ptr);
+      unmarshaller->Results<X_STORAGE_DOWNLOAD_TO_MEMORY_RESULTS>();
 
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->results_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  // Fixed 415607DD & 41560834
-  memset(download_results_ptr, 0, internal_data_ptr->results_size);
-
-  uint32_t offset = 0;
-
-  xe::be<uint32_t> user_index = 0;
-  memcpy(&user_index, args_stream_ptr, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> server_path_len = 0;
-  memcpy(&server_path_len, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  char16_t* arg_server_path_ptr =
-      reinterpret_cast<char16_t*>(args_stream_ptr + offset);
-
-  uint32_t server_path_size = server_path_len * sizeof(char16_t);
-
-  offset += server_path_size;
-
-  xe::be<uint32_t> buffer_size = 0;
-  memcpy(&buffer_size, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> download_buffer_address = 0;
-  memcpy(&download_buffer_address, args_stream_ptr + offset, sizeof(uint32_t));
-
-  if (!download_buffer_address) {
-    return X_E_INVALIDARG;
-  }
-
-  uint8_t* download_buffer_ptr =
-      kernel_state()->memory()->TranslateVirtual<uint8_t*>(
-          download_buffer_address);
-
-  // 41560845 - Access Violation
-  // std::fill_n(download_buffer_ptr, buffer_size, 0);
-
-  std::span<uint8_t> download_buffer =
-      std::span<uint8_t>(download_buffer_ptr, buffer_size);
+  std::span<uint8_t> download_buffer = unmarshaller->GetDownloadBuffer();
 
   const auto user_profile =
-      kernel_state()->xam_state()->GetUserProfile(user_index);
+      kernel_state()->xam_state()->GetUserProfile(unmarshaller->UserIndex());
 
   uint64_t xuid_owner = 0;
 
@@ -1675,22 +1754,9 @@ X_HRESULT XLiveBaseApp::XStorageDownloadToMemory(uint32_t buffer_ptr) {
     xuid_owner = user_profile->GetOnlineXUID();
   }
 
-  // Exclude null-terminator
-  server_path_len -= 1;
-
-  std::u16string server_path;
-  server_path.resize(server_path_len, 0);
-
-  xe::copy_and_swap(server_path.data(), arg_server_path_ptr,
-                    static_cast<uint32_t>(server_path_len));
-
-  std::string item_to_download = xe::to_utf8(server_path);
+  std::string item_to_download = xe::to_utf8(unmarshaller->ServerPath());
 
   X_STATUS result = X_ONLINE_E_STORAGE_FILE_NOT_FOUND;
-
-  if (server_path.empty()) {
-    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
-  }
 
   X_STORAGE_FACILITY facility_type =
       GetStorageFacilityTypeFromServerPath(item_to_download);
@@ -1712,8 +1778,8 @@ X_HRESULT XLiveBaseApp::XStorageDownloadToMemory(uint32_t buffer_ptr) {
 
       memcpy(download_buffer.data(), buffer.data(), buffer.size_bytes());
 
-      // Possible solution: Use custom header or encode binary in base64 with
-      // metadata
+      // Possible solution: Use custom HTTP header or encode binary in base64
+      // with metadata
       download_results_ptr->xuid_owner = xuid_owner;
       download_results_ptr->bytes_total =
           static_cast<uint32_t>(buffer.size_bytes());
@@ -1747,9 +1813,9 @@ X_HRESULT XLiveBaseApp::XStorageDownloadToMemory(uint32_t buffer_ptr) {
       output_file->Destroy();
 
       if (!open_result) {
-        if (bytes_read > buffer_size) {
+        if (bytes_read > unmarshaller->BufferSize()) {
           XELOGI("{}: Provided file size {}b is larger than expected {}b",
-                 __func__, bytes_read, buffer_size.get());
+                 __func__, bytes_read, unmarshaller->BufferSize());
           return X_E_INSUFFICIENT_BUFFER;
         }
 
@@ -1772,8 +1838,8 @@ X_HRESULT XLiveBaseApp::XStorageDownloadToMemory(uint32_t buffer_ptr) {
   }
 
   XELOGI("{}: Downloaded Bytes: {}b, Buffer Size: {}b, Server Path: {}",
-         __func__, download_results_ptr->bytes_total.get(), buffer_size.get(),
-         item_to_download);
+         __func__, download_results_ptr->bytes_total.get(),
+         unmarshaller->BufferSize(), item_to_download);
 
   return result;
 }
@@ -1783,78 +1849,18 @@ X_HRESULT XLiveBaseApp::XStorageUploadFromMemory(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XStorageUploadFromMemory_Marshalled_Data* data_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<XStorageUploadFromMemory_Marshalled_Data*>(
-              buffer_ptr);
+  XStorageUploadToMemoryUnmarshaller* unmarshaller =
+      new XStorageUploadToMemoryUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
-
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
+  if (deserialize_result) {
+    return deserialize_result;
   }
 
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
+  std::span<uint8_t> upload_buffer = unmarshaller->GetUploadBuffer();
 
-  uint32_t offset = 0;
-
-  xe::be<uint32_t> user_index = 0;
-  memcpy(&user_index, args_stream_ptr, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> server_path_len = 0;
-  memcpy(&server_path_len, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  char16_t* arg_server_path_ptr =
-      reinterpret_cast<char16_t*>(args_stream_ptr + offset);
-
-  uint32_t server_path_size = server_path_len * sizeof(char16_t);
-
-  offset += server_path_size;
-
-  xe::be<uint32_t> buffer_size = 0;
-  memcpy(&buffer_size, args_stream_ptr + offset, sizeof(uint32_t));
-
-  offset += sizeof(uint32_t);
-
-  xe::be<uint32_t> upload_buffer_address = 0;
-  memcpy(&upload_buffer_address, args_stream_ptr + offset, sizeof(uint32_t));
-
-  if (!upload_buffer_address) {
-    return X_E_INVALIDARG;
-  }
-
-  if (buffer_size > kTMSClipMaxSize) {
-    return X_ONLINE_E_STORAGE_FILE_IS_TOO_BIG;
-  }
-
-  uint8_t* upload_buffer_ptr =
-      kernel_state()->memory()->TranslateVirtual<uint8_t*>(
-          upload_buffer_address);
-
-  std::span<uint8_t> upload_buffer =
-      std::span<uint8_t>(upload_buffer_ptr, buffer_size);
-
-  // Exclude null-terminator
-  server_path_len -= 1;
-
-  std::u16string server_path;
-  server_path.resize(server_path_len);
-
-  xe::copy_and_swap(server_path.data(), arg_server_path_ptr, server_path_len);
-
-  std::string upload_file_path = xe::to_utf8(server_path);
+  std::string upload_file_path = xe::to_utf8(unmarshaller->ServerPath());
   std::string filename = utf8::find_name_from_path(upload_file_path, '/');
 
   X_STATUS result = X_E_FAIL;
@@ -1908,8 +1914,9 @@ X_HRESULT XLiveBaseApp::XStorageUploadFromMemory(uint32_t buffer_ptr) {
 
       if (!result) {
         size_t bytes_written = 0;
-        result = upload_file->WriteSync({upload_buffer.data(), buffer_size}, 0,
-                                        &bytes_written);
+        result = upload_file->WriteSync(
+            {upload_buffer.data(), unmarshaller->BufferSize()}, 0,
+            &bytes_written);
 
         // Update the size of the entry for XStorageDownloadToMemory
         upload_file->entry()->update();
@@ -1932,7 +1939,7 @@ X_HRESULT XLiveBaseApp::XStorageUploadFromMemory(uint32_t buffer_ptr) {
       break;
   }
 
-  XELOGI("{}: Size: {}b, Path: {}", __func__, buffer_size.get(),
+  XELOGI("{}: Size: {}b, Path: {}", __func__, unmarshaller->BufferSize(),
          upload_file_path);
 
   return result;
@@ -1952,6 +1959,11 @@ X_HRESULT XLiveBaseApp::XStorageBuildServerPath(uint32_t buffer_ptr) {
   }
 
   if (!args->server_path_length_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (args->user_index >= XUserMaxUserCount &&
+      args->user_index != XUserIndexNone) {
     return X_E_INVALIDARG;
   }
 
@@ -2191,25 +2203,29 @@ X_HRESULT XLiveBaseApp::XOnlineGetTaskProgress(uint32_t buffer_ptr) {
   }
 
   if (numerator_ptr) {
-    *numerator_ptr = 0;
+    *numerator_ptr = 100;
   }
 
   if (denominator_ptr) {
-    *denominator_ptr = 0;
+    *denominator_ptr = 100;
   }
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::XUserFindUsersUnkn58017(uint32_t buffer_ptr) {
+X_HRESULT XLiveBaseApp::GetNextSequenceMessage(uint32_t buffer_ptr) {
   if (!buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  uint8_t* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(buffer_ptr);
+  XLIVEBASE_GET_SEQUENCE* data_ptr =
+      kernel_state_->memory()->TranslateVirtual<XLIVEBASE_GET_SEQUENCE*>(
+          buffer_ptr);
 
-  std::fill_n(data_ptr, sizeof(uint64_t), 0);
+  data_ptr->seq_num = 0;
+
+  // Size in bytes of args to deserialize
+  data_ptr->msg_length = sizeof(BASE_MSG_HEADER);
 
   return X_E_SUCCESS;
 }
@@ -2221,80 +2237,33 @@ X_HRESULT XLiveBaseApp::XUserFindUsers(uint32_t buffer_ptr) {
     return X_E_INVALIDARG;
   }
 
-  XUserFindUsers_Marshalled_Data* data_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<XUserFindUsers_Marshalled_Data*>(buffer_ptr);
+  XUserFindUsersUnmarshaller* unmarshaller =
+      new XUserFindUsersUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  X_HRESULT deserialize_result = unmarshaller->Deserialize();
 
-  FIND_USERS_RESPONSE* results_ptr =
-      kernel_state_->memory()->TranslateVirtual<FIND_USERS_RESPONSE*>(
-          internal_data_ptr->results_ptr);
-
-  if (!data_ptr->internal_data_ptr) {
-    return X_E_INVALIDARG;
+  if (deserialize_result) {
+    return deserialize_result;
   }
-
-  if (!internal_data_ptr->start_args_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  if (!internal_data_ptr->results_ptr) {
-    return X_E_INVALIDARG;
-  }
-
-  uint8_t* args_stream_ptr =
-      kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-          internal_data_ptr->start_args_ptr);
 
   // Fixed 58410B5D
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  unmarshaller->ZeroResults();
 
-  uint32_t offset = 0;
-
-  // 1065
-  uint32_t value_const = *reinterpret_cast<uint32_t*>(args_stream_ptr);
-
-  offset += sizeof(uint32_t);
-
-  // Data from 58017
-  uint64_t unkn_value = *reinterpret_cast<uint64_t*>(args_stream_ptr + offset);
-
-  offset += sizeof(uint64_t);
-
-  // XnpLogonGetStatus
-  SGADDR* security_gateway =
-      reinterpret_cast<SGADDR*>(args_stream_ptr + offset);
-
-  offset += sizeof(SGADDR);
-
-  uint64_t xuid_issuer = *reinterpret_cast<uint64_t*>(args_stream_ptr + offset);
-
-  offset += sizeof(uint64_t);
-
-  uint32_t num_users = *reinterpret_cast<uint32_t*>(args_stream_ptr + offset);
-
-  offset += sizeof(uint32_t);
-
-  FIND_USER_INFO* users_ptr =
-      reinterpret_cast<FIND_USER_INFO*>(args_stream_ptr + offset);
+  FIND_USERS_RESPONSE* results_ptr =
+      unmarshaller->Results<FIND_USERS_RESPONSE>();
 
   std::vector<FIND_USER_INFO> find_users = {};
   std::vector<FIND_USER_INFO> resolved_users = {};
 
-  for (uint32_t i = 0; i < num_users; i++) {
-    FIND_USER_INFO user = users_ptr[i];
-
-    const uint64_t xuid = xe::byte_swap(users_ptr[i].xuid);
+  for (auto const& user : unmarshaller->Users()) {
+    const uint64_t xuid = xe::byte_swap(user.xuid);
 
     const auto user_profile =
         kernel_state()->xam_state()->GetUserProfileLive(xuid);
 
     // Only lookup non-local users
     if (user_profile) {
-      FIND_USER_INFO local_user = users_ptr[i];
+      FIND_USER_INFO local_user = user;
 
       local_user.xuid = xuid;
       strcpy(local_user.gamertag, user_profile->name().c_str());
@@ -2312,8 +2281,8 @@ X_HRESULT XLiveBaseApp::XUserFindUsers(uint32_t buffer_ptr) {
                           resolved.end());
   }
 
-  uint32_t results_size =
-      sizeof(FIND_USERS_RESPONSE) + (num_users * sizeof(FIND_USER_INFO));
+  uint32_t results_size = sizeof(FIND_USERS_RESPONSE) +
+                          (unmarshaller->NumUsers() * sizeof(FIND_USER_INFO));
 
   uint32_t users_address = kernel_state()->memory()->HostToGuestVirtual(
       std::to_address(results_ptr + 1));
@@ -2423,212 +2392,480 @@ X_STORAGE_FACILITY XLiveBaseApp::GetStorageFacilityTypeFromServerPath(
   return facility_type;
 }
 
-X_HRESULT XLiveBaseApp::Unkn5008C(uint32_t buffer_ptr) {
-  // Called on startup of blades dashboard v1888 to v2858
-  // Address: 92433DA8
-
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
-
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
-
-  uint8_t* results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
-
-  // 5 Arguments
-  X_DATA_ARGS_5008C* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_5008C*>(
-          internal_data_ptr->start_args_ptr);
-
-  // Crashes if buffer filled with 0xFF
-  memset(results_ptr, 0, internal_data_ptr->results_size);
-
-  return X_E_SUCCESS;
-}
-
 X_HRESULT XLiveBaseApp::XAccountGetPointsBalance(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
+  // Blades Dashboard v1888
 
   // Current Balance in sub menus:
   // All New Demos and Trailers
   // More Videos and Downloads
   // Address: 92433368
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  if (!buffer_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  X_GET_POINTS_BALANCE_RESPONSE* results_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_GET_POINTS_BALANCE_RESPONSE*>(
-          internal_data_ptr->results_ptr);
+  XACCOUNT_GET_POINTS_BALANCE_REQUEST* points_balance_request_ptr =
+      unmarshaller
+          ->DeserializeReinterpret<XACCOUNT_GET_POINTS_BALANCE_REQUEST>();
 
-  // 2 Arguments
-  X_DATA_ARGS_50077* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_50077*>(
-          internal_data_ptr->start_args_ptr);
+  if (!points_balance_request_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  unmarshaller->ZeroResults();
 
-  results_ptr->balance = 1000000000;
-  results_ptr->dmp_account_status = DMP_STATUS_TYPE::DMP_STATUS_ACTIVE;
-  results_ptr->response_flags =
+  X_GET_POINTS_BALANCE_RESPONSE* points_balance_results_ptr =
+      unmarshaller->Results<X_GET_POINTS_BALANCE_RESPONSE>();
+
+  points_balance_results_ptr->balance = 1000000000;
+  points_balance_results_ptr->dmp_account_status =
+      DMP_STATUS_TYPE::DMP_STATUS_ACTIVE;
+  points_balance_results_ptr->response_flags =
       GET_POINTS_BALANCE_RESPONSE_FLAGS::ABOVE_LOW_BALANCE;
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::Unkn5008B(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
+X_HRESULT XLiveBaseApp::GetBannerList(uint32_t buffer_ptr) {
+  // Called on startup of blades dashboard v1888 to v2858
+  // Address: 92433DA8
 
-  // Fixes accessing marketplace Featured Downloads.
-  // Address: 92433BB0
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  GET_BANNER_LIST_REQUEST* banner_list_request_ptr =
+      unmarshaller->DeserializeReinterpret<GET_BANNER_LIST_REQUEST>();
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  if (!banner_list_request_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  X_GET_FEATURED_DOWNLOADS_RESPONSE* results_ptr =
-      kernel_state_->memory()
-          ->TranslateVirtual<X_GET_FEATURED_DOWNLOADS_RESPONSE*>(
-              internal_data_ptr->results_ptr);
+  unmarshaller->ZeroResults();
 
-  // 5 Arguments
-  X_DATA_ARGS_5008B* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_5008B*>(
-          internal_data_ptr->start_args_ptr);
+  GET_BANNER_LIST_RESPONSE* banner_list_results_ptr =
+      unmarshaller->Results<GET_BANNER_LIST_RESPONSE>();
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
-
-  results_ptr->entries = 5;
-  results_ptr->flags = 0xFFFFFFFF;
+  banner_list_results_ptr->banner_count_total = 5;
+  banner_list_results_ptr->banner_count = 0;
+  banner_list_results_ptr->banner_list = 0;
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::Unkn5008F(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
+X_HRESULT XLiveBaseApp::GetBannerListHot(uint32_t buffer_ptr) {
+  // Blades Dashboard v1888
+
+  // Fixes accessing marketplace Featured Downloads.
+  // Address: 92433BB0
+
+  if (!buffer_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
+
+  GET_BANNER_LIST_REQUEST* banner_list_request =
+      unmarshaller->DeserializeReinterpret<GET_BANNER_LIST_REQUEST>();
+
+  if (!banner_list_request) {
+    return X_E_INVALIDARG;
+  }
+
+  unmarshaller->ZeroResults();
+
+  GET_BANNER_LIST_RESPONSE* banner_list_results_ptr =
+      unmarshaller->Results<GET_BANNER_LIST_RESPONSE>();
+
+  banner_list_results_ptr->banner_count_total = 5;
+  banner_list_results_ptr->banner_count = 0xFFFF;
+  banner_list_results_ptr->banner_list = 0xFF;
+
+  return X_E_SUCCESS;
+}
+
+X_HRESULT XLiveBaseApp::ContentEnumerate(uint32_t buffer_ptr) {
+  // Blades Dashboard v1888
 
   // Fixes accessing marketplace sub menus:
   // All New Demos and Trailers
   // More Videos and Downloads
   // Address: 92433FA8
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  CONTENT_ENUMERATE_REQUEST* content_enumerate_request_ptr =
+      unmarshaller->DeserializeReinterpret<CONTENT_ENUMERATE_REQUEST>();
 
-  uint8_t* results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
+  if (!content_enumerate_request_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  // 12 Arguments
-  X_DATA_ARGS_5008F* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_5008F*>(
-          internal_data_ptr->start_args_ptr);
+  unmarshaller->ZeroResults();
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  // Results Layout
+  // CONTENT_ENUMERATE_RESPONSE[]
+  // CONTENT_INFO[]
+  // char16_t[] (Content Names)
+  CONTENT_ENUMERATE_RESPONSE* content_enumerate_results_ptr =
+      unmarshaller->Results<CONTENT_ENUMERATE_RESPONSE>();
+
+  CONTENT_INFO* content_info_ptr =
+      reinterpret_cast<CONTENT_INFO*>(content_enumerate_results_ptr + 1);
+
+  uint32_t content_info_address = kernel_state_->memory()->HostToGuestVirtual(
+      std::to_address(content_info_ptr));
+
+  const std::vector<std::u16string> contents = {
+      u"Content 1", u"Content 2", u"Content 3", u"Content 4", u"Content 5"};
+
+  char16_t* content_names_ptr = reinterpret_cast<char16_t*>(
+      content_info_ptr + content_enumerate_request_ptr->max_results);
+
+  const uint32_t end_index = content_enumerate_request_ptr->starting_index +
+                             content_enumerate_request_ptr->max_results;
+
+  uint32_t total_content_count = static_cast<uint32_t>(contents.size());
+  uint32_t returned_content_count = 0;
+
+  // Paging
+  for (uint32_t i = content_enumerate_request_ptr->starting_index;
+       i < end_index; i++) {
+    if (i >= contents.size()) {
+      break;
+    }
+
+    const std::u16string content_name = contents[i];
+
+    const uint16_t size = static_cast<uint16_t>(content_name.size() + 1);
+
+    xe::string_util::copy_and_swap_truncating(content_names_ptr,
+                                              content_name.c_str(), size);
+
+    content_info_ptr->offer_name = kernel_state_->memory()->HostToGuestVirtual(
+        std::to_address(content_names_ptr));
+    content_info_ptr->offer_name_length = size;
+
+    content_info_ptr += 1;
+    content_names_ptr += size;
+
+    returned_content_count++;
+  }
+
+  content_enumerate_results_ptr->content_total = total_content_count;
+  content_enumerate_results_ptr->content_returned = returned_content_count;
+  content_enumerate_results_ptr->enumerate_content_info_ptr =
+      content_info_address;
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::Unkn50090(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
-
+X_HRESULT XLiveBaseApp::GenresEnumerate(uint32_t buffer_ptr) {
   // Fixes accessing marketplace Game Downloads->All Games->Xbox Live Arcade
   // sub menu.
   // Address: 92434218
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  GENRES_ENUMERATE_REQUEST* genre_enumerate_request_ptr =
+      unmarshaller->DeserializeReinterpret<GENRES_ENUMERATE_REQUEST>();
 
-  uint8_t* results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
+  if (!genre_enumerate_request_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  // 9 Arguments
-  X_DATA_ARGS_50090* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_50090*>(
-          internal_data_ptr->start_args_ptr);
+  unmarshaller->ZeroResults();
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  // Add max string length?
+  const uint32_t total_genre_info_size =
+      sizeof(GENRE_INFO) * genre_enumerate_request_ptr->max_count;
+
+  assert_true(unmarshaller->GetAsyncTask()->GetXLiveAsyncTask()->results_size >
+              total_genre_info_size);
+
+  // Results Layout
+  // GENRES_ENUMERATE_RESPONSE[]
+  // GENRE_INFO[]
+  // char16_t[] (Genres Names)
+  GENRES_ENUMERATE_RESPONSE* genre_enumerate_results_ptr =
+      unmarshaller->Results<GENRES_ENUMERATE_RESPONSE>();
+
+  GENRE_INFO* genre_info_ptr =
+      reinterpret_cast<GENRE_INFO*>(genre_enumerate_results_ptr + 1);
+
+  uint32_t genre_info_address = kernel_state_->memory()->HostToGuestVirtual(
+      std::to_address(genre_info_ptr));
+
+  const std::vector<std::u16string> genres = {
+      u"Action",  u"Adventure", u"Simulation", u"Strategy",
+      u"Shooter", u"Sports",    u"Puzzle",     u"RPG",
+  };
+
+  char16_t* genre_names_ptr = reinterpret_cast<char16_t*>(
+      genre_info_ptr + genre_enumerate_request_ptr->max_count);
+
+  const uint32_t end_index = genre_enumerate_request_ptr->start_index +
+                             genre_enumerate_request_ptr->max_count;
+
+  uint32_t total_genres_count = static_cast<uint32_t>(genres.size());
+  uint32_t returned_genres_count = 0;
+
+  // Paging
+  for (uint32_t i = genre_enumerate_request_ptr->start_index; i < end_index;
+       i++) {
+    if (i >= genres.size()) {
+      break;
+    }
+
+    const std::u16string genre_name = genres[i];
+
+    const uint16_t size = static_cast<uint16_t>(genre_name.size() + 1);
+
+    xe::string_util::copy_and_swap_truncating(genre_names_ptr,
+                                              genre_name.c_str(), size);
+
+    genre_info_ptr->localized_genre_name =
+        kernel_state_->memory()->HostToGuestVirtual(
+            std::to_address(genre_names_ptr));
+    genre_info_ptr->localized_genre_length = size;
+
+    genre_info_ptr += 1;
+    genre_names_ptr += size;
+
+    returned_genres_count++;
+  }
+
+  genre_enumerate_results_ptr->geners_total = total_genres_count;
+  genre_enumerate_results_ptr->geners_returned = returned_genres_count;
+  genre_enumerate_results_ptr->enumerate_genre_info_ptr = genre_info_address;
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::Unkn50091(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
+X_HRESULT XLiveBaseApp::EnumerateTitlesByFilter(uint32_t buffer_ptr) {
+  // Blades Dashboard v1888
 
   // Fixes accessing marketplace Game Downloads.
   // Address: 92434468
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  ENUMERATE_TITLES_BY_FILTER* enumerate_titles_request_ptr =
+      unmarshaller->DeserializeReinterpret<ENUMERATE_TITLES_BY_FILTER>();
 
-  uint8_t* results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
+  if (!enumerate_titles_request_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  // 10 Arguments
-  X_DATA_ARGS_50091* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_50091*>(
-          internal_data_ptr->start_args_ptr);
+  unmarshaller->ZeroResults();
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  const uint32_t request_type = enumerate_titles_request_ptr->request_flags;
+
+  std::string enumerate_flags = "";
+
+  if (request_type &
+      static_cast<uint32_t>(ENUMERATE_TITLES_BY_FILTER_FLAGS::Played)) {
+    enumerate_flags.append("Played, ");
+  }
+
+  if (request_type &
+      static_cast<uint32_t>(ENUMERATE_TITLES_BY_FILTER_FLAGS::New)) {
+    enumerate_flags.append("New, ");
+  }
+
+  if (request_type == 0) {
+    enumerate_flags.append("Alphabetically Sort, ");
+  }
+
+  XELOGI("{}:: Requesting: {}", __func__, enumerate_flags);
+
+  // Results Layout
+  // ENUMERATE_TITLES_BY_FILTER_RESPONSE[]
+  // ENUMERATE_TITLES_INFO[]
+  // char16_t[] (Title Names)
+  ENUMERATE_TITLES_BY_FILTER_RESPONSE* enumerate_titles_results_ptr =
+      unmarshaller->Results<ENUMERATE_TITLES_BY_FILTER_RESPONSE>();
+
+  ENUMERATE_TITLES_INFO* title_info_ptr =
+      reinterpret_cast<ENUMERATE_TITLES_INFO*>(enumerate_titles_results_ptr +
+                                               1);
+
+  // Add max string length?
+  const uint32_t enumerate_titles_info_size =
+      sizeof(ENUMERATE_TITLES_INFO) * enumerate_titles_request_ptr->max_count;
+
+  assert_true(unmarshaller->GetAsyncTask()->GetXLiveAsyncTask()->results_size >
+              enumerate_titles_info_size);
+
+  uint32_t title_info_address = kernel_state_->memory()->HostToGuestVirtual(
+      std::to_address(title_info_ptr));
+
+  uint32_t total_titles_count = 0;
+  uint32_t returned_titles_count = 0;
+
+  if (enumerate_titles_request_ptr->request_flags &
+      static_cast<uint16_t>(ENUMERATE_TITLES_BY_FILTER_FLAGS::Played)) {
+    const std::vector<TitleInfo> played_titles =
+        kernel_state()->xam_state()->user_tracker()->GetPlayedTitles(
+            enumerate_titles_request_ptr->xuid);
+
+    total_titles_count = static_cast<uint32_t>(played_titles.size());
+
+    char16_t* titles_names_ptr = reinterpret_cast<char16_t*>(
+        title_info_ptr + enumerate_titles_request_ptr->max_count);
+
+    const uint32_t end_index = enumerate_titles_request_ptr->start_index +
+                               enumerate_titles_request_ptr->max_count;
+
+    // Paging
+    for (uint32_t i = enumerate_titles_request_ptr->start_index; i < end_index;
+         i++) {
+      if (i >= played_titles.size()) {
+        break;
+      }
+
+      const TitleInfo played_title = played_titles[i];
+
+      const uint16_t size =
+          static_cast<uint16_t>(played_title.title_name.size() + 1);
+
+      xe::string_util::copy_and_swap_truncating(
+          titles_names_ptr, played_title.title_name.c_str(), size);
+
+      title_info_ptr->title_id = played_title.id;
+      title_info_ptr->played = true;
+      title_info_ptr->title_name = kernel_state_->memory()->HostToGuestVirtual(
+          std::to_address(titles_names_ptr));
+      title_info_ptr->title_name_length = size;
+
+      title_info_ptr += 1;
+      titles_names_ptr += size;
+
+      returned_titles_count++;
+    }
+  }
+
+  enumerate_titles_results_ptr->total_titles_count = total_titles_count;
+  enumerate_titles_results_ptr->titles_returned = returned_titles_count;
+  enumerate_titles_results_ptr->enumerate_title_info_ptr = title_info_address;
 
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::Unkn50097(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
-
+X_HRESULT XLiveBaseApp::SubscriptionEnumerate(uint32_t buffer_ptr) {
   // Fixes accessing marketplace Memberships.
   // Address: 924346C0
 
-  Generic_Marshalled_Data* data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Generic_Marshalled_Data*>(
-          buffer_ptr);
+  GenericUnmarshaller* unmarshaller = new GenericUnmarshaller(buffer_ptr);
 
-  Internal_Marshalled_Data* internal_data_ptr =
-      kernel_state_->memory()->TranslateVirtual<Internal_Marshalled_Data*>(
-          data_ptr->internal_data_ptr);
+  SUBSCRIPTION_ENUMERATE_REQUEST* subscription_enumerate_ptr =
+      unmarshaller->DeserializeReinterpret<SUBSCRIPTION_ENUMERATE_REQUEST>();
 
-  uint8_t* results_ptr = kernel_state_->memory()->TranslateVirtual<uint8_t*>(
-      internal_data_ptr->results_ptr);
+  if (!subscription_enumerate_ptr) {
+    return X_E_INVALIDARG;
+  }
 
-  // 13 Arguments
-  X_DATA_ARGS_50097* args_ptr =
-      kernel_state_->memory()->TranslateVirtual<X_DATA_ARGS_50097*>(
-          internal_data_ptr->start_args_ptr);
+  unmarshaller->ZeroResults();
 
-  memset(results_ptr, 0, internal_data_ptr->results_size);
+  const uint32_t request_type = subscription_enumerate_ptr->request_flags;
+
+  std::string enumerate_flags = "";
+
+  if (request_type & static_cast<uint32_t>(SUBSCRIPTION_ENUMERATE_FLAGS::New)) {
+    enumerate_flags.append("New, ");
+  }
+
+  if (request_type &
+      static_cast<uint32_t>(SUBSCRIPTION_ENUMERATE_FLAGS::Renewals)) {
+    enumerate_flags.append("Renewals, ");
+  }
+
+  if (request_type &
+      static_cast<uint32_t>(SUBSCRIPTION_ENUMERATE_FLAGS::Current)) {
+    enumerate_flags.append("Current, ");
+  }
+
+  if (request_type &
+      static_cast<uint32_t>(SUBSCRIPTION_ENUMERATE_FLAGS::Expired)) {
+    enumerate_flags.append("Expired, ");
+  }
+
+  if (request_type &
+      static_cast<uint32_t>(SUBSCRIPTION_ENUMERATE_FLAGS::Suspended)) {
+    enumerate_flags.append("Suspended, ");
+  }
+
+  XELOGI("{}:: Requesting: {}", __func__, enumerate_flags);
+
+  // Add max string length?
+  const uint32_t subscription_info_size =
+      sizeof(SUBSCRIPTION_INFO) * subscription_enumerate_ptr->max_results;
+
+  assert_true(unmarshaller->GetAsyncTask()->GetXLiveAsyncTask()->results_size >
+              subscription_info_size);
+
+  SUBSCRIPTION_ENUMERATE_RESPONSE* subscription_enumerate_results_ptr =
+      unmarshaller->Results<SUBSCRIPTION_ENUMERATE_RESPONSE>();
+
+  SUBSCRIPTION_INFO* subscriptions_info_ptr =
+      reinterpret_cast<SUBSCRIPTION_INFO*>(subscription_enumerate_results_ptr +
+                                           1);
+
+  uint32_t subscriptions_info_address =
+      kernel_state_->memory()->HostToGuestVirtual(
+          std::to_address(subscriptions_info_ptr));
+
+  const std::vector<std::u16string> memberships = {
+      u"Premium Xenia Canary",
+      u"Premium Lite Xenia Canary",
+  };
+
+  char16_t* offer_names_ptr = reinterpret_cast<char16_t*>(
+      subscriptions_info_ptr + subscription_enumerate_ptr->max_results);
+
+  uint32_t total_membership_count = static_cast<uint32_t>(memberships.size());
+  uint32_t returned_membership_count = 0;
+
+  const uint32_t end_index = subscription_enumerate_ptr->starting_index +
+                             subscription_enumerate_ptr->max_results;
+
+  // Paging
+  for (uint32_t i = subscription_enumerate_ptr->starting_index; i < end_index;
+       i++) {
+    if (i >= memberships.size()) {
+      break;
+    }
+
+    const std::u16string membership = memberships[i];
+
+    const uint16_t size = static_cast<uint16_t>(membership.size() + 1);
+
+    xe::string_util::copy_and_swap_truncating(
+        offer_names_ptr, membership.c_str(), membership.size() + 1);
+
+    subscriptions_info_ptr->offer_id = i;
+    subscriptions_info_ptr->offer_name =
+        kernel_state_->memory()->HostToGuestVirtual(
+            std::to_address(offer_names_ptr));
+    subscriptions_info_ptr->offer_name_length = size;
+
+    subscriptions_info_ptr += 1;
+    offer_names_ptr += size;
+
+    returned_membership_count++;
+  }
+
+  subscription_enumerate_results_ptr->offers_total = total_membership_count;
+  subscription_enumerate_results_ptr->offers_returned =
+      returned_membership_count;
+  subscription_enumerate_results_ptr->subscription_info_ptr =
+      subscriptions_info_address;
 
   return X_E_SUCCESS;
 }
 
 X_HRESULT XLiveBaseApp::XUpdateAccessTimes(uint32_t buffer_ptr) {
-  // Called on blades dashboard v1888
+  // Blades Dashboard v1888
   // More Videos and Downloads
 
   XLIVEBASE_UPDATE_ACCESS_TIMES* data_ptr =
@@ -2637,12 +2874,15 @@ X_HRESULT XLiveBaseApp::XUpdateAccessTimes(uint32_t buffer_ptr) {
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::XMessageEnumerate(uint32_t buffer_length) {
-  // Called on blades dashboard v1888
+X_HRESULT XLiveBaseApp::XMessageEnumerate(uint32_t buffer_ptr,
+                                          uint32_t buffer_length) {
+  // Blades Dashboard v1888
 
-  if (!buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 
@@ -2674,12 +2914,15 @@ X_HRESULT XLiveBaseApp::XMessageEnumerate(uint32_t buffer_length) {
   return X_E_SUCCESS;
 }
 
-X_HRESULT XLiveBaseApp::XPresenceGetState(uint32_t buffer_length) {
-  // Called on blades dashboard v1888
+X_HRESULT XLiveBaseApp::XPresenceGetState(uint32_t buffer_ptr,
+                                          uint32_t buffer_length) {
+  // Blades Dashboard v1888
 
-  if (!buffer_length) {
+  if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  XLivebaseAsyncTask* async_task = new XLivebaseAsyncTask(buffer_ptr);
 
   Memory* memory = kernel_state_->memory();
 

--- a/src/xenia/kernel/xam/apps/xlivebase_app.h
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.h
@@ -26,30 +26,35 @@ class XLiveBaseApp : public App {
                                 uint32_t buffer_length) override;
 
  private:
-  X_HRESULT XPresenceInitialize(uint32_t buffer_length);
-  X_HRESULT XPresenceSubscribe(uint32_t buffer_length);
-  X_HRESULT XPresenceUnsubscribe(uint32_t buffer_length);
-  X_HRESULT XPresenceCreateEnumerator(uint32_t buffer_length);
+  X_HRESULT XPresenceInitialize(uint32_t buffer_ptr, uint32_t buffer_length);
+  X_HRESULT XPresenceSubscribe(uint32_t buffer_ptr, uint32_t buffer_length);
+  X_HRESULT XPresenceUnsubscribe(uint32_t buffer_ptr, uint32_t buffer_length);
+  X_HRESULT XPresenceCreateEnumerator(uint32_t buffer_ptr,
+                                      uint32_t buffer_length);
   X_HRESULT XOnlineQuerySearch(uint32_t buffer_ptr);
   X_HRESULT XOnlineGetServiceInfo(uint32_t service_id, uint32_t service_info);
 
-  X_HRESULT XFriendsCreateEnumerator(uint32_t buffer_ptr);
+  X_HRESULT XFriendsCreateEnumerator(uint32_t buffer_ptr,
+                                     uint32_t buffer_length);
   void UpdateFriendPresence(const uint32_t user_index);
   void UpdatePresenceXUIDs(const std::vector<uint64_t>& xuids,
                            const uint32_t user_index);
+  X_HRESULT XInviteSend(uint32_t buffer_ptr);
+  X_HRESULT XInviteGetAcceptedInfo(uint32_t buffer_ptr, uint32_t buffer_length);
   X_HRESULT GenericMarshalled(uint32_t buffer_ptr);
-  X_HRESULT XInviteGetAcceptedInfo(uint32_t buffer_length);
+  X_HRESULT XUserMuteListQuery(uint32_t buffer_ptr, uint32_t buffer_length);
   X_HRESULT XUserMuteListAdd(uint32_t buffer_ptr);
   X_HRESULT XUserMuteListRemove(uint32_t buffer_ptr);
   X_HRESULT XAccountGetUserInfo(uint32_t buffer_ptr);
   X_HRESULT XStorageEnumerate(uint32_t buffer_ptr);
   X_HRESULT XStringVerify(uint32_t buffer_ptr);
+  X_HRESULT XUserEstimateRankForRating(uint32_t buffer_ptr);
   X_HRESULT XStorageDelete(uint32_t buffer_ptr);
   X_HRESULT XStorageDownloadToMemory(uint32_t buffer_ptr);
   X_HRESULT XStorageUploadFromMemory(uint32_t buffer_ptr);
   X_HRESULT XStorageBuildServerPath(uint32_t buffer_ptr);
   X_HRESULT XOnlineGetTaskProgress(uint32_t buffer_ptr);
-  X_HRESULT XUserFindUsersUnkn58017(uint32_t buffer_ptr);
+  X_HRESULT GetNextSequenceMessage(uint32_t buffer_ptr);
   X_HRESULT XUserFindUsers(uint32_t buffer_ptr);
   X_HRESULT XContentGetMarketplaceCounts(uint32_t buffer_ptr);
 
@@ -60,18 +65,18 @@ class XLiveBaseApp : public App {
   X_STORAGE_FACILITY GetStorageFacilityTypeFromServerPath(
       std::string server_path);
 
-  X_HRESULT Unkn5008C(uint32_t buffer_ptr);
+  X_HRESULT GetBannerList(uint32_t buffer_ptr);
   X_HRESULT XAccountGetPointsBalance(uint32_t buffer_ptr);
-  X_HRESULT Unkn5008B(uint32_t buffer_ptr);
-  X_HRESULT Unkn5008F(uint32_t buffer_ptr);
-  X_HRESULT Unkn50090(uint32_t buffer_ptr);
-  X_HRESULT Unkn50091(uint32_t buffer_ptr);
-  X_HRESULT Unkn50097(uint32_t buffer_ptr);
+  X_HRESULT GetBannerListHot(uint32_t buffer_ptr);
+  X_HRESULT ContentEnumerate(uint32_t buffer_ptr);
+  X_HRESULT GenresEnumerate(uint32_t buffer_ptr);
+  X_HRESULT EnumerateTitlesByFilter(uint32_t buffer_ptr);
+  X_HRESULT SubscriptionEnumerate(uint32_t buffer_ptr);
 
   X_HRESULT XUpdateAccessTimes(uint32_t buffer_ptr);
 
-  X_HRESULT XMessageEnumerate(uint32_t buffer_length);
-  X_HRESULT XPresenceGetState(uint32_t buffer_length);
+  X_HRESULT XMessageEnumerate(uint32_t buffer_ptr, uint32_t buffer_length);
+  X_HRESULT XPresenceGetState(uint32_t buffer_ptr, uint32_t buffer_length);
 
   static constexpr std::string_view xstorage_symboliclink = "XSTORAGE:";
 };

--- a/src/xenia/kernel/xam/unmarshaller/generic_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/generic_unmarshaller.cc
@@ -1,0 +1,33 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/generic_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+GenericUnmarshaller::GenericUnmarshaller(uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address) {}
+
+X_HRESULT GenericUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/generic_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/generic_unmarshaller.h
@@ -1,0 +1,34 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_GENERIC_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_GENERIC_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class GenericUnmarshaller : public Unmarshaller {
+ public:
+  GenericUnmarshaller(uint32_t marshaller_buffer);
+
+  ~GenericUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+ private:
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_GENERIC_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/unmarshaller.cc
@@ -1,0 +1,87 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+Unmarshaller::Unmarshaller(uint32_t marshaller_address)
+    : xlivebase_async_message_ptr_(nullptr),
+      async_task_(nullptr),
+      position_(0) {
+  if (!marshaller_address) {
+    return;
+  }
+
+  xlivebase_async_message_ptr_ =
+      kernel_state()->memory()->TranslateVirtual<XLIVEBASE_ASYNC_MESSAGE*>(
+          marshaller_address);
+
+  async_task_ = new XLivebaseAsyncTask(
+      xlivebase_async_message_ptr_->xlive_async_task_ptr);
+}
+
+std::span<uint8_t> Unmarshaller::Advance(size_t count) {
+  const size_t offset = position_ + count;
+
+  if (offset > async_task_->data_ptr_.size()) {
+    assert_always(std::format("{}: Out of Bounds Span!", __func__));
+
+    return std::span<uint8_t>();
+  }
+
+  std::span<uint8_t> data = async_task_->data_ptr_.subspan(position_, count);
+
+  position_ = offset;
+
+  return data;
+}
+
+std::u16string Unmarshaller::ReadSwapUTF16String(uint32_t length) {
+  // Excludes null terminator
+  std::u16string server_path = xe::load_and_swap<std::u16string>(
+      reinterpret_cast<char16_t*>(async_task_->data_ptr_.data() + position_));
+
+  std::span<uint8_t> string_data =
+      Advance(xe::string_util::size_in_bytes(server_path, true));
+
+  assert_false(length != server_path.length() + 1);
+
+  if (string_data.empty()) {
+    return u"";
+  }
+
+  return server_path;
+}
+
+std::string Unmarshaller::ReadString(uint32_t length) {
+  std::span<uint8_t> string_data = Advance(length);
+
+  if (string_data.empty()) {
+    return "";
+  }
+
+  return std::string(reinterpret_cast<char*>(string_data.data()), length);
+}
+
+X_HRESULT Unmarshaller::Deserialize() { return X_E_FAIL; }
+
+XLIVEBASE_ASYNC_MESSAGE* Unmarshaller::GetXLiveBaseAsyncMessage() {
+  return xlivebase_async_message_ptr_;
+}
+
+XLivebaseAsyncTask* Unmarshaller::GetAsyncTask() { return async_task_; }
+
+size_t Unmarshaller::GetPosition() const { return position_; }
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/unmarshaller.h
@@ -1,0 +1,85 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_UNMARSHALLER_H_
+
+#include "xenia/kernel/util/shim_utils.h"
+#include "xenia/kernel/xam/unmarshaller/xlivebase_task.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class Unmarshaller {
+ public:
+  std::span<uint8_t> Advance(size_t count);
+
+  template <typename T>
+  std::span<uint8_t> AdvanceSizeOf() {
+    return Advance(sizeof(T));
+  };
+
+  template <typename T>
+  T Read() {
+    std::span<uint8_t> data = AdvanceSizeOf<T>();
+
+    if (data.empty()) {
+      return {};
+    }
+
+    return *reinterpret_cast<T*>(data.data());
+  };
+
+  template <typename T>
+  T ReadSwap() {
+    return xe::byte_swap<T>(Read<T>());
+  };
+
+  std::u16string ReadSwapUTF16String(uint32_t length);
+
+  std::string ReadString(uint32_t length);
+
+  virtual X_HRESULT Deserialize();
+
+  template <typename T>
+  T* DeserializeReinterpret() {
+    return async_task_->DeserializeReinterpret<T>();
+  };
+
+  template <typename T>
+  T* Results() const {
+    return async_task_->Results<T>();
+  };
+
+  bool ZeroResults() const { return async_task_->ZeroResults(); };
+
+  XLIVEBASE_ASYNC_MESSAGE* GetXLiveBaseAsyncMessage();
+
+  XLivebaseAsyncTask* GetAsyncTask();
+
+  size_t GetPosition() const;
+
+  ~Unmarshaller() {};
+
+ protected:
+  Unmarshaller(uint32_t marshaller_buffer);
+
+  XLIVEBASE_ASYNC_MESSAGE* xlivebase_async_message_ptr_;
+  XLivebaseAsyncTask* async_task_;
+
+ private:
+  size_t position_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.cc
@@ -1,0 +1,59 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XAccountGetUserInfoUnmarshaller::XAccountGetUserInfoUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      xuid_(0),
+      machine_id_(0),
+      title_id_(0) {}
+
+X_HRESULT XAccountGetUserInfoUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  if (GetAsyncTask()->GetXLiveAsyncTask()->results_size <
+      XAccountGetUserInfoResponseSize()) {
+    return X_ONLINE_E_ACCOUNTS_USER_GET_ACCOUNT_INFO_ERROR;
+  }
+
+  xuid_ = Read<uint64_t>();
+  machine_id_ = Read<uint64_t>();
+  title_id_ = Read<uint32_t>();
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xaccount_getuserinfo_unmarshaller.h
@@ -1,0 +1,43 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XACCOUNT_GETUSERINFO_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XACCOUNT_GETUSERINFO_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XAccountGetUserInfoUnmarshaller : public Unmarshaller {
+ public:
+  XAccountGetUserInfoUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XAccountGetUserInfoUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint64_t XUID() const { return xuid_; };
+
+  const uint64_t MachineID() const { return machine_id_; };
+
+  const uint32_t TitleId() const { return title_id_; };
+
+ private:
+  uint64_t xuid_;
+  uint64_t machine_id_;
+  uint32_t title_id_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XACCOUNT_GETUSERINFO_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.cc
@@ -1,0 +1,69 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XInviteSendUnmarshaller::XInviteSendUnmarshaller(uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      user_index_(0),
+      num_invitees_(0),
+      invitees_({}),
+      display_string_size_(0),
+      display_string_(u""),
+      xmsg_handle_(0) {}
+
+X_HRESULT XInviteSendUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (GetAsyncTask()->GetXLiveAsyncTask()->results_ptr ||
+      GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    assert_always(std::format("{} results unexpected!", __func__));
+  }
+
+  user_index_ = ReadSwap<uint32_t>();
+  num_invitees_ = ReadSwap<uint32_t>();
+
+  if (num_invitees_ > X_ONLINE_MAX_FRIENDS) {
+    return X_E_INVALIDARG;
+  }
+
+  for (uint32_t i = 0; i < num_invitees_; i++) {
+    invitees_.push_back(ReadSwap<uint64_t>());
+  }
+
+  display_string_size_ = ReadSwap<uint32_t>();
+  display_string_ = ReadSwapUTF16String(display_string_size_);
+
+  xmsg_handle_ = ReadSwap<uint32_t>();
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (display_string_size_ > X_ONLINE_MAX_XINVITE_DISPLAY_STRING) {
+    return X_E_INVALIDARG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xinvite_send_unmarshaller.h
@@ -1,0 +1,52 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XINVITE_SEND_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XINVITE_SEND_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XInviteSendUnmarshaller : public Unmarshaller {
+ public:
+  XInviteSendUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XInviteSendUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t UserIndex() const { return user_index_; };
+
+  const uint32_t NumInvitees() const { return num_invitees_; };
+
+  const std::vector<uint64_t> Invitees() const { return invitees_; };
+
+  const uint32_t DisplayStringSize() const { return display_string_size_; };
+
+  const std::u16string DisplayString() const { return display_string_; };
+
+  const uint32_t XMessageHandle() const { return xmsg_handle_; };
+
+ private:
+  uint32_t user_index_;
+  uint32_t num_invitees_;
+  std::vector<uint64_t> invitees_;
+  uint32_t display_string_size_;
+  std::u16string display_string_;
+  uint32_t xmsg_handle_;  // const 0
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XINVITE_SEND_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xlivebase_task.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xlivebase_task.cc
@@ -1,0 +1,324 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xlivebase_task.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XLivebaseAsyncTask::XLivebaseAsyncTask(uint32_t async_task_address)
+    : xlive_async_task_ptr_(nullptr),
+      schema_data_ptr_(nullptr),
+      ordinal_to_index_ptr_(nullptr),
+      schema_table_entry_ptr_(nullptr),
+      data_ptr_({}),
+      url_offsets_ptr(nullptr),
+      url_data_ptr(nullptr),
+      constant_list_ptr(nullptr) {
+  if (!async_task_address) {
+    return;
+  }
+
+  xlive_async_task_ptr_ =
+      kernel_state()->memory()->TranslateVirtual<XLIVE_ASYNC_TASK*>(
+          async_task_address);
+
+  schema_data_ptr_ = kernel_state()->memory()->TranslateVirtual<SCHEMA_DATA*>(
+      xlive_async_task_ptr_->schema_data_ptr);
+
+  ordinal_to_index_ptr_ =
+      kernel_state()->memory()->TranslateVirtual<ORDINAL_TO_INDEX*>(
+          schema_data_ptr_->OrdinalToIndexPtr);
+
+  schema_table_entry_ptr_ =
+      kernel_state()->memory()->TranslateVirtual<SCHEMA_TABLE_ENTRY*>(
+          schema_data_ptr_->TableEntriesPtr);
+
+  url_offsets_ptr =
+      kernel_state()->memory()->TranslateVirtual<xe::be<uint16_t>*>(
+          schema_data_ptr_->UrlOffsetsPtr);
+
+  url_data_ptr = kernel_state()->memory()->TranslateVirtual<char*>(
+      schema_data_ptr_->UrlDataPtr);
+
+  constant_list_ptr =
+      kernel_state()->memory()->TranslateVirtual<xe::be<uint32_t>*>(
+          schema_data_ptr_->ConstantListPtr);
+
+  uint8_t* data_request_ptr =
+      kernel_state()->memory()->TranslateVirtual<uint8_t*>(
+          xlive_async_task_ptr_->marshalled_request_ptr);
+
+  url_ = GetTaskUrl();
+
+  data_ptr_ = std::span<uint8_t>(
+      data_request_ptr, xlive_async_task_ptr_->marshalled_request_size);
+
+  if (!url_.empty()) {
+    std::string info =
+        fmt::format("{}: Sechma Index {:04X}, URL: {}", __func__,
+                    xlive_async_task_ptr_->schema_index.get(), url_);
+
+    XELOGI(info.c_str());
+  }
+
+  PrintTaskInfo();
+}
+
+void XLivebaseAsyncTask::PrintTaskInfo() {
+  XELOGD(
+      "\n***************** XLiveBase Task Info *****************\n"
+      "SchemaVersionMajor: {}\n"
+      "SchemaVersionMinor: {}\n"
+      "ToolVersion: {:08X}\n"
+      "TaskFlags: {:08X}\n"
+      "SchemaTableEntries: {}\n"
+      "OrdinalToIndexPtr: {:08X}\n"
+      "SechmaIndex: {:04X}\n"
+      "MarshalledRequestPtr: {:08X}\n"
+      "MarshalledRequestSize: {}\n"
+      "ResultsPtr: {:08X}\n"
+      "RequestsSize: {}\n"
+      "URL: {}\n",
+      schema_data_ptr_->Header.SchemaVersionMajor.get(),
+      schema_data_ptr_->Header.SchemaVersionMinor.get(),
+      schema_data_ptr_->Header.ToolVersion.get(),
+      xlive_async_task_ptr_->task_flags.get(),
+      schema_data_ptr_->Header.SchemaTableEntries.get(),
+      schema_data_ptr_->OrdinalToIndexPtr.get(),
+      xlive_async_task_ptr_->schema_index.get(),
+      xlive_async_task_ptr_->marshalled_request_ptr.get(),
+      xlive_async_task_ptr_->marshalled_request_size.get(),
+      xlive_async_task_ptr_->results_ptr.get(),
+      xlive_async_task_ptr_->results_size.get(), GetTaskUrl());
+}
+
+bool XLivebaseAsyncTask::GetSchemaEntry(uint16_t schema_index,
+                                        SCHEMA_TABLE_ENTRY* schema_entry_ptr) {
+  if (schema_index >= GetSchemaData()->Header.SchemaTableEntries) {
+    return false;
+  }
+
+  std::memcpy(schema_entry_ptr, schema_table_entry_ptr_ + schema_index,
+              sizeof(SCHEMA_TABLE_ENTRY));
+
+  return true;
+}
+
+bool XLivebaseAsyncTask::GetSchemaDataFromEntry(
+    SCHEMA_TABLE_ENTRY* schema_entry_ptr, bool request,
+    std::span<uint8_t>* schema_data) {
+  uint32_t request_schema_offset = 0;
+  uint32_t schema_data_size = 0;
+
+  if (request) {
+    schema_data_size = schema_entry_ptr->RequestSchemaSize;
+    request_schema_offset = schema_entry_ptr->RequestSchemaOffset;
+  } else {
+    schema_data_size = schema_entry_ptr->ResponseSchemaSize;
+    request_schema_offset = schema_entry_ptr->ResponseSchemaOffset;
+  }
+
+  uint8_t* schema_data_ptr =
+      kernel_state()->memory()->TranslateVirtual<uint8_t*>(
+          schema_data_ptr_->SchemaDataPtr);
+
+  uint8_t* buffer_ptr = &schema_data_ptr[request_schema_offset];
+
+  *schema_data = std::span<uint8_t>(buffer_ptr, schema_data_size);
+
+  return true;
+}
+
+bool XLivebaseAsyncTask::EndianBufferBind(BASE_ENDIAN_BUFFER* base,
+                                          std::span<uint8_t>& buffer) {
+  base->BufferPtr = kernel_state()->memory()->HostToGuestVirtual(
+      std::to_address(buffer.data()));
+  base->BufferSize = static_cast<uint32_t>(buffer.size());
+  base->AvailableSize = static_cast<uint32_t>(buffer.size());
+  base->ConsumedSize = 0;
+  base->ReverseEndian = 1;
+
+  return true;
+}
+
+bool XLivebaseAsyncTask::XLookupSchemaIndexFromOrdinal(
+    uint16_t ordinal, uint16_t* schema_index) const {
+  auto CompareOrdinal = [](const void* e1, const void* e2) -> int {
+    const auto* element1 = reinterpret_cast<const xe::be<uint16_t>*>(e1);
+    const auto* element2 = reinterpret_cast<const xe::be<uint16_t>*>(e2);
+
+    return *element1 - *element2;
+  };
+
+  ordinal = xe::byte_swap(ordinal);
+
+  const ORDINAL_TO_INDEX* found = static_cast<ORDINAL_TO_INDEX*>(std::bsearch(
+      &ordinal, ordinal_to_index_ptr_,
+      schema_data_ptr_->Header.SchemaTableEntries, 4, CompareOrdinal));
+
+  if (!found) {
+    return false;
+  }
+
+  *schema_index = found->Index;
+
+  return true;
+}
+
+bool XLivebaseAsyncTask::LookupUrlFromTable(uint16_t url_index,
+                                            std::string_view* url_ptr) {
+  if (url_index > GetSchemaData()->Header.UrlTableSize) {
+    return false;
+  }
+
+  char* url_data_ptr = kernel_state()->memory()->TranslateVirtual<char*>(
+      schema_data_ptr_->UrlDataPtr);
+
+  uint16_t url_offset = url_offsets_ptr[url_index];
+
+  if (url_offset > schema_data_ptr_->Header.UrlTableDataSize) {
+    return false;
+  }
+
+  *url_ptr = std::string_view(url_data_ptr + url_offset);
+
+  return true;
+};
+
+bool XLivebaseAsyncTask::LookupConstantFromTable(uint16_t constant_index,
+                                                 uint32_t* value_ptr) {
+  if (constant_index > schema_data_ptr_->Header.ConstantsTableSize) {
+    return false;
+  }
+
+  assert_false(schema_data_ptr_->Header.ConstantSize != 4);
+
+  *value_ptr = constant_list_ptr[constant_index];
+
+  return true;
+}
+
+std::string_view XLivebaseAsyncTask::GetTaskUrl() {
+  SCHEMA_TABLE_ENTRY schema_entry = {};
+  std::string_view url = "";
+
+  GetSchemaEntry(xlive_async_task_ptr_->schema_index, &schema_entry);
+  LookupUrlFromTable(schema_entry.RequestUrlIndex, &url);
+
+  return url;
+}
+
+void XLivebaseAsyncTask::PrettyPrintSchemaTables() const {
+  const auto schema_table_entries = std::vector<SCHEMA_TABLE_ENTRY>(
+      schema_table_entry_ptr_,
+      schema_table_entry_ptr_ + schema_data_ptr_->Header.SchemaTableEntries);
+
+  std::string schema_entries_details = fmt::format(
+      "\nSchema Version: {}.{}\n",
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMajor),
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMinor));
+
+  for (uint32_t i = 0; const auto& entry : schema_table_entries) {
+    std::string entry_details = fmt::format(
+        "Schema entry {}: Request [{:08X}, {:08X}, {:08X}], Response [{:08X}, "
+        "{:08X}, "
+        "{:08X}], Service: {} ({})\n",
+        i, entry.RequestSchemaSize.get(), entry.ResponseSchemaSize.get(),
+        entry.RequestSchemaOffset.get(), entry.ResponseSchemaOffset.get(),
+        entry.MaxRequestAggregateSize.get(),
+        entry.MaxResponseAggregateSize.get(), entry.ServiceIDIndex.get(),
+        entry.RequestUrlIndex.get());
+
+    schema_entries_details.append(entry_details);
+
+    i++;
+  }
+
+  XELOGI(schema_entries_details);
+}
+
+void XLivebaseAsyncTask::PrettyPrintUrls() {
+  const auto schema_table_entries = std::vector<SCHEMA_TABLE_ENTRY>(
+      schema_table_entry_ptr_,
+      schema_table_entry_ptr_ + schema_data_ptr_->Header.SchemaTableEntries);
+
+  std::string pretty_urls = fmt::format(
+      "\nSchema Version: {}.{}\n",
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMajor),
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMinor));
+
+  for (const auto& entry : schema_table_entries) {
+    std::string_view url = "";
+
+    LookupUrlFromTable(entry.RequestUrlIndex, &url);
+
+    pretty_urls.append(fmt::format("URL: {}\n", url));
+  }
+
+  XELOGI(pretty_urls);
+}
+
+void XLivebaseAsyncTask::PrettyPrintUrlsWithSchemaIndex() {
+  const auto schema_table_entries = std::vector<SCHEMA_TABLE_ENTRY>(
+      schema_table_entry_ptr_,
+      schema_table_entry_ptr_ + schema_data_ptr_->Header.SchemaTableEntries);
+
+  const auto ordinal_to_index_entries = std::vector<ORDINAL_TO_INDEX>(
+      ordinal_to_index_ptr_,
+      ordinal_to_index_ptr_ + schema_data_ptr_->Header.SchemaTableEntries);
+
+  std::string pretty_urls = fmt::format(
+      "\nSchema Version: {}.{}\n",
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMajor),
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMinor));
+
+  for (const auto& ordinal_entry : ordinal_to_index_entries) {
+    SCHEMA_TABLE_ENTRY schema_entry = {};
+    std::string_view url = "";
+
+    GetSchemaEntry(ordinal_entry.Index.get(), &schema_entry);
+    LookupUrlFromTable(schema_entry.RequestUrlIndex, &url);
+
+    pretty_urls.append(fmt::format("Schema Index: {:04X}, URL: {}\n",
+                                   ordinal_entry.Index.get(), url));
+  }
+
+  XELOGI(pretty_urls);
+}
+
+void XLivebaseAsyncTask::PrettyPrintOrdinalToIndex() const {
+  const auto ordinal_to_index_entries = std::vector<ORDINAL_TO_INDEX>(
+      ordinal_to_index_ptr_,
+      ordinal_to_index_ptr_ + schema_data_ptr_->Header.SchemaTableEntries);
+
+  std::string pretty_schema_table = fmt::format(
+      "\nSchema Version: {}.{}\n",
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMajor),
+      static_cast<uint32_t>(schema_data_ptr_->Header.SchemaVersionMinor));
+
+  for (const auto& entry : ordinal_to_index_entries) {
+    pretty_schema_table.append(fmt::format("Ordinal: {:04X}, Index: {:04X}\n",
+                                           static_cast<uint16_t>(entry.Ordinal),
+                                           static_cast<uint16_t>(entry.Index)));
+  }
+
+  XELOGI(pretty_schema_table);
+}
+
+XLIVE_ASYNC_TASK* XLivebaseAsyncTask::GetXLiveAsyncTask() {
+  return xlive_async_task_ptr_;
+}
+
+SCHEMA_DATA* XLivebaseAsyncTask::GetSchemaData() { return schema_data_ptr_; }
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xlivebase_task.h
+++ b/src/xenia/kernel/xam/unmarshaller/xlivebase_task.h
@@ -1,0 +1,107 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XLIVEBASETASK_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XLIVEBASETASK_H_
+
+#include "xenia/kernel/util/shim_utils.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XLivebaseAsyncTask {
+ public:
+  XLivebaseAsyncTask(uint32_t async_task_address);
+
+  ~XLivebaseAsyncTask() {};
+
+  void PrintTaskInfo();
+
+  bool GetSchemaEntry(uint16_t schema_index,
+                      SCHEMA_TABLE_ENTRY* schema_entry_ptr);
+
+  bool GetSchemaDataFromEntry(SCHEMA_TABLE_ENTRY* schema_entry_ptr,
+                              bool request, std::span<uint8_t>* schema_data);
+
+  bool EndianBufferBind(BASE_ENDIAN_BUFFER* base, std::span<uint8_t>& buffer);
+
+  bool XLookupSchemaIndexFromOrdinal(uint16_t ordinal,
+                                     uint16_t* schema_index) const;
+
+  bool LookupUrlFromTable(uint16_t url_index, std::string_view* url_ptr);
+
+  bool LookupConstantFromTable(uint16_t constant_index, uint32_t* value_ptr);
+
+  std::string_view GetTaskUrl();
+
+  void PrettyPrintSchemaTables() const;
+
+  void PrettyPrintUrls();
+
+  void PrettyPrintUrlsWithSchemaIndex();
+
+  void PrettyPrintOrdinalToIndex() const;
+
+  XLIVE_ASYNC_TASK* GetXLiveAsyncTask();
+
+  SCHEMA_DATA* GetSchemaData();
+
+  template <typename T>
+  T* DeserializeReinterpret() {
+    if (!xlive_async_task_ptr_ ||
+        !xlive_async_task_ptr_->marshalled_request_ptr) {
+      return nullptr;
+    }
+
+    assert_false(sizeof(T) != xlive_async_task_ptr_->marshalled_request_size);
+
+    return kernel_state()->memory()->TranslateVirtual<T*>(
+        xlive_async_task_ptr_->marshalled_request_ptr);
+  };
+
+  template <typename T>
+  T* Results() const {
+    if (!xlive_async_task_ptr_ || !xlive_async_task_ptr_->results_ptr) {
+      return nullptr;
+    }
+
+    return kernel_state()->memory()->TranslateVirtual<T*>(
+        xlive_async_task_ptr_->results_ptr);
+  };
+
+  bool ZeroResults() const {
+    if (!xlive_async_task_ptr_ || !xlive_async_task_ptr_->results_ptr) {
+      return false;
+    }
+
+    uint8_t* results_ptr = kernel_state()->memory()->TranslateVirtual<uint8_t*>(
+        xlive_async_task_ptr_->results_ptr);
+
+    std::fill_n(results_ptr, xlive_async_task_ptr_->results_size.get(), 0);
+
+    return true;
+  };
+
+  XLIVE_ASYNC_TASK* xlive_async_task_ptr_;
+  SCHEMA_DATA* schema_data_ptr_;
+  ORDINAL_TO_INDEX* ordinal_to_index_ptr_;
+  SCHEMA_TABLE_ENTRY* schema_table_entry_ptr_;
+  xe::be<uint16_t>* url_offsets_ptr;
+  char* url_data_ptr;
+  xe::be<uint32_t>* constant_list_ptr;
+  std::string_view url_ = "";
+  std::span<uint8_t> data_ptr_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XLIVEBASETASK_H_

--- a/src/xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.cc
@@ -1,0 +1,129 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XQuerySearchUnmarshaller::XQuerySearchUnmarshaller(uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      title_id_(0),
+      dataset_id_(0),
+      proc_index_(0),
+      page_(0),
+      results_pre_page_(0),
+      num_result_specs_(0),
+      num_attributes_(0),
+      attributes_spec_({}) {};
+
+X_HRESULT XQuerySearchUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  title_id_ = Read<uint32_t>();
+  dataset_id_ = Read<uint32_t>();
+  proc_index_ = Read<uint32_t>();
+  page_ = Read<uint32_t>();
+  results_pre_page_ = Read<uint32_t>();
+  num_result_specs_ = Read<uint32_t>();
+  num_attributes_ = Read<uint32_t>();
+
+  for (uint32_t i = 0; i < num_result_specs_; i++) {
+    X_ONLINE_QUERY_ATTRIBUTE_SPEC attribute_spec =
+        Read<X_ONLINE_QUERY_ATTRIBUTE_SPEC>();
+
+    attributes_spec_.push_back(attribute_spec);
+  }
+
+  assert_false(num_attributes_ > 0);
+
+  // for (uint32_t i = 0; i < num_attributes_; i++) {
+  //   X_ONLINE_QUERY_ATTRIBUTE_DATA* attribute =
+  //       reinterpret_cast<X_ONLINE_QUERY_ATTRIBUTE_DATA*>(
+  //           Advance(sizeof(X_ONLINE_QUERY_ATTRIBUTE_DATA)).data());
+  // }
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (results_pre_page_ == 0) {
+    return X_E_INVALIDARG;
+  }
+
+  if (results_pre_page_ > X_ONLINE_QUERY_MAX_PAGE_SIZE) {
+    return X_E_INVALIDARG;
+  }
+
+  if (dataset_id_ != X_ONLINE_LSP_DEFAULT_DATASET_ID) {
+    return X_E_INVALIDARG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+void XQuerySearchUnmarshaller::PrettyPrintAttributesSpec() {
+  std::string attribute_details = "\n\nXOnlineQuerySearch Attributes:\n";
+
+  for (const auto& attribute : attributes_spec_) {
+    std::string attribute_type = "Unknown";
+    std::string attribute_desc = "";
+
+    switch (attribute.type & X_ATTRIBUTE_DATATYPE_MASK) {
+      case X_ATTRIBUTE_DATATYPE_INTEGER:
+        attribute_type = "Integer";
+        break;
+      case X_ATTRIBUTE_DATATYPE_STRING:
+        attribute_type = "String";
+        break;
+      case X_ATTRIBUTE_DATATYPE_BLOB:
+        attribute_type = "Blob";
+        break;
+    }
+
+    switch (attribute.type) {
+      case X_ONLINE_LSP_ATTRIBUTE_TSADDR:
+        attribute_desc = "TSADDR";
+        break;
+      case X_ONLINE_LSP_ATTRIBUTE_XNKID:
+        attribute_desc = "XNKID";
+        break;
+      case X_ONLINE_LSP_ATTRIBUTE_KEY:
+        attribute_desc = "XNKEY";
+        break;
+      case X_ONLINE_LSP_ATTRIBUTE_USER:
+        attribute_desc = "USER";
+        break;
+      case X_ONLINE_LSP_ATTRIBUTE_PARAM_USER:
+        attribute_desc = "PARAM USER";
+        break;
+      default:
+        attribute_desc = attribute_type;
+        break;
+    }
+
+    attribute_details.append(fmt::format(
+        "ID: {:08X}\nSize: {}\nType: {}\nDescription: {}\n\n", attribute.type,
+        attribute.length, attribute_type, attribute_desc));
+  }
+
+  XELOGD(attribute_details);
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xonline_query_search_unmarshaller.h
@@ -1,0 +1,62 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XONLINE_QUERYSEARCH_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XONLINE_QUERYSEARCH_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XQuerySearchUnmarshaller : public Unmarshaller {
+ public:
+  XQuerySearchUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XQuerySearchUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t TitleID() const { return title_id_; };
+
+  const uint32_t DatasetID() const { return dataset_id_; };
+
+  const uint32_t ProcedureIndex() const { return proc_index_; };
+
+  const uint32_t Page() const { return page_; };
+
+  const uint32_t ResultsPrePage() const { return results_pre_page_; };
+
+  const uint32_t NumResultSpects() const { return num_result_specs_; };
+
+  const uint32_t NumAttributes() const { return num_attributes_; };
+
+  const std::vector<X_ONLINE_QUERY_ATTRIBUTE_SPEC> SpecAttributes() const {
+    return attributes_spec_;
+  };
+
+  void PrettyPrintAttributesSpec();
+
+ private:
+  uint32_t title_id_;
+  uint32_t dataset_id_;
+  uint32_t proc_index_;
+  uint32_t page_;
+  uint32_t results_pre_page_;
+  uint32_t num_result_specs_;
+  uint32_t num_attributes_;
+  std::vector<X_ONLINE_QUERY_ATTRIBUTE_SPEC> attributes_spec_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XONLINE_QUERYSEARCH_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.cc
@@ -1,0 +1,59 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XStorageDeleteUnmarshaller::XStorageDeleteUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      user_index_(0),
+      server_path_len_(0),
+      server_path_(u"") {}
+
+X_HRESULT XStorageDeleteUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (GetAsyncTask()->GetXLiveAsyncTask()->results_ptr ||
+      GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    assert_always(std::format("{} results unexpected!", __func__));
+  }
+
+  user_index_ = ReadSwap<uint32_t>();
+  server_path_len_ = ReadSwap<uint32_t>();
+  server_path_ = ReadSwapUTF16String(server_path_len_);
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (ServerPathLength() > X_ONLINE_MAX_PATHNAME_LENGTH) {
+    return X_E_INVALIDARG;
+  }
+
+  if (ServerPath().empty()) {
+    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_delete_unmarshaller.h
@@ -1,0 +1,43 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DELETE_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DELETE_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XStorageDeleteUnmarshaller : public Unmarshaller {
+ public:
+  XStorageDeleteUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XStorageDeleteUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t UserIndex() const { return user_index_; };
+
+  const uint32_t ServerPathLength() const { return server_path_len_; };
+
+  const std::u16string ServerPath() const { return server_path_; };
+
+ private:
+  uint32_t user_index_;
+  uint32_t server_path_len_;
+  std::u16string server_path_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DELETE_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.cc
@@ -1,0 +1,74 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XStorageDownloadToMemoryUnmarshaller::XStorageDownloadToMemoryUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      user_index_(0),
+      server_path_len_(0),
+      server_path_(u""),
+      buffer_size_(0),
+      download_buffer_address_(0) {}
+
+X_HRESULT XStorageDownloadToMemoryUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  user_index_ = ReadSwap<uint32_t>();
+  server_path_len_ = ReadSwap<uint32_t>();
+  server_path_ = ReadSwapUTF16String(server_path_len_);
+  buffer_size_ = ReadSwap<uint32_t>();
+  download_buffer_address_ = ReadSwap<uint32_t>();
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (ServerPathLength() > X_ONLINE_MAX_PATHNAME_LENGTH) {
+    return X_E_INVALIDARG;
+  }
+
+  if (ServerPath().empty()) {
+    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
+  }
+
+  if (!DownloadBufferAddress()) {
+    return X_E_INVALIDARG;
+  }
+
+  if (BufferSize() > kTMSFileMaxSize) {
+    return X_ONLINE_E_STORAGE_FILE_IS_TOO_BIG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_download_unmarshaller.h
@@ -1,0 +1,59 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DOWNLOAD_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DOWNLOAD_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XStorageDownloadToMemoryUnmarshaller : public Unmarshaller {
+ public:
+  XStorageDownloadToMemoryUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XStorageDownloadToMemoryUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t UserIndex() const { return user_index_; };
+
+  const uint32_t ServerPathLength() const { return server_path_len_; };
+
+  const std::u16string ServerPath() const { return server_path_; };
+
+  const uint32_t BufferSize() const { return buffer_size_; };
+
+  const uint32_t DownloadBufferAddress() const {
+    return download_buffer_address_;
+  };
+
+  std::span<uint8_t> GetDownloadBuffer() const {
+    uint8_t* download_buffer_ptr =
+        kernel_state()->memory()->TranslateVirtual<uint8_t*>(
+            download_buffer_address_);
+
+    return std::span<uint8_t>(download_buffer_ptr, buffer_size_);
+  };
+
+ private:
+  uint32_t user_index_;
+  uint32_t server_path_len_;
+  std::u16string server_path_;
+  uint32_t buffer_size_;
+  uint32_t download_buffer_address_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_DOWNLOAD_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.cc
@@ -1,0 +1,74 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XStorageEnumerateUnmarshaller::XStorageEnumerateUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      user_index_(0),
+      server_path_len_(0),
+      server_path_(u""),
+      starting_index_(0),
+      max_results_to_return_(0) {}
+
+X_HRESULT XStorageEnumerateUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  user_index_ = ReadSwap<uint32_t>();
+  server_path_len_ = ReadSwap<uint32_t>();
+  server_path_ = ReadSwapUTF16String(server_path_len_);
+  starting_index_ = ReadSwap<uint32_t>();
+  max_results_to_return_ = ReadSwap<uint32_t>();
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (ServerPathLength() > X_ONLINE_MAX_PATHNAME_LENGTH) {
+    return X_E_INVALIDARG;
+  }
+
+  if (ServerPath().empty()) {
+    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
+  }
+
+  if (MaxResultsToReturn() > X_STORAGE_MAX_RESULTS_TO_RETURN) {
+    return X_E_INVALIDARG;
+  }
+
+  if (StartingIndex() >= X_STORAGE_MAX_RESULTS_TO_RETURN) {
+    return X_E_INVALIDARG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_enumerate_unmarshaller.h
@@ -1,0 +1,49 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_ENUMERATE_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_ENUMERATE_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XStorageEnumerateUnmarshaller : public Unmarshaller {
+ public:
+  XStorageEnumerateUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XStorageEnumerateUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t UserIndex() const { return user_index_; };
+
+  const uint32_t ServerPathLength() const { return server_path_len_; };
+
+  const std::u16string ServerPath() const { return server_path_; };
+
+  const uint32_t StartingIndex() const { return starting_index_; };
+
+  const uint32_t MaxResultsToReturn() const { return max_results_to_return_; };
+
+ private:
+  uint32_t user_index_;
+  uint32_t server_path_len_;
+  std::u16string server_path_;
+  uint32_t starting_index_;
+  uint32_t max_results_to_return_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_ENUMERATE_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.cc
@@ -1,0 +1,71 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XStorageUploadToMemoryUnmarshaller::XStorageUploadToMemoryUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      user_index_(0),
+      server_path_len_(0),
+      server_path_(u""),
+      buffer_size_(0),
+      upload_buffer_address_(0) {}
+
+X_HRESULT XStorageUploadToMemoryUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (GetAsyncTask()->GetXLiveAsyncTask()->results_ptr ||
+      GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    assert_always(std::format("{} results unexpected!", __func__));
+  }
+
+  user_index_ = ReadSwap<uint32_t>();
+  server_path_len_ = ReadSwap<uint32_t>();
+  server_path_ = ReadSwapUTF16String(server_path_len_);
+  buffer_size_ = ReadSwap<uint32_t>();
+  upload_buffer_address_ = ReadSwap<uint32_t>();
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (ServerPathLength() > X_ONLINE_MAX_PATHNAME_LENGTH) {
+    return X_E_INVALIDARG;
+  }
+
+  if (ServerPath().empty()) {
+    return X_ONLINE_E_STORAGE_INVALID_STORAGE_PATH;
+  }
+
+  if (!UploadBufferAddress()) {
+    return X_E_INVALIDARG;
+  }
+
+  if (BufferSize() > kTMSClipMaxSize) {
+    return X_ONLINE_E_STORAGE_FILE_IS_TOO_BIG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xstorage_upload_unmarshaller.h
@@ -1,0 +1,57 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_UPLOAD_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_UPLOAD_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XStorageUploadToMemoryUnmarshaller : public Unmarshaller {
+ public:
+  XStorageUploadToMemoryUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XStorageUploadToMemoryUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t UserIndex() const { return user_index_; };
+
+  const uint32_t ServerPathLength() const { return server_path_len_; };
+
+  const std::u16string ServerPath() const { return server_path_; };
+
+  const uint32_t BufferSize() const { return buffer_size_; };
+
+  const uint32_t UploadBufferAddress() const { return upload_buffer_address_; };
+
+  std::span<uint8_t> GetUploadBuffer() const {
+    uint8_t* upload_buffer_ptr =
+        kernel_state()->memory()->TranslateVirtual<uint8_t*>(
+            upload_buffer_address_);
+
+    return std::span<uint8_t>(upload_buffer_ptr, buffer_size_);
+  };
+
+ private:
+  uint32_t user_index_;
+  uint32_t server_path_len_;
+  std::u16string server_path_;
+  uint32_t buffer_size_;
+  uint32_t upload_buffer_address_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XSTORAGE_UPLOAD_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.cc
@@ -1,0 +1,76 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XStringVerifyUnmarshaller::XStringVerifyUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      title_id_(0),
+      flags_(0),
+      locale_size_(0),
+      num_strings_(0),
+      locale_(""),
+      strings_to_verify_({}) {}
+
+X_HRESULT XStringVerifyUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  title_id_ = Read<uint32_t>();
+  flags_ = Read<uint32_t>();
+  locale_size_ = Read<uint16_t>();
+  num_strings_ = Read<uint16_t>();
+  locale_ = ReadString(locale_size_);
+
+  if (NumStrings() > X_ONLINE_MAX_XSTRING_VERIFY_STRING_DATA) {
+    return X_E_INVALIDARG;
+  }
+
+  for (uint32_t i = 0; i < num_strings_; i++) {
+    uint16_t string_size = Read<uint16_t>();
+
+    // Unicode is represented as UTF-8 array
+    std::string input = ReadString(string_size);
+
+    strings_to_verify_.push_back(input);
+  }
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  if (LocaleSize() > X_ONLINE_MAX_XSTRING_VERIFY_LOCALE) {
+    return X_E_INVALIDARG;
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xstring_verify_unmarshaller.h
@@ -1,0 +1,54 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XSTRINGVERIFY_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XSTRINGVERIFY_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XStringVerifyUnmarshaller : public Unmarshaller {
+ public:
+  XStringVerifyUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XStringVerifyUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t TitleId() const { return title_id_; };
+
+  const uint32_t Flags() const { return flags_; };
+
+  const uint16_t LocaleSize() const { return locale_size_; };
+
+  const uint16_t NumStrings() const { return num_strings_; };
+
+  const std::string Locale() const { return locale_; };
+
+  const std::vector<std::string>& StringToVerify() const {
+    return strings_to_verify_;
+  };
+
+ private:
+  uint32_t title_id_;
+  uint32_t flags_;
+  uint16_t locale_size_;
+  uint16_t num_strings_;
+  std::string locale_;
+  std::vector<std::string> strings_to_verify_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XSTRINGVERIFY_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.cc
@@ -1,0 +1,63 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XUserEstimateRankForRatingUnmarshaller::XUserEstimateRankForRatingUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      title_id_(0),
+      ratings_count_(0),
+      estimate_ranks_({}) {}
+
+X_HRESULT XUserEstimateRankForRatingUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  title_id_ = Read<uint32_t>();
+  ratings_count_ = Read<uint32_t>();
+
+  if (ratings_count_ > X_ONLINE_MAX_STATS_ESTIMATE_RATING_COUNT) {
+    return X_E_INVALIDARG;
+  }
+
+  for (uint32_t i = 0; i < ratings_count_; i++) {
+    X_USER_RANK_REQUEST estimate_rank = Read<X_USER_RANK_REQUEST>();
+
+    estimate_ranks_.push_back(estimate_rank);
+  }
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xuser_estimate_rank_for_ratings_unmarshaller.h
@@ -1,0 +1,45 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_ESTIMATE_RANK_FOR_RATINGS_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_ESTIMATE_RANK_FOR_RATINGS_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XUserEstimateRankForRatingUnmarshaller : public Unmarshaller {
+ public:
+  XUserEstimateRankForRatingUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XUserEstimateRankForRatingUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const uint32_t TitleId() const { return title_id_; };
+
+  const uint32_t RatingCount() const { return ratings_count_; };
+
+  const std::vector<X_USER_RANK_REQUEST>& StatsEstimateRanks() const {
+    return estimate_ranks_;
+  };
+
+ private:
+  uint32_t title_id_;
+  uint32_t ratings_count_;
+  std::vector<X_USER_RANK_REQUEST> estimate_ranks_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_ESTIMATE_RANK_FOR_RATINGS_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.cc
+++ b/src/xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.cc
@@ -1,0 +1,58 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+XUserFindUsersUnmarshaller::XUserFindUsersUnmarshaller(
+    uint32_t marshaller_address)
+    : Unmarshaller(marshaller_address),
+      msg_header_({}),
+      xuid_issuer_(0),
+      num_users_(0) {}
+
+X_HRESULT XUserFindUsersUnmarshaller::Deserialize() {
+  if (!GetXLiveBaseAsyncMessage()->xlive_async_task_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_ptr) {
+    return X_E_INVALIDARG;
+  }
+
+  if (!GetAsyncTask()->GetXLiveAsyncTask()->results_size) {
+    return X_E_INVALIDARG;
+  }
+
+  msg_header_ = Read<BASE_MSG_HEADER>();
+  xuid_issuer_ = Read<uint64_t>();
+  num_users_ = Read<uint32_t>();
+
+  for (uint32_t i = 0; i < num_users_; i++) {
+    users_.push_back(Read<FIND_USER_INFO>());
+  }
+
+  if (GetPosition() !=
+      GetAsyncTask()->GetXLiveAsyncTask()->marshalled_request_size) {
+    assert_always(std::format("{} deserialization incomplete", __func__));
+  }
+
+  return X_E_SUCCESS;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.h
+++ b/src/xenia/kernel/xam/unmarshaller/xuser_findusers_unmarshaller.h
@@ -1,0 +1,46 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_FINDUSERS_UNMARSHALLER_H_
+#define XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_FINDUSERS_UNMARSHALLER_H_
+
+#include "xenia/kernel/xam/unmarshaller/unmarshaller.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class XUserFindUsersUnmarshaller : public Unmarshaller {
+ public:
+  XUserFindUsersUnmarshaller(uint32_t marshaller_buffer);
+
+  ~XUserFindUsersUnmarshaller() {};
+
+  virtual X_HRESULT Deserialize();
+
+  const BASE_MSG_HEADER MessageHeader() const { return msg_header_; };
+
+  const uint64_t XUIDIssuer() const { return xuid_issuer_; };
+
+  const uint32_t NumUsers() const { return num_users_; };
+
+  const std::vector<FIND_USER_INFO>& Users() const { return users_; };
+
+ private:
+  BASE_MSG_HEADER msg_header_;
+  uint64_t xuid_issuer_;
+  uint32_t num_users_;
+  std::vector<FIND_USER_INFO> users_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_UNMARSHALLER_XUSER_FINDUSERS_UNMARSHALLER_H_

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -456,6 +456,32 @@ const std::vector<uint64_t> UserProfile::GetSubscribedXUIDs() const {
   return subscribed_xuids;
 }
 
+bool UserProfile::MutePlayer(uint64_t xuid) {
+  const bool muted = IsPlayerMuted(xuid);
+
+  if (!muted) {
+    muted_players_.push_back(xuid);
+  }
+
+  return !muted;
+}
+
+bool UserProfile::UnmutePlayer(uint64_t xuid) {
+  const bool unmuted = std::erase_if(
+      muted_players_,
+      [xuid](const uint64_t muted_xuid) { return muted_xuid == xuid; });
+
+  return unmuted;
+}
+
+bool UserProfile::IsPlayerMuted(uint64_t xuid) const {
+  const auto it = std::find_if(
+      muted_players_.cbegin(), muted_players_.cend(),
+      [xuid](const uint64_t muted_xuid) { return muted_xuid == xuid; });
+
+  return it != muted_players_.end();
+}
+
 std::u16string UserProfile::GetPresenceString() const {
   return online_presence_desc_;
 }

--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -176,6 +176,10 @@ class UserProfile {
 
   const std::vector<uint64_t> GetSubscribedXUIDs() const;
 
+  bool MutePlayer(uint64_t xuid);
+  bool UnmutePlayer(uint64_t xuid);
+  bool IsPlayerMuted(uint64_t xuid) const;
+
   std::u16string GetPresenceString() const;
   bool UpdatePresence();
   bool BuildPresenceString();
@@ -190,6 +194,7 @@ class UserProfile {
   std::vector<Property> properties_;  // Includes contexts!
   std::vector<X_ONLINE_FRIEND> friends_;
   std::map<uint64_t, X_ONLINE_PRESENCE> subscriptions_;
+  std::vector<uint64_t> muted_players_;
 
   std::map<XTileType, std::vector<uint8_t>> profile_images_;
   std::u16string online_presence_desc_ = u"";

--- a/src/xenia/kernel/xam/user_tracker.cc
+++ b/src/xenia/kernel/xam/user_tracker.cc
@@ -545,7 +545,7 @@ std::optional<TitleInfo> UserTracker::GetUserTitleInfo(
 }
 
 std::vector<TitleInfo> UserTracker::GetPlayedTitles(uint64_t xuid) const {
-  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  auto user = kernel_state()->xam_state()->GetUserProfileAny(xuid);
   if (!user) {
     return {};
   }

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -99,6 +99,8 @@ namespace xe {
 #define X_ONLINE_MAX_XSTRING_VERIFY_LOCALE                  512
 #define X_ONLINE_MAX_XSTRING_VERIFY_STRING_DATA             10
 #define X_MAX_RICHPRESENCE_SIZE_EXTRA                       100 // 4D5308AB uses rich presence string > 64
+#define X_ONLINE_MAX_XINVITE_DISPLAY_STRING                 255
+#define X_ONLINE_MAX_STATS_ESTIMATE_RATING_COUNT            101
 
 #define X_PARTY_MAX_USERS                                   32
 
@@ -117,6 +119,26 @@ namespace xe {
 #define MAX_DISTRICT_SIZE                                   64
 #define MAX_STATE_SIZE                                      64
 #define MAX_POSTALCODE_SIZE                                 16
+
+// XOnlineQuerySearch
+#define X_ATTRIBUTE_DATATYPE_MASK                           0x00F00000
+#define X_ATTRIBUTE_DATATYPE_INTEGER                        0x00000000
+#define X_ATTRIBUTE_DATATYPE_STRING                         0x00100000
+#define X_ATTRIBUTE_DATATYPE_BLOB                           0x00200000
+
+#define X_ONLINE_QUERY_MAX_PAGE                             255
+#define X_ONLINE_QUERY_MAX_PAGE_SIZE                        255
+#define X_ONLINE_QUERY_MAX_ATTRIBUTES                       255
+#define X_MAX_STRING_ATTRIBUTE_LENGTH                       400
+#define X_MAX_BLOB_ATTRIBUTE_LENGTH                         800
+
+#define X_ONLINE_LSP_ATTRIBUTE_TSADDR                       0x80200001
+#define X_ONLINE_LSP_ATTRIBUTE_XNKID                        0x80200002
+#define X_ONLINE_LSP_ATTRIBUTE_KEY                          0x80200003
+#define X_ONLINE_LSP_ATTRIBUTE_USER                         0x80100004 // LSP Filter?
+#define X_ONLINE_LSP_ATTRIBUTE_PARAM_USER                   0x02100004
+
+#define X_ONLINE_LSP_DEFAULT_DATASET_ID                     0xAAAA
 
 constexpr uint32_t PropertyID(bool system_property,
                               kernel::xam::X_USER_DATA_TYPE type, uint16_t id) {
@@ -239,10 +261,13 @@ constexpr uint8_t kXUserMaxStatsAttributes = 64;
 constexpr uint32_t kTMSUserMaxSize = 8192;          // 8 KB
 constexpr uint32_t kTMSTitleMaxSize = 1048576 * 5;  // 5 MB
 constexpr uint32_t kTMSClipMaxSize = 1048576 * 11;  // 11 MB
+constexpr uint32_t kTMSFileMaxSize = 1048576 * 20;  // 20 MB (Custom)
 
 enum NETWORK_MODE : uint32_t { OFFLINE, LAN, XBOXLIVE };
 
 enum X_USER_AGE_GROUP : uint32_t { CHILD, TEEN, ADULT };
+
+enum class P_MSG_TYPES : uint32_t { FIND_USERS = 1065 };
 
 enum X_STATS_ENUMERATOR_TYPE : uint32_t {
   XUID,
@@ -296,7 +321,7 @@ static_assert_size(XNKEY, 0x10);
 struct SGADDR {
   in_addr ina;                                  // IP address of the SG for the client
   xe::be<uint32_t> security_parameter_index;    // Pseudo-random identifier assigned by the SG
-  xe::be<uint64_t> xbox_id;                     // Unique identifier of client machine account - maybe XUID?
+  xe::be<uint64_t> xbox_id;                     // Unique identifier of client machine account - machine id?
   uint8_t reserved[4];
 };
 static_assert_size(SGADDR, 0x14);
@@ -499,7 +524,7 @@ static_assert_size(X_USER_STATS_SPEC, 8 + kXUserMaxStatsAttributes * 2);
 
 struct X_USER_ESTIMATE_RANK_RESULTS {
   xe::be<uint32_t> num_ranks;
-  xe::be<uint32_t> ranks_ptr;
+  xe::be<uint32_t> ranks_ptr;  // uint32_t*
 };
 static_assert_size(X_USER_ESTIMATE_RANK_RESULTS, 0x8);
 
@@ -625,6 +650,20 @@ static_assert_size(X_GET_TASK_PROGRESS, 0x10);
 
 #pragma pack(push, 4)
 
+struct XLIVEBASE_GET_SEQUENCE {
+  xe::be<uint32_t> seq_num;
+  xe::be<uint32_t> msg_length;
+};
+static_assert_size(XLIVEBASE_GET_SEQUENCE, 0x8);
+
+struct BASE_MSG_HEADER {
+  P_MSG_TYPES msg_type;
+  uint32_t msg_length;
+  uint32_t seq_num;
+  SGADDR sgaddr;  // XnpLogonGetStatus
+};
+static_assert_size(BASE_MSG_HEADER, 0x20);
+
 struct X_ONLINE_PRESENCE {
   xe::be<uint64_t> xuid;
   xe::be<uint32_t> state;
@@ -660,10 +699,35 @@ struct X_INVITE_INFO {
 static_assert_size(X_INVITE_INFO, 0x54);
 
 struct X_USER_RANK_REQUEST {
-  xe::be<uint32_t> view_id;
-  xe::be<uint64_t> i64_rating;
+  uint32_t view_id;
+  uint64_t i64Rating;
 };
 static_assert_size(X_USER_RANK_REQUEST, 0xC);
+
+#pragma pack(pop)
+
+#pragma pack(push, 2)
+
+struct X_GET_POINTS_BALANCE_RESPONSE {
+  xe::be<uint32_t> balance;
+  uint8_t dmp_account_status;
+  uint8_t response_flags;
+};
+static_assert_size(X_GET_POINTS_BALANCE_RESPONSE, 0x6);
+
+struct CONTENT_ENUMERATE_RESPONSE {
+  xe::be<uint16_t> content_returned;
+  xe::be<uint32_t> enumerate_content_info_ptr;
+  xe::be<uint32_t> content_total;
+};
+static_assert_size(CONTENT_ENUMERATE_RESPONSE, 0xA);
+
+struct SUBSCRIPTION_ENUMERATE_RESPONSE {
+  xe::be<uint16_t> offers_returned;
+  xe::be<uint32_t> subscription_info_ptr;
+  xe::be<uint32_t> offers_total;
+};
+static_assert_size(SUBSCRIPTION_ENUMERATE_RESPONSE, 0xA);
 
 #pragma pack(pop)
 
@@ -755,32 +819,38 @@ struct X_ONLINE_QUERY_ATTRIBUTE_INTEGER {
   xe::be<uint32_t> length;
   xe::be<uint64_t> value;
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE_INTEGER, 0xC);
 
 struct X_ONLINE_QUERY_ATTRIBUTE_STRING {
   xe::be<uint32_t> length;
-  xe::be<uint32_t> value_ptr;
+  xe::be<uint32_t> value_ptr;  // char16_t*
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE_STRING, 0x8);
 
 struct X_ONLINE_QUERY_ATTRIBUTE_BLOB {
   xe::be<uint32_t> length;
-  xe::be<uint32_t> value_ptr;
+  xe::be<uint32_t> value_ptr;  // uint8_t*
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE_BLOB, 0x8);
 
 union X_ONLINE_QUERY_ATTRIBUTE_DATA {
   X_ONLINE_QUERY_ATTRIBUTE_INTEGER integer;
   X_ONLINE_QUERY_ATTRIBUTE_STRING string;
   X_ONLINE_QUERY_ATTRIBUTE_BLOB blob;
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE_DATA, 0xC);
 
 struct X_ONLINE_QUERY_ATTRIBUTE {
   xe::be<uint32_t> attribute_id;
   X_ONLINE_QUERY_ATTRIBUTE_DATA info;
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE, 0x10);
 
 struct X_ONLINE_QUERY_ATTRIBUTE_SPEC {
-  xe::be<uint32_t> type;
-  xe::be<uint32_t> length;
+  uint32_t type;
+  uint32_t length;
 };
+static_assert_size(X_ONLINE_QUERY_ATTRIBUTE_SPEC, 0x8);
 
 struct QUERY_SEARCH_RESULT {
   xe::be<uint32_t> total_results;
@@ -788,210 +858,320 @@ struct QUERY_SEARCH_RESULT {
   xe::be<uint32_t> num_result_attributes;
   xe::be<uint32_t> attributes_ptr;  // X_ONLINE_QUERY_ATTRIBUTE
 };
+static_assert_size(QUERY_SEARCH_RESULT, 0x10);
 
-struct __declspec(align(2)) X_GET_POINTS_BALANCE_RESPONSE {
-  xe::be<uint32_t> balance;
-  uint8_t dmp_account_status;
-  uint8_t response_flags;
-};
-static_assert_size(X_GET_POINTS_BALANCE_RESPONSE, 0x6);
-
-struct X_GET_FEATURED_DOWNLOADS_RESPONSE {
-  uint8_t data[12];
-  xe::be<uint16_t> entries;
-  xe::be<uint32_t> flags;  // 0xFFFFFFFF = Free
-};
-
-struct X_DATA_ARGS_5008C {
-  uint64_t xuid;
-  uint32_t unkn;
-  uint8_t value_const_1;   // 1
-  uint32_t value_const_2;  // 0
-  uint32_t value_const_3;  // 256
-};
-
-struct X_DATA_ARGS_50077 {
+struct XACCOUNT_GET_POINTS_BALANCE_REQUEST {
   uint64_t xuid;
   uint64_t machine_id;  // XNetLogonGetMachineID
 };
+static_assert_size(XACCOUNT_GET_POINTS_BALANCE_REQUEST, 0x10);
 
-struct X_DATA_ARGS_5008B {
-  uint64_t xuid;
-  uint32_t language;    // XLanguage
-  uint8_t value_const;  // 2
-  uint32_t unkn1;
-  uint32_t unkn2;
-};
-
-struct X_DATA_ARGS_50090 {
+struct GENRES_ENUMERATE_REQUEST {
   uint8_t user_country;  // XamUserGetOnlineCountryFromXUID
   uint16_t language;     // XLanguage
-  uint32_t unkn1;
-  uint32_t unkn2;
-  uint16_t unkn3;
-  uint8_t unkn4;
-  uint32_t unkn5;
-  uint32_t unkn6;
-  uint32_t unkn7;
+  uint32_t start_index;
+  uint32_t max_count;
+  uint16_t game_rating;
+  uint8_t tier_required;
+  uint32_t offer_type;
+  uint32_t parent_genreid;
+};
+static_assert_size(GENRES_ENUMERATE_REQUEST, 0x16);
+
+struct GENRES_ENUMERATE_RESPONSE {
+  xe::be<uint16_t> geners_returned;
+  xe::be<uint32_t> enumerate_genre_info_ptr;
+  xe::be<uint32_t> geners_total;
+};
+static_assert_size(GENRES_ENUMERATE_RESPONSE, 0xA);
+
+struct GENRE_INFO {
+  xe::be<uint32_t> genre_id;
+  xe::be<uint16_t> localized_genre_length;
+  xe::be<uint32_t> localized_genre_name;
+};
+static_assert_size(GENRE_INFO, 0xA);
+
+enum class SUBSCRIPTION_ENUMERATE_FLAGS : uint16_t {
+  New = 1,
+  Renewals = 2,
+  Current = 4,
+  Expired = 8,
+  Suspended = 16,
 };
 
-struct X_DATA_ARGS_50091 {
-  uint64_t xuid;
-  uint8_t user_country;  // XamUserGetOnlineCountryFromXUID
-  uint16_t language;     // XLanguage
-  uint32_t unkn1;
-  uint32_t unkn2;
-  uint16_t unkn3;
-  uint8_t unkn4;
-  uint32_t unkn5;
-  uint32_t unkn6;
-  uint32_t unkn7;
-};
-
-struct X_DATA_ARGS_5008F {
-  uint64_t xuid;
-  uint8_t user_country;  // XamUserGetOnlineCountryFromXUID
-  uint16_t language;     // XLanguage
-  uint16_t unkn1;
-  uint32_t unkn2;
-  uint32_t unkn3;
-  uint8_t unkn4;
-  uint32_t unkn5;
-  uint32_t unkn6;
-  uint16_t unkn7;
-  xe::be<uint32_t> unkn8;
-};
-
-struct X_DATA_ARGS_50097 {
+struct SUBSCRIPTION_ENUMERATE_REQUEST {
   uint64_t xuid;
   uint64_t machine_id;  // XNetLogonGetMachineID
-  uint8_t unkn1;
-  uint8_t unkn2;
-  uint16_t unkn3;
-  uint16_t unkn4;
-  uint32_t unkn5;
-  uint32_t unkn6;
-  uint32_t unkn7;
-  uint32_t unkn8;
-  uint16_t unkn9;
-  uint32_t unkn10;
-  uint32_t unkn11;
+  uint8_t user_tier;
+  uint8_t country_id;
+  uint16_t language_id;
+  uint16_t game_rating;
+  uint32_t offer_type;
+  uint32_t payment_type;
+  uint32_t title_id;
+  uint32_t title_categories;
+  uint16_t request_flags;
+  uint32_t starting_index;
+  uint32_t max_results;
 };
+static_assert_size(SUBSCRIPTION_ENUMERATE_REQUEST, 0x30);
+
+struct SUBSCRIPTION_INFO {
+  xe::be<uint64_t> offer_id;
+  xe::be<uint16_t> offer_name_length;
+  xe::be<uint32_t> offer_name;  // char16_t*
+  xe::be<uint32_t> offer_type;
+  xe::be<uint8_t> relation_type;
+  xe::be<uint8_t> convert_mode;
+  xe::be<uint16_t> instance_id_length;
+  xe::be<uint32_t> instance_id;
+  xe::be<uint32_t> title_id;
+  xe::be<uint32_t> title_category;
+  xe::be<uint16_t> title_name_length;
+  xe::be<uint32_t> title_name;  // char16_t*
+  xe::be<uint16_t> game_rating;
+  xe::be<uint8_t> duration;
+  xe::be<uint8_t> frequency;
+  xe::be<uint8_t> tier_provided;
+  xe::be<uint8_t> tier_required;
+  xe::be<uint32_t> sell_text_length;
+  xe::be<uint32_t> sell_text;  // char16_t*
+  xe::be<uint64_t> related_offer_id;
+  xe::be<uint16_t> response_flags;
+  xe::be<uint8_t> prices_length;
+  xe::be<uint32_t> prices;  // OFFER_PRICE*
+};
+static_assert_size(SUBSCRIPTION_INFO, 0x45);
+
+enum class ENUMERATE_TITLES_BY_FILTER_FLAGS : uint16_t {
+  New = 1,
+  Played = 2,
+};
+
+struct ENUMERATE_TITLES_BY_FILTER {
+  uint64_t xuid;
+  uint8_t user_country;  // XamUserGetOnlineCountryFromXUID
+  uint16_t language;     // XLanguage
+  uint32_t start_index;
+  uint32_t max_count;
+  uint16_t game_rating;
+  uint8_t tier_required;
+  uint32_t genre_id;
+  uint32_t offer_type;
+  uint16_t request_flags;
+};
+static_assert_size(ENUMERATE_TITLES_BY_FILTER, 0x20);
+
+struct ENUMERATE_TITLES_BY_FILTER_RESPONSE {
+  xe::be<uint32_t> titles_returned;
+  xe::be<uint32_t> enumerate_title_info_ptr;
+  xe::be<uint32_t> total_titles_count;
+};
+static_assert_size(ENUMERATE_TITLES_BY_FILTER_RESPONSE, 0xC);
+
+struct ENUMERATE_TITLES_INFO {
+  xe::be<uint16_t> title_name_length;
+  xe::be<uint32_t> title_name;  // char16_t*
+  xe::be<uint32_t> title_id;
+  xe::be<uint8_t> played;
+  xe::be<uint32_t> purchased_content_count;
+  xe::be<uint32_t> total_content_count;
+  xe::be<uint8_t> new_content_exists;
+};
+static_assert_size(ENUMERATE_TITLES_INFO, 0x14);
+
+struct CONTENT_ENUMERATE_REQUEST {
+  uint64_t xuid;
+  uint8_t user_country;  // XamUserGetOnlineCountryFromXUID
+  uint16_t language;     // XLanguage
+  uint16_t game_rating;
+  uint32_t offer_type;
+  uint32_t payment_type;
+  uint8_t tier_required;
+  uint32_t title_id;
+  uint32_t title_categories;
+  uint8_t request_flags;
+  uint32_t starting_index;
+  uint32_t max_results;
+};
+static_assert_size(CONTENT_ENUMERATE_REQUEST, 0x27);
+
+struct CONTENT_INFO {
+  xe::be<uint64_t> offer_id;
+  xe::be<uint16_t> offer_name_length;
+  xe::be<uint32_t> offer_name;  // char16_t*
+  xe::be<uint32_t> offer_type;
+  xe::be<uint8_t> content_id;
+  xe::be<uint32_t> title_id;
+  xe::be<uint32_t> title_category;
+  xe::be<uint16_t> title_name_length;
+  xe::be<uint32_t> title_name;  // char16_t*
+  xe::be<uint8_t> tier_required;
+  xe::be<uint16_t> game_rating;
+  xe::be<uint16_t> response_flags;
+  xe::be<uint32_t> package_size;
+  xe::be<uint32_t> install_size;
+  xe::be<uint32_t> sell_text_length;
+  xe::be<uint32_t> sell_text;  // char16_t*
+  xe::be<uint8_t> prices_length;
+  xe::be<uint32_t> prices;  // OFFER_PRICE*
+  xe::be<uint32_t> unkn1;
+  xe::be<uint32_t> unkn2;
+  xe::be<uint32_t> unkn3;
+  xe::be<uint32_t> unkn4;
+  xe::be<uint16_t> unkn5;
+  xe::be<uint8_t> unkn6;
+};
+static_assert_size(CONTENT_INFO, 0x4E);
+
+enum class BANNER_LEVEL : uint8_t { BannerOnly = 1, HotList = 2 };
+
+struct GET_BANNER_LIST_REQUEST {
+  uint64_t xuid;
+  uint32_t language;  // XLanguage
+  uint8_t level;
+  uint32_t starting_index;
+  uint32_t max_results;
+};
+static_assert_size(GET_BANNER_LIST_REQUEST, 0x15);
+
+struct GET_BANNER_LIST_RESPONSE {
+  xe::be<uint64_t> expires;
+  xe::be<uint32_t> culture_id;
+  xe::be<uint16_t> banner_count_total;
+  xe::be<uint16_t> banner_count;
+  xe::be<uint32_t> banner_list;  // BANNER_LIST_ENTRY*
+};
+static_assert_size(GET_BANNER_LIST_RESPONSE, 0x14);
+
+struct BANNER_LIST_ENTRY {
+  xe::be<uint8_t> banner_type;
+  xe::be<uint32_t> is_my_game;
+  xe::be<uint16_t> width;
+  xe::be<uint16_t> height;
+  xe::be<uint16_t> path_length;
+  xe::be<uint32_t> path;
+};
+static_assert_size(BANNER_LIST_ENTRY, 0xF);
+
+struct BANNER_LIST_HOT_ENTRY {
+  xe::be<uint8_t> banner_type;
+  xe::be<uint32_t> is_my_game;
+  xe::be<uint16_t> width;
+  xe::be<uint16_t> height;
+  xe::be<uint16_t> path_length;
+  xe::be<uint32_t> path;
+  xe::be<uint32_t> title_id;
+  xe::be<uint16_t> title_name_length;
+  xe::be<uint32_t> title_name;
+  xe::be<uint64_t> offer_id;
+  xe::be<uint16_t> offer_name_length;
+  xe::be<uint32_t> offer_name;
+  xe::be<uint32_t> price;  // OFFER_PRICE*
+  xe::be<uint64_t> date_approved;
+};
+static_assert_size(BANNER_LIST_HOT_ENTRY, 0x33);
+
+struct OFFER_PRICE {
+  xe::be<uint32_t> payment_type;
+  xe::be<uint8_t> tax_type;
+  xe::be<uint32_t> whole_price;
+  xe::be<uint32_t> fractional_price;
+  xe::be<uint16_t> price_text_length;
+  xe::be<uint32_t> price_text;  // char16_t*
+};
+static_assert_size(OFFER_PRICE, 0x13);
 
 #pragma pack(pop)
 
-struct Internal_Marshalled_Data {
-  uint8_t unkn1_data[22];
-  xe::be<uint32_t> start_args_ptr;  // CArgumentList*
-  uint8_t unkn2_data[14];
+struct SCHEMA_HEADER {
+  xe::be<uint16_t> SchemaVersionMajor;
+  xe::be<uint16_t> SchemaVersionMinor;
+  xe::be<uint32_t> ToolVersion;
+  xe::be<uint32_t> Flags;
+  xe::be<uint32_t> CompressedSize;
+  xe::be<uint32_t> UncompressedSize;
+  xe::be<uint32_t> ConstantsTableOffset;
+  xe::be<uint16_t> ConstantsTableSize;
+  xe::be<uint16_t> ConstantSize;
+  xe::be<uint32_t> UrlTableOffset;
+  xe::be<uint16_t> UrlTableSize;
+  xe::be<uint16_t> UrlTableDataSize;
+  xe::be<uint16_t> HeaderSize;
+  xe::be<uint16_t> ExtensionDataSize;
+  xe::be<uint16_t> SchemaTableEntries;
+  xe::be<uint16_t> SchemaTableEntrySize;
+};
+static_assert_size(SCHEMA_HEADER, 0x2C);
+
+struct ORDINAL_TO_INDEX {
+  xe::be<uint16_t> Ordinal;
+  xe::be<uint16_t> Index;
+};
+static_assert_size(ORDINAL_TO_INDEX, 0x4);
+
+struct SCHEMA_TABLE_ENTRY {
+  xe::be<uint16_t> RequestSchemaSize;
+  xe::be<uint16_t> ResponseSchemaSize;
+  xe::be<uint32_t> RequestSchemaOffset;
+  xe::be<uint32_t> ResponseSchemaOffset;
+  xe::be<uint32_t> MaxRequestAggregateSize;
+  xe::be<uint32_t> MaxResponseAggregateSize;
+  xe::be<uint16_t> ServiceIDIndex;
+  xe::be<uint16_t> RequestUrlIndex;
+};
+static_assert_size(SCHEMA_TABLE_ENTRY, 0x18);
+
+struct SCHEMA_DATA {
+  SCHEMA_HEADER Header;
+  xe::be<uint32_t> OrdinalToIndexPtr;
+  xe::be<uint32_t> TableEntriesPtr;
+  xe::be<uint32_t> SchemaDataPtr;
+  xe::be<uint32_t> SchemaDataSize;
+  xe::be<uint32_t> ExtensionDataPtr;
+  xe::be<uint32_t> ConstantListPtr;
+  xe::be<uint32_t> UrlOffsetsPtr;
+  xe::be<uint32_t> UrlDataPtr;
+};
+static_assert_size(SCHEMA_DATA, 0x4C);
+
+struct BASE_ENDIAN_BUFFER {
+  xe::be<uint32_t> BufferPtr;
+  xe::be<uint32_t> BufferSize;
+  xe::be<uint32_t> AvailableSize;
+  xe::be<uint32_t> ConsumedSize;
+  xe::be<int32_t> ReverseEndian;
+};
+static_assert_size(BASE_ENDIAN_BUFFER, 0x14);
+
+struct XLIVE_ASYNC_TASK {
+  xe::be<uint32_t> ordinal;
+  xe::be<uint32_t> schema_data_ptr;  // SCHEMA_DATA*
+  xe::be<uint32_t> schema_index;
+  xe::be<uint32_t> task_flags;
+  xe::be<uint32_t> live_async_task_internal_ptr;  // XLiveAsyncTaskInternal*
+  xe::be<uint32_t> internal_task_size;
+  xe::be<uint32_t> marshalled_request_ptr;
+  xe::be<uint32_t> marshalled_request_size;
+  xe::be<uint32_t> total_wire_buffe_size;
+  xe::be<uint32_t> counter;
+  xe::be<uint32_t> logon_id;
   xe::be<uint32_t> results_ptr;  // STRUCT*
   xe::be<uint32_t> results_size;
+  BASE_ENDIAN_BUFFER wire_buffer;
+  xe::be<uint32_t> overlapped_ptr;
 };
+static_assert_size(XLIVE_ASYNC_TASK, 0x4C);
 
-struct Generic_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> unkn2_ptr;
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> unkn3_ptr;
-  uint8_t unkn4_data[12];
-  xe::be<uint32_t> unkn4_ptr;
+struct XLIVEBASE_ASYNC_MESSAGE {
+  xe::be<uint32_t> xlive_async_task_ptr;
+  xe::be<uint64_t> current_numerator;
+  xe::be<uint64_t> current_denominator;
+  xe::be<uint64_t> last_numerator;
+  xe::be<uint64_t> last_denominator;
 };
-
-struct XStorageDelete_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
-};
-
-struct XStringVerify_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> locale_size_ptr;
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> num_strings_ptr;
-  uint8_t unkn4_data[12];
-  xe::be<uint32_t> last_entry_ptr;
-};
-
-struct XStorageDownloadToMemory_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> serialized_buffer_ptr;  // Entry 2
-};
-
-struct XStorageUploadFromMemory_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> serialized_buffer_ptr;  // Entry 2
-};
-
-struct XStorageEnumerate_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> serialized_server_path_ptr;  // Entry 1
-  xe::be<uint32_t> locale_size_ptr;
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> num_strings_ptr;
-  uint8_t unkn4_data[12];
-  xe::be<uint32_t> last_entry_ptr;
-};
-
-struct XUserFindUsers_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> empty;  // Entry 1
-  uint8_t unkn3_data[12];
-  xe::be<uint32_t> serialized_users_info_ptr;  // Entry 2
-};
-
-struct XAccountGetUserInfo_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-};
-
-struct XOnlineQuerySearch_Marshalled_Data {
-  xe::be<uint32_t> internal_data_ptr;
-  uint8_t unkn1_data[44];
-  xe::be<uint32_t> unkn1_ptr;
-  uint8_t unkn2_data[24];
-  xe::be<uint32_t> serialized_num_result_specs_ptr;  // Entry 1
-  uint8_t unkn3_data[24];
-  xe::be<uint32_t> serialized_attribute_specs_ptr;  // Entry 2
-};
-
-struct XOnlineQuerySearch_Args {
-  uint32_t title_id;
-  uint32_t dataset_id;
-  uint32_t proc_index;
-  uint32_t page;
-  uint32_t results_pre_page;
-  uint32_t num_result_specs;
-  uint32_t attribute_specs_address;
-  uint32_t num_attributes;
-  uint32_t attributes_address;
-  uint8_t unkn[24];
-};
-static_assert_size(XOnlineQuerySearch_Args, 0x3C);
+static_assert_size(XLIVEBASE_ASYNC_MESSAGE, 0x28);
 
 struct XLIVEBASE_UPDATE_ACCESS_TIMES {
   xe::be<uint32_t> user_index;


### PR DESCRIPTION
Implemented unmarshaller classes for:

- XInviteSend
- XStringVerify
- XUserFindUsers
- XAccountGetUserInfo
- XOnlineQuerySearch
- XUserEstimateRankForRating
- XStorageDownloadToMemory
- XStorageUploadFromMemory
- XStorageEnumerate
- XStorageDelete


Newly Implemented:

- XOnlineQuerySearch
- XUserEstimateRankForRating
- XUserMuteListQuery

Partially Implemented:
- SubscriptionEnumerate
- EnumerateTitlesByFilter
- GenresEnumerate
- ContentEnumerate
- GetBannerList
- GetBannerListHot
- GetNextSequenceMessage

Fixed:

- Peggle no longer crashes after finishing a level.
- Forza Motorsport 2 no longer crashes after finishing a race.
