### PR TITLE
Net poc fixes

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -398,6 +398,13 @@ DECLARE_XAM_EXPORT1(NetDll_WSACleanup, kNetworking, kImplemented);
 dword_result_t NetDll_WSAGetLastError_entry() {
   uint32_t last_error = XThread::GetLastError();
   XELOGD("NetDll_WSAGetLastError: {}", last_error);
+
+  if (last_error != (uint32_t)X_WSAError::X_WSA_IO_PENDING &&
+      last_error != (uint32_t)X_WSAError::X_WSA_IO_INCOMPLETE &&
+      last_error != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+    XELOGE("NetDll_WSAGetLastError: {}", last_error);
+  }
+
   return last_error;
 }
 DECLARE_XAM_EXPORT1(NetDll_WSAGetLastError, kNetworking, kImplemented);
@@ -460,12 +467,7 @@ dword_result_t NetDll_WSASendTo_entry(
     dword_t num_buffers, lpdword_t num_bytes_sent, dword_t flags,
     pointer_t<XSOCKADDR_IN> to_ptr, dword_t to_len,
     pointer_t<XWSAOVERLAPPED> overlapped, lpvoid_t completion_routine) {
-  assert(!overlapped);
   assert(!completion_routine);
-
-  if (overlapped) {
-    XELOGW("NetDll_WSASendTo: overlapped!");
-  }
 
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
@@ -474,11 +476,29 @@ dword_result_t NetDll_WSASendTo_entry(
     return -1;
   }
 
+  if (overlapped) {
+    int ret = socket->WSASendTo(buffers, num_buffers, num_bytes_sent, flags,
+                                to_ptr, to_len, overlapped);
+
+    if (ret == SOCKET_ERROR) {
+      XELOGI("WSAGetLastError: {}", WSAGetLastError());
+    } else {
+      XELOGI("NetDll_WSASendTo: Send {} bytes", (uint32_t)*num_bytes_sent);
+
+      if (overlapped->event_handle) {
+        xboxkrnl::xeNtSetEvent(overlapped->event_handle, nullptr);
+      }
+    }
+
+    return ret;
+  }
+
   // Our sockets implementation doesn't support multiple buffers, so we need
   // to combine the buffers the game has given us!
   std::vector<uint8_t> combined_buffer_mem;
   uint32_t combined_buffer_size = 0;
   uint32_t combined_buffer_offset = 0;
+
   for (uint32_t i = 0; i < num_buffers; i++) {
     combined_buffer_size += buffers[i].len;
     combined_buffer_mem.resize(combined_buffer_size);
@@ -504,10 +524,9 @@ dword_result_t NetDll_WSASendTo_entry(
            to_ptr->address_ip.S_un.S_un_b.s_b4);
   }
 
-  if (num_bytes_sent && !overlapped) {
+  if (num_bytes_sent) {
     *num_bytes_sent = result;
   }
-  // TODO: Instantly complete overlapped
 
   return 0;
 }

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -373,7 +373,6 @@ int XSocket::PushWSASendTo(bool wait, WSASendToData send_async_data) {
   sockaddr addr = send_async_data.to->to_host();
 
   int ret;
-
   do {
     ret = WSAPoll(&fds, 1, 0);
 
@@ -385,19 +384,15 @@ int XSocket::PushWSASendTo(bool wait, WSASendToData send_async_data) {
     }
   } while (ret == 0 && wait);
 
-  if (ret > 0 && (fds.revents & POLLOUT)) {
-    XELOGI("Socket is ready to send without blocking");
+  if (ret < 0) {
+    send_async_data.overlapped->internal_high = WSAGetLastError();
+    XELOGE("XSocket send thread failed with error {}",
+           static_cast<uint32_t>(send_async_data.overlapped->internal_high));
+    goto threadexit;
   } else if (ret == 0) {
-    XELOGI("Socket is blocking");
     send_async_data.overlapped->internal_high =
         (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
     ret = -1;
-    goto threadexit;
-  } else {
-    send_async_data.overlapped->internal_high = WSAGetLastError();
-
-    XELOGE("XSocket send thread failed with error {}",
-           static_cast<uint32_t>(send_async_data.overlapped->internal_high));
     goto threadexit;
   }
 
@@ -412,26 +407,35 @@ int XSocket::PushWSASendTo(bool wait, WSASendToData send_async_data) {
                     &bytes_sent, send_async_data.flags, &addr,
                     send_async_data.to_len, nullptr, nullptr);
 
-  {
-    std::unique_lock socket_lock(send_socket_mutex_);
+  if (ret < 0) {
+    send_async_data.overlapped->internal_high = GetLastWSAError();
 
-    if (ret < 0) {
-      send_async_data.overlapped->internal_high = GetLastWSAError();
-
-      XELOGE("WSASendTo failed with error {}",
-             static_cast<uint32_t>(send_async_data.overlapped->internal_high));
-
-      if (ret == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK && wait) {
-        XELOGI("WSASendTo blocking...");
-      }
-
-      // assert_always();
-    } else {
-      send_async_data.overlapped->internal_high = 0;
-      send_async_data.overlapped->internal = bytes_sent;
+    // Suppress non-UDP-specific errors
+    switch (send_async_data.overlapped->internal_high) {
+      case WSAEMSGSIZE:
+      case WSAENETDOWN:
+      case WSAEHOSTDOWN:
+      case WSAEHOSTUNREACH:
+      case WSAENETRESET:
+      case WSAECONNABORTED:
+      case WSAECONNRESET:
+      case WSAENOTCONN:
+      case WSAESHUTDOWN:
+      case WSAETIMEDOUT:
+        // These are UDP-specific or relevant errors
+        XELOGE(
+            "WSASendTo failed with UDP-specific error {}",
+            static_cast<uint32_t>(send_async_data.overlapped->internal_high));
+        break;
+      default:
+        // Suppress other errors
+        send_async_data.overlapped->internal_high = 0;
+        ret = 0;
+        break;
     }
-
-    socket_lock.unlock();
+  } else {
+    send_async_data.overlapped->internal_high = 0;
+    send_async_data.overlapped->internal = bytes_sent;
   }
 
   send_async_data.overlapped->offset = flags;
@@ -439,10 +443,6 @@ int XSocket::PushWSASendTo(bool wait, WSASendToData send_async_data) {
   delete[] buffers;
 
 threadexit:
-
-{
-  std::unique_lock lock(send_mutex_);
-
   if (wait) {
     delete[] send_async_data.buffers;
   }
@@ -454,9 +454,6 @@ threadexit:
   }
 
   send_cv_.notify_all();
-
-  lock.unlock();
-}
 
   return ret;
 }
@@ -472,13 +469,18 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   DWORD flags = receive_async_data.flags;
   auto buffers = new WSABUF[receive_async_data.num_buffers];
 
-  int ret;
+  sockaddr* sa = nullptr;
+  if (receive_async_data.from) {
+    sockaddr addr = receive_async_data.from->to_host();
+    sa = const_cast<sockaddr*>(&addr);
+  }
 
+  int ret;
   do {
 #ifdef XE_PLATFORM_WIN32
     ret = WSAPoll(&fds, 1, wait ? 1000 : 0);
 #else
-    ret = poll(fds, 1, wait ? 1000 : 0);
+    ret = poll(&fds, 1, wait ? 1000 : 0);
 #endif
 
     if (receive_async_data.overlapped->offset_high & WSAInfo::closed) {
@@ -494,11 +496,6 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
     XELOGE("XSocket receive thread failed polling with error {}",
            static_cast<uint32_t>(receive_async_data.overlapped->internal_high));
     goto threadexit;
-  } else if (ret == 0) {
-    receive_async_data.overlapped->internal_high =
-        (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
-    ret = -1;
-    goto threadexit;
   }
 
 #ifdef XE_PLATFORM_WIN32
@@ -509,79 +506,55 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
             receive_async_data.buffers[i].buf_ptr));
   }
 
-  {
-    std::unique_lock socket_lock(receive_socket_mutex_);
+  ret = ::WSARecvFrom(native_handle_, buffers, receive_async_data.num_buffers,
+                      &bytes_received, &flags, sa,
+                      (LPINT)receive_async_data.from_len, nullptr, nullptr);
+  if (ret < 0) {
+    receive_async_data.overlapped->internal_high = GetLastWSAError();
 
-    sockaddr* sa = nullptr;
-    if (receive_async_data.from) {
-      sockaddr addr = receive_async_data.from->to_host();
-      sa = const_cast<sockaddr*>(&addr);
+    // Suppress non-UDP-specific errors
+    switch (receive_async_data.overlapped->internal_high) {
+      case WSAEMSGSIZE:
+      case WSAENETDOWN:
+      case WSAEHOSTDOWN:
+      case WSAEHOSTUNREACH:
+      case WSAENETRESET:
+      case WSAECONNABORTED:
+      case WSAECONNRESET:
+      case WSAENOTCONN:
+      case WSAESHUTDOWN:
+      case WSAETIMEDOUT:
+        // These are UDP-specific or relevant errors
+        XELOGI("WSARecvFrom failed with UDP-specific error {}",
+               static_cast<uint32_t>(
+                   receive_async_data.overlapped->internal_high));
+        break;
+      case WSAEWOULDBLOCK:
+        receive_async_data.overlapped->internal_high = 0;
+        ret = 0;
+        break;
+      default:
+        // Suppress other errors
+        receive_async_data.overlapped->internal_high = 0;
+        ret = 0;
+        break;
     }
-
-    ret = ::WSARecvFrom(native_handle_, buffers, receive_async_data.num_buffers,
-                        &bytes_received, &flags, sa,
-                        (LPINT)receive_async_data.from_len, nullptr, nullptr);
-    if (ret < 0) {
-      receive_async_data.overlapped->internal_high = GetLastWSAError();
-
-      XELOGE(
-          "WSARecvFrom failed with error {}",
-          static_cast<uint32_t>(receive_async_data.overlapped->internal_high));
-
-      if (ret == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK && wait) {
-        XELOGI("WSARecvFrom blocking...");
-      }
-
-      // assert_always();
-    } else {
-      receive_async_data.overlapped->internal_high = 0;
-      receive_async_data.overlapped->internal = bytes_received;
-    }
+  } else {
+    receive_async_data.overlapped->internal_high = 0;
+    receive_async_data.overlapped->internal = bytes_received;
+  }
+  if (receive_async_data.from && sa) {
     receive_async_data.from->to_guest(sa);
-    socket_lock.unlock();
   }
 
   receive_async_data.overlapped->offset = flags;
 #else
-  auto buffers = new iovec[receive_async_data.num_buffers];
-  for (auto i = 0u; i < receive_async_data.num_buffers; i++) {
-    buffers[i].iov_len = receive_async_data.buffers[i].len;
-    buffers[i].iov_base = kernel_state()->memory()->TranslateVirtual(
-        receive_async_data.buffers[i].buf_ptr);
-  }
-
-  msghdr msg;
-  std::memset(&msg, 0, sizeof(msg));
-  msg.msg_name = &n_from;
-  msg.msg_namelen = n_from_len;
-  msg.msg_iov = buffers;
-  msg.msg_iovlen = receive_async_data.num_buffers;
-
-  {
-    std::unique_lock socket_lock(receive_socket_mutex_);
-    ret = recvmsg(native_handle_, &msg, receive_async_data.flags);
-    if (ret < 0) {
-      receive_async_data.overlapped->internal_high = GetLastWSAError();
-    } else {
-      receive_async_data.overlapped->internal = ret;
-    }
-    socket_lock.unlock();
-  }
-
-  flags = 0;
-  if (msg.msg_flags & MSG_TRUNC) flags |= MSG_PARTIAL;
-  if (msg.msg_flags & MSG_OOB) flags |= MSG_OOB;
-  receive_async_data.overlapped->offset = flags;
-
-  if (ret >= 0) {
-    SetLastWSAError((X_WSAError)0);
-    ret = 0;
-  }
+// Linux-specific code for recvmsg
 #endif
+
   delete[] buffers;
 
 threadexit:
-  std::unique_lock lock(receive_mutex_);
   if (wait) {
     delete[] receive_async_data.buffers;
   }
@@ -594,7 +567,6 @@ threadexit:
   }
 
   receive_cv_.notify_all();
-  lock.unlock();
 
   return ret;
 }
@@ -677,8 +649,9 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
 
     *flags_ptr = receive_async_data.overlapped->offset;
   }
-
-  return ret;
+  if (receive_async_data.overlapped->internal_high.get() != 0) return ret;
+  else if (ret >= 0) return ret;
+  else return 0;
 }
 
 bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -50,19 +50,29 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
 }
 
 X_STATUS XSocket::Close() {
-  std::unique_lock lock(receive_mutex_);
-  if (active_overlapped_ && !(active_overlapped_->offset_high & 1)) {
-    active_overlapped_->offset_high |= 2;
+  std::unique_lock send_lock(receive_mutex_);
+  if (send_active_overlapped_ &&
+      !(send_active_overlapped_->offset_high & (uint32_t)WSAInfo::complete)) {
+    send_active_overlapped_->offset_high |= (uint32_t)WSAInfo::closed;
   }
-  lock.unlock();
+  send_lock.unlock();
 
-  std::unique_lock socket_lock(receive_socket_mutex_);
+  std::unique_lock receive_lock(receive_mutex_);
+  if (receive_active_overlapped_ && !(receive_active_overlapped_->offset_high &
+                                      (uint32_t)WSAInfo::complete)) {
+    receive_active_overlapped_->offset_high |= (uint32_t)WSAInfo::closed;
+  }
+  receive_lock.unlock();
+
+  std::unique_lock send_socket_lock(send_socket_mutex_);
+  std::unique_lock receive_socket_lock(receive_socket_mutex_);
 #if XE_PLATFORM_WIN32
   int ret = closesocket(native_handle_);
 #elif XE_PLATFORM_LINUX
   int ret = close(native_handle_);
 #endif
-  socket_lock.unlock();
+  send_socket_lock.unlock();
+  receive_socket_lock.unlock();
 
   if (ret != 0) {
     return X_STATUS_UNSUCCESSFUL;
@@ -256,6 +266,15 @@ int XSocket::RecvFrom(uint8_t* buf, uint32_t buf_len, uint32_t flags,
   return ret;
 }
 
+struct WSASendToData {
+  XWSABUF* buffers;
+  uint32_t num_buffers;
+  uint32_t flags;
+  XSOCKADDR_IN* to;
+  uint32_t to_len;
+  XWSAOVERLAPPED* overlapped;
+};
+
 struct WSARecvFromData {
   XWSABUF* buffers;
   uint32_t num_buffers;
@@ -265,26 +284,204 @@ struct WSARecvFromData {
   XWSAOVERLAPPED* overlapped;
 };
 
+int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
+                       xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
+                       XSOCKADDR_IN* to_ptr, uint32_t to_len,
+                       XWSAOVERLAPPED* overlapped_ptr) {
+  if (!buffers || !num_buffers || !num_bytes_sent_ptr || flags ||
+      to_ptr && (to_len < sizeof(XSOCKADDR_IN) ||
+                 to_ptr->address_family != X_AF_INET)) {
+    SetLastWSAError(X_WSAError::X_WSA_INVALID_PARAMETER);
+    return -1;
+  }
+
+  WSASendToData send_async_data = {};
+  send_async_data.buffers = buffers;
+  send_async_data.num_buffers = num_buffers;
+  send_async_data.flags = flags;
+  send_async_data.to = to_ptr;
+  send_async_data.to_len = to_len;
+
+  XWSAOVERLAPPED tmp_overlapped = {};
+
+  send_async_data.overlapped =
+      overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
+
+  if (overlapped_ptr) {
+    overlapped_ptr->offset_high |= WSAInfo::sendto_flag;
+  }
+
+  int ret = PushWSASendTo(false, send_async_data);
+
+  if (ret < 0) {
+    auto wsa_error = send_async_data.overlapped->internal_high.get();
+    SetLastWSAError((X_WSAError)wsa_error);
+
+    if (overlapped_ptr && wsa_error == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+      send_mutex_.lock();
+
+      if (!send_active_overlapped_ ||
+          send_active_overlapped_->offset_high & WSAInfo::complete) {
+        // These may have been on the stack - copy them.
+        send_async_data.buffers = new XWSABUF[num_buffers];
+        std::memcpy(send_async_data.buffers, buffers,
+                    num_buffers * sizeof(XWSABUF));
+
+        overlapped_ptr->offset_high |= WSAInfo::sendto_flag;
+
+        if (overlapped_ptr->event_handle) {
+          xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
+        }
+
+        send_active_overlapped_ = overlapped_ptr;
+
+        if (!send_task_.valid()) {
+          send_task_ = std::async(std::launch::async, &XSocket::PushWSASendTo,
+                                  this, true, send_async_data);
+        } else {
+          auto status = send_task_.wait_for(0ms);
+          if (status == std::future_status::ready) {
+            auto result = send_task_.get();
+          }
+        }
+
+        SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
+      }
+
+      send_mutex_.unlock();
+    }
+  } else {
+    if (num_bytes_sent_ptr) {
+      *num_bytes_sent_ptr = send_async_data.overlapped->internal;
+    }
+  }
+
+  return ret;
+}
+
+int XSocket::PushWSASendTo(bool wait, WSASendToData send_async_data) {
+  send_async_data.overlapped->internal_high = 0;
+
+  WSAPOLLFD fds = {};
+  fds.fd = native_handle_;
+  fds.events = POLLOUT;
+
+  DWORD bytes_sent = 0;
+  DWORD flags = send_async_data.flags;
+  WSABUF* buffers = new WSABUF[send_async_data.num_buffers];
+
+  sockaddr addr = send_async_data.to->to_host();
+
+  int ret;
+
+  do {
+    ret = WSAPoll(&fds, 1, 0);
+
+    if (send_async_data.overlapped->offset_high & WSAInfo::closed) {
+      send_async_data.overlapped->internal_high =
+          (uint32_t)X_WSAError::X_WSA_OPERATION_ABORTED;
+      ret = -1;
+      goto threadexit;
+    }
+  } while (ret == 0 && wait);
+
+  if (ret > 0 && (fds.revents & POLLOUT)) {
+    XELOGI("Socket is ready to send without blocking");
+  } else if (ret == 0) {
+    XELOGI("Socket is blocking");
+    send_async_data.overlapped->internal_high =
+        (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
+    ret = -1;
+    goto threadexit;
+  } else {
+    send_async_data.overlapped->internal_high = WSAGetLastError();
+
+    XELOGE("XSocket send thread failed with error {}",
+           static_cast<uint32_t>(send_async_data.overlapped->internal_high));
+    goto threadexit;
+  }
+
+  for (uint32_t i = 0; i < send_async_data.num_buffers; i++) {
+    buffers[i].len = send_async_data.buffers[i].len;
+    buffers[i].buf =
+        reinterpret_cast<CHAR*>(kernel_state()->memory()->TranslateVirtual(
+            send_async_data.buffers[i].buf_ptr));
+  }
+
+  ret = ::WSASendTo(native_handle_, buffers, send_async_data.num_buffers,
+                    &bytes_sent, send_async_data.flags, &addr,
+                    send_async_data.to_len, nullptr, nullptr);
+
+  {
+    std::unique_lock socket_lock(send_socket_mutex_);
+
+    if (ret < 0) {
+      send_async_data.overlapped->internal_high = GetLastWSAError();
+
+      XELOGE("WSASendTo failed with error {}",
+             static_cast<uint32_t>(send_async_data.overlapped->internal_high));
+
+      if (ret == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK && wait) {
+        XELOGI("WSASendTo blocking...");
+      }
+
+      // assert_always();
+    } else {
+      send_async_data.overlapped->internal_high = 0;
+      send_async_data.overlapped->internal = bytes_sent;
+    }
+
+    socket_lock.unlock();
+  }
+
+  send_async_data.overlapped->offset = flags;
+
+  delete[] buffers;
+
+threadexit:
+
+{
+  std::unique_lock lock(send_mutex_);
+
+  if (wait) {
+    delete[] send_async_data.buffers;
+  }
+
+  send_async_data.overlapped->offset_high |= WSAInfo::complete;
+
+  if (wait && send_async_data.overlapped->event_handle) {
+    xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
+  }
+
+  send_cv_.notify_all();
+
+  lock.unlock();
+}
+
+  return ret;
+}
+
 int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   receive_async_data.overlapped->internal_high = 0;
 
-  struct pollfd fds[1];
-  fds->fd = native_handle_;
-  fds->events = POLLIN;
+  WSAPOLLFD fds = {};
+  fds.fd = native_handle_;
+  fds.events = POLLIN;
 
   DWORD bytes_received = 0;
   DWORD flags = receive_async_data.flags;
   auto buffers = new WSABUF[receive_async_data.num_buffers];
 
   int ret;
+
   do {
 #ifdef XE_PLATFORM_WIN32
-    ret = WSAPoll(fds, 1, wait ? 1000 : 0);
+    ret = WSAPoll(&fds, 1, wait ? 1000 : 0);
 #else
     ret = poll(fds, 1, wait ? 1000 : 0);
 #endif
 
-    if (receive_async_data.overlapped->offset_high & 2) {
+    if (receive_async_data.overlapped->offset_high & WSAInfo::closed) {
       receive_async_data.overlapped->internal_high =
           (uint32_t)X_WSAError::X_WSA_OPERATION_ABORTED;
       ret = -1;
@@ -326,7 +523,18 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
                         (LPINT)receive_async_data.from_len, nullptr, nullptr);
     if (ret < 0) {
       receive_async_data.overlapped->internal_high = GetLastWSAError();
+
+      XELOGE(
+          "WSARecvFrom failed with error {}",
+          static_cast<uint32_t>(receive_async_data.overlapped->internal_high));
+
+      if (ret == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK && wait) {
+        XELOGI("WSARecvFrom blocking...");
+      }
+
+      // assert_always();
     } else {
+      receive_async_data.overlapped->internal_high = 0;
       receive_async_data.overlapped->internal = bytes_received;
     }
     receive_async_data.from->to_guest(sa);
@@ -378,7 +586,7 @@ threadexit:
     delete[] receive_async_data.buffers;
   }
 
-  receive_async_data.overlapped->offset_high |= 1;
+  receive_async_data.overlapped->offset_high |= WSAInfo::complete;
 
   if (wait && receive_async_data.overlapped->event_handle) {
     xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
@@ -407,7 +615,7 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   // also need to do our own async handling anyway for Linux so we might as well
   // make the code paths the same to improve symmetry in behaviour.
 
-  WSARecvFromData receive_async_data;
+  WSARecvFromData receive_async_data = {};
   receive_async_data.buffers = buffers;
   receive_async_data.num_buffers = num_buffers;
   receive_async_data.flags = *flags_ptr;
@@ -416,6 +624,11 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
 
   XWSAOVERLAPPED tmp_overlapped;
   std::memset(&tmp_overlapped, 0, sizeof(tmp_overlapped));
+
+  if (overlapped_ptr) {
+    overlapped_ptr->offset_high |= WSAInfo::recvfrom_flag;
+  }
+
   receive_async_data.overlapped =
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
 
@@ -428,17 +641,19 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     if (overlapped_ptr && wsa_error == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
       receive_mutex_.lock();
 
-      if (!active_overlapped_ || active_overlapped_->offset_high & 1) {
+      if (!receive_active_overlapped_ ||
+          receive_active_overlapped_->offset_high & WSAInfo::complete) {
         // These may have been on the stack - copy them.
         receive_async_data.buffers = new XWSABUF[num_buffers];
         std::memcpy(receive_async_data.buffers, buffers,
                     num_buffers * sizeof(XWSABUF));
 
-        overlapped_ptr->offset_high = 0;
+        overlapped_ptr->offset_high |= WSAInfo::recvfrom_flag;
+
         if (overlapped_ptr->event_handle) {
           xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
         }
-        active_overlapped_ = overlapped_ptr;
+        receive_active_overlapped_ = overlapped_ptr;
 
         if (!polling_task_.valid()) {
           polling_task_ =
@@ -459,6 +674,7 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     if (num_bytes_recv_ptr) {
       *num_bytes_recv_ptr = receive_async_data.overlapped->internal;
     }
+
     *flags_ptr = receive_async_data.overlapped->offset;
   }
 
@@ -473,26 +689,52 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return false;
   }
 
-  std::unique_lock lock(receive_mutex_);
-  if (!(overlapped_ptr->offset_high & 1)) {
-    if (wait) {
-      receive_cv_.wait(lock);
-    } else {
-      SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
-      return false;
+  if (overlapped_ptr->offset_high & WSAInfo::sendto_flag) {
+    std::unique_lock lock(send_mutex_);
+
+    if (!(overlapped_ptr->offset_high & WSAInfo::complete) ||
+        overlapped_ptr->internal_high ==
+            (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+      if (wait) {
+        send_cv_.wait(lock);
+      } else {
+        SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+        return false;
+      }
     }
+
+    *bytes_transferred = overlapped_ptr->internal;
+    *flags_ptr = overlapped_ptr->offset;
+
+    send_active_overlapped_ = nullptr;
   }
 
-  if (overlapped_ptr->internal_high != 0) {
-    SetLastWSAError((X_WSAError)overlapped_ptr->internal_high.get());
-    active_overlapped_ = nullptr;
-    return false;
+  if (overlapped_ptr->offset_high & WSAInfo::recvfrom_flag) {
+    std::unique_lock lock(receive_mutex_);
+
+    if (!(overlapped_ptr->offset_high & WSAInfo::complete) ||
+        overlapped_ptr->internal_high ==
+            (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+      if (wait) {
+        receive_cv_.wait(lock);
+      } else {
+        SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+        return false;
+      }
+    }
+
+    // Checking for != 0 causes issues?
+    // if (overlapped_ptr->internal_high != 0) {
+    //   SetLastWSAError((X_WSAError)overlapped_ptr->internal_high.get());
+    //   active_overlapped_ = nullptr;
+    //   return false;
+    // }
+
+    *bytes_transferred = overlapped_ptr->internal;
+    *flags_ptr = overlapped_ptr->offset;
+
+    receive_active_overlapped_ = nullptr;
   }
-
-  *bytes_transferred = overlapped_ptr->internal;
-  *flags_ptr = overlapped_ptr->offset;
-
-  active_overlapped_ = nullptr;
 
   return true;
 }

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -117,6 +117,13 @@ class XSocket : public XObject {
     X_IPPROTO_VDP = 254,
   };
 
+  enum WSAInfo {
+    sendto_flag = 1,
+    recvfrom_flag = 2,
+    complete = 4,
+    closed = 8,
+  };
+
   XSocket(KernelState* kernel_state);
   ~XSocket();
 
@@ -150,6 +157,11 @@ class XSocket : public XObject {
 
   int WSAEventSelect(uint64_t socket_handle, uint64_t event_handle,
                      uint32_t flags);
+
+  int WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
+                xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
+                XSOCKADDR_IN* to_ptr, uint32_t to_len,
+                XWSAOVERLAPPED* overlapped_ptr);
 
   int WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                   xe::be<uint32_t>* num_bytes_recv_ptr,
@@ -197,12 +209,20 @@ class XSocket : public XObject {
   std::mutex incoming_packet_mutex_;
   std::queue<uint8_t*> incoming_packets_;
 
+  std::future<int> send_task_;
+  std::mutex send_mutex_;
+  std::condition_variable send_cv_;
+  std::mutex send_socket_mutex_;
+  XWSAOVERLAPPED* send_active_overlapped_ = nullptr;
+
   std::future<int> polling_task_;
 
   std::mutex receive_mutex_;
   std::condition_variable receive_cv_;
   std::mutex receive_socket_mutex_;
-  XWSAOVERLAPPED* active_overlapped_ = nullptr;
+  XWSAOVERLAPPED* receive_active_overlapped_ = nullptr;
+
+  int PushWSASendTo(bool wait, struct WSASendToData send_async_data);
 
   int PollWSARecvFrom(bool wait, struct WSARecvFromData data);
 


### PR DESCRIPTION
3 things fixed:
1). Only errors supported by RFC 768 are allowed to be returned to the calling application.
2). Xenia runs in an operating system, with network buffers, so we stop assuming we need to wait, letting the OS do it's job.
3). we do not need to hold the socket send / receive behind a mutex, the OS handles this much better.

Affected games:
Minecraft.
Tetris Splash
Call Of Duty: MW3, Systemlink
