### PR TITLE
[XSocket] Refactored WSARecvFrom and Implemented WSASendTo

### DIFF
--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -474,6 +474,13 @@ DECLARE_XAM_EXPORT1(NetDll_WSACleanup, kNetworking, kImplemented);
 dword_result_t NetDll_WSAGetLastError_entry() {
   uint32_t last_error = XThread::GetLastError();
   XELOGD("NetDll_WSAGetLastError: {}", last_error);
+
+  if (last_error != (uint32_t)X_WSAError::X_WSA_IO_PENDING &&
+      last_error != (uint32_t)X_WSAError::X_WSA_IO_INCOMPLETE &&
+      last_error != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+    XELOGE("NetDll_WSAGetLastError: {}", last_error);
+  }
+
   return last_error;
 }
 DECLARE_XAM_EXPORT1(NetDll_WSAGetLastError, kNetworking, kImplemented);
@@ -536,12 +543,7 @@ dword_result_t NetDll_WSASendTo_entry(
     dword_t num_buffers, lpdword_t num_bytes_sent, dword_t flags,
     pointer_t<XSOCKADDR_IN> to_ptr, dword_t to_len,
     pointer_t<XWSAOVERLAPPED> overlapped, lpvoid_t completion_routine) {
-  assert(!overlapped);
   assert(!completion_routine);
-
-  if (overlapped) {
-    XELOGW("NetDll_WSASendTo: overlapped!");
-  }
 
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
@@ -550,42 +552,44 @@ dword_result_t NetDll_WSASendTo_entry(
     return -1;
   }
 
-  // Our sockets implementation doesn't support multiple buffers, so we need
-  // to combine the buffers the game has given us!
-  std::vector<uint8_t> combined_buffer_mem;
-  uint32_t combined_buffer_size = 0;
-  uint32_t combined_buffer_offset = 0;
-  for (uint32_t i = 0; i < num_buffers; i++) {
-    combined_buffer_size += buffers[i].len;
-    combined_buffer_mem.resize(combined_buffer_size);
-    uint8_t* combined_buffer = combined_buffer_mem.data();
-
-    std::memcpy(combined_buffer + combined_buffer_offset,
-                kernel_memory()->TranslateVirtual(buffers[i].buf_ptr),
-                buffers[i].len);
-    combined_buffer_offset += buffers[i].len;
-  }
-
-  const int result = socket->SendTo(
-      combined_buffer_mem.data(), combined_buffer_size, flags, to_ptr, to_len);
+  int result = socket->WSASendTo(buffers, num_buffers, num_bytes_sent, flags,
+                                 to_ptr, to_len, overlapped);
 
   if (result == -1) {
-    XThread::SetLastError(socket->GetLastWSAError());
-    return result;
-  } else if (result != -1 && to_ptr && !cvars::log_mask_ips) {
-    XELOGI("NetDll_WSASendTo: Send {} bytes to: {}:{}({})", result,
+    uint32_t error = socket->GetLastWSAError();
+
+    if (error != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+      XELOGI("WSASendTo failed with error code {}", error);
+    }
+
+    XThread::SetLastError(error);
+  } else if (to_ptr && num_bytes_sent && !cvars::log_mask_ips) {
+    XELOGI("NetDll_WSASendTo: Send {} bytes to: {}:{}({})",
+           static_cast<uint32_t>(*num_bytes_sent),
            ip_to_string(to_ptr->address_ip), to_ptr->address_port.get(),
            socket->GetProtocolUPnPString());
   }
 
-  if (num_bytes_sent && !overlapped) {
-    *num_bytes_sent = result;
-  }
-  // TODO: Instantly complete overlapped
-
-  return 0;
+  return result;
 }
 DECLARE_XAM_EXPORT1(NetDll_WSASendTo, kNetworking, kImplemented);
+
+dword_result_t NetDll_WSACancelOverlappedIO_entry(dword_t caller,
+                                                  dword_t socket_handle) {
+  auto socket =
+      kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
+  if (!socket) {
+    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    return -1;
+  }
+
+  int ret = socket->WSACancelOverlappedIO();
+
+  XThread::SetLastError(socket->GetLastWSAError());
+
+  return ret;
+}
+DECLARE_XAM_EXPORT1(NetDll_WSACancelOverlappedIO, kNetworking, kImplemented)
 
 dword_result_t NetDll_WSAWaitForMultipleEvents_entry(dword_t num_events,
                                                      lpdword_t events,

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -499,6 +499,10 @@ dword_result_t NetDll_WSARecvFrom_entry(
     return -1;
   }
 
+  // Wait for WSARecvFrom to finish writing to overlapped_ptr
+  std::unique_lock socket_lock =
+      std::unique_lock(socket->receive_socket_mutex_);
+
   int ret =
       socket->WSARecvFrom(buffers, num_buffers, num_bytes_recv_ptr, flags_ptr,
                           from_ptr, fromlen_ptr, overlapped_ptr);
@@ -551,6 +555,9 @@ dword_result_t NetDll_WSASendTo_entry(
     XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
+
+  // Wait for WSASendTo to finish writing to overlapped_ptr
+  std::unique_lock socket_lock = std::unique_lock(socket->send_socket_mutex_);
 
   int result = socket->WSASendTo(buffers, num_buffers, num_bytes_sent, flags,
                                  to_ptr, to_len, overlapped);

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -370,13 +370,13 @@ dword_result_t NetDll_XNetGetOpt_entry(dword_t caller, dword_t option_id,
     case 1:
       if (*buffer_size < sizeof(XNetStartupParams)) {
         *buffer_size = sizeof(XNetStartupParams);
-        return uint32_t(X_WSAError::X_WSAEMSGSIZE);
+        return uint32_t(X_WSA_ERROR::X_WSAEMSGSIZE);
       }
       std::memcpy(buffer_ptr, &xnet_startup_params, sizeof(XNetStartupParams));
       return 0;
     default:
       XELOGE("NetDll_XNetGetOpt: option {} unimplemented", option_id.value());
-      return uint32_t(X_WSAError::X_WSAEINVAL);
+      return uint32_t(X_WSA_ERROR::X_WSAEINVAL);
   }
 }
 DECLARE_XAM_EXPORT1(NetDll_XNetGetOpt, kNetworking, kSketchy);
@@ -475,9 +475,9 @@ dword_result_t NetDll_WSAGetLastError_entry() {
   uint32_t last_error = XThread::GetLastError();
   XELOGD("NetDll_WSAGetLastError: {}", last_error);
 
-  if (last_error != (uint32_t)X_WSAError::X_WSA_IO_PENDING &&
-      last_error != (uint32_t)X_WSAError::X_WSA_IO_INCOMPLETE &&
-      last_error != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+  if (last_error != (uint32_t)X_WSA_ERROR::X_WSA_IO_PENDING &&
+      last_error != (uint32_t)X_WSA_ERROR::X_WSA_IO_INCOMPLETE &&
+      last_error != (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     XELOGE("NetDll_WSAGetLastError: {}", last_error);
   }
 
@@ -495,7 +495,7 @@ dword_result_t NetDll_WSARecvFrom_entry(
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -503,7 +503,7 @@ dword_result_t NetDll_WSARecvFrom_entry(
       socket->WSARecvFrom(buffers, num_buffers, num_bytes_recv_ptr, flags_ptr,
                           from_ptr, fromlen_ptr, overlapped_ptr);
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   } else if (ret >= 0 && !cvars::log_mask_ips && from_ptr) {
     XELOGI("NetDll_WSARecvFrom: Received {} bytes from: {}:{}({})",
            static_cast<uint32_t>(*num_bytes_recv_ptr),
@@ -523,14 +523,14 @@ dword_result_t NetDll_WSAGetOverlappedResult_entry(
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return 0;
   }
 
   bool ret = socket->WSAGetOverlappedResult(overlapped_ptr, bytes_transferred,
                                             wait, flags_ptr);
   if (!ret) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   }
   return ret;
 }
@@ -548,7 +548,7 @@ dword_result_t NetDll_WSASendTo_entry(
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -556,9 +556,9 @@ dword_result_t NetDll_WSASendTo_entry(
                                  to_ptr, to_len, overlapped);
 
   if (result == -1) {
-    uint32_t error = socket->GetLastWSAError();
+    uint32_t error = socket->XWSAGetLastError();
 
-    if (error != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+    if (error != (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
       XELOGI("WSASendTo failed with error code {}", error);
     }
 
@@ -579,13 +579,13 @@ dword_result_t NetDll_WSACancelOverlappedIO_entry(dword_t caller,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int ret = socket->WSACancelOverlappedIO();
 
-  XThread::SetLastError(socket->GetLastWSAError());
+  XThread::SetLastError(socket->XWSAGetLastError());
 
   return ret;
 }
@@ -597,7 +597,7 @@ dword_result_t NetDll_WSAWaitForMultipleEvents_entry(dword_t num_events,
                                                      dword_t timeout,
                                                      dword_t alertable) {
   if (num_events > 64) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSA_INVALID_PARAMETER));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSA_INVALID_PARAMETER));
     return -1;
   }
 
@@ -742,7 +742,7 @@ dword_result_t NetDll_XNetXnAddrToMachineId_entry(dword_t caller,
   id_ptr.Zero();
 
   if (!addr_ptr->inaOnline.s_addr || !addr_ptr->wPortOnline) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   const MacAddress mac = MacAddress(addr_ptr->abEnet);
@@ -758,7 +758,7 @@ dword_result_t NetDll_XNetUnregisterInAddr_entry(dword_t caller, dword_t addr) {
   XELOGI("NetDll_XNetUnregisterInAddr({:08X})",
          cvars::log_mask_ips ? 0 : addr.value());
 
-  // return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+  // return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
 
   return X_ERROR_SUCCESS;
 }
@@ -790,11 +790,11 @@ dword_result_t NetDll_XNetServerToInAddr_entry(dword_t caller,
 
   if (kernel_state()->GetXboxLiveAPI()->GetInitState() !=
       XLiveAPI::InitState::Success) {
-    return static_cast<uint32_t>(X_WSAError::X_WSANOTINITIALISED);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSANOTINITIALISED);
   }
 
   if (!server_addr || !service_id) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   pina->s_addr = htonl(server_addr);
@@ -811,7 +811,7 @@ dword_result_t NetDll_XNetInAddrToServer_entry(dword_t caller,
   XELOGI("XNetInAddrToServer");
 
   if (!server_addr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   pina->s_addr = htonl(server_addr);
@@ -830,7 +830,7 @@ dword_result_t NetDll_XNetTsAddrToInAddr_entry(dword_t caller,
   XELOGI("XNetTsAddrToInAddr");
 
   if (!tsaddr_ptr || !service_id || !xnkid_ptr || !ina_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   // Use XNKID to lookup security association?
@@ -1013,14 +1013,14 @@ dword_result_t NetDll_XNetSetSystemLinkPort_entry(dword_t caller, word_t port) {
   if (!xboxkrnl::XexCheckExecutablePrivilege(
           XEX_PRIVILEGE_CROSSPLATFORM_SYSTEM_LINK)) {
     XELOGW("Title not allowed to set System Link port!");
-    return static_cast<uint32_t>(X_WSAError::X_WSAEACCES);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEACCES);
   }
 
   // XNET_SYSTEMLINK_PORT = port;
 
   XELOGI("XNetSetSystemLinkPort: {}", port.value());
 
-  return static_cast<uint32_t>(X_WSAError::X_WSAEADDRINUSE);
+  return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEADDRINUSE);
 }
 DECLARE_XAM_EXPORT1(NetDll_XNetSetSystemLinkPort, kNetworking, kImplemented);
 
@@ -1028,7 +1028,7 @@ dword_result_t NetDll_XNetGetSystemLinkPort_entry(dword_t caller,
                                                   lpword_t port) {
   if (!xboxkrnl::XexCheckExecutablePrivilege(
           XEX_PRIVILEGE_CROSSPLATFORM_SYSTEM_LINK)) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEACCES);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEACCES);
   }
 
   *port = XNET_SYSTEMLINK_PORT;
@@ -1063,13 +1063,13 @@ dword_result_t NetDll_XNetDnsLookup_entry(dword_t caller, lpstring_t host,
   XELOGI("DNS Lookup: {}", host.value());
 
   if (!dns_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   const uint32_t dns_address = kernel_memory()->SystemHeapAlloc(sizeof(XNDNS));
   XNDNS* dns = kernel_memory()->TranslateVirtual<XNDNS*>(dns_address);
 
-  dns->status = static_cast<uint32_t>(X_WSAError::X_WSAEINPROGRESS);
+  dns->status = static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINPROGRESS);
 
   *dns_ptr = dns_address;
 
@@ -1087,7 +1087,7 @@ dword_result_t NetDll_XNetDnsLookup_entry(dword_t caller, lpstring_t host,
 
     if (status) {
       XELOGI("DNS Lookup: Failed");
-      dns->status = XSocket::GetLastWSAError();
+      dns->status = XSocket::XWSAGetLastError();
       xboxkrnl::xeNtSetEvent(event_handle, nullptr);
       return;
     }
@@ -1105,7 +1105,7 @@ dword_result_t NetDll_XNetDnsLookup_entry(dword_t caller, lpstring_t host,
     }
 
     dns->cina = address_index;
-    dns->status = XSocket::GetLastWSAError();
+    dns->status = XSocket::XWSAGetLastError();
 
     xboxkrnl::xeNtSetEvent(event_handle, nullptr);
   };
@@ -1124,7 +1124,7 @@ DECLARE_XAM_EXPORT1(NetDll_XNetDnsLookup, kNetworking, kImplemented);
 dword_result_t NetDll_XNetDnsRelease_entry(dword_t caller,
                                            pointer_t<XNDNS> dns_ptr) {
   if (!dns_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   const uint32_t dns_address =
@@ -1155,7 +1155,7 @@ dword_result_t NetDll_XNetQosServiceLookup_entry(dword_t caller, dword_t flags,
          flags.value(), event_handle.value(), qos_ptr.guest_address());
 
   if (!qos_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   const uint32_t qos_address = kernel_memory()->SystemHeapAlloc(sizeof(XNQOS));
@@ -1207,7 +1207,7 @@ DECLARE_XAM_EXPORT1(NetDll_XNetQosServiceLookup, kNetworking, kStub);
 dword_result_t NetDll_XNetQosRelease_entry(dword_t caller,
                                            pointer_t<XNQOS> qos_ptr) {
   if (!qos_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEINVAL);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEINVAL);
   }
 
   const uint32_t qos_address =
@@ -1311,7 +1311,7 @@ dword_result_t NetDll_XNetQosLookup_entry(
     dword_t probes_count, dword_t bits_per_second, dword_t flags,
     dword_t event_handle, lpdword_t qos_ptr) {
   if (!qos_ptr) {
-    return static_cast<uint32_t>(X_WSAError::X_WSAEACCES);
+    return static_cast<uint32_t>(X_WSA_ERROR::X_WSAEACCES);
   }
 
   auto session_ids = std::make_shared<std::vector<XNKID>>();
@@ -1966,9 +1966,9 @@ dword_result_t NetDll_socket_entry(dword_t caller, dword_t af, dword_t type,
   if (XFAILED(result)) {
     socket->ReleaseHandle();
 
-    XThread::SetLastError(XSocket::GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     XELOGE("NetDll_socket: failed with error {:08X}",
-           XSocket::GetLastWSAError());
+           XSocket::XWSAGetLastError());
     return -1;
   }
 
@@ -1984,7 +1984,7 @@ dword_result_t NetDll_closesocket_entry(dword_t caller, dword_t socket_handle) {
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -2011,13 +2011,13 @@ int_result_t NetDll_shutdown_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   auto ret = socket->Shutdown(how);
   if (ret == -1) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   }
   return ret;
 }
@@ -2029,13 +2029,13 @@ dword_result_t NetDll_setsockopt_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   auto ret = socket->SetOption(level, optname, optval_ptr, optlen);
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2049,14 +2049,14 @@ dword_result_t NetDll_getsockopt_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   uint32_t native_len = *optlen;
   X_STATUS status = socket->GetOption(level, optname, optval_ptr, &native_len);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2069,15 +2069,15 @@ dword_result_t NetDll_ioctlsocket_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   X_STATUS status = socket->IOControl(cmd, arg_ptr.as<uint32_t*>());
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     XELOGE("NetDll_ioctlsocket: failed with error {:08X}",
-           socket->GetLastWSAError());
+           socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2092,7 +2092,7 @@ dword_result_t NetDll_bind_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -2104,8 +2104,8 @@ dword_result_t NetDll_bind_entry(dword_t caller, dword_t socket_handle,
 
   X_STATUS status = socket->Bind(name, namelen);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
-    XELOGE("NetDll_bind: failed with error {:08X}", socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
+    XELOGE("NetDll_bind: failed with error {:08X}", socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2149,13 +2149,13 @@ dword_result_t NetDll_connect_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   X_STATUS status = socket->Connect(name, namelen);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2168,13 +2168,13 @@ dword_result_t NetDll_listen_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   X_STATUS status = socket->Listen(backlog);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2188,7 +2188,7 @@ dword_result_t NetDll_accept_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -2198,7 +2198,7 @@ dword_result_t NetDll_accept_entry(dword_t caller, dword_t socket_handle,
   }
   auto new_socket = socket->Accept(addr_ptr, name_len_host_ptr);
   if (!new_socket) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   } else if (addr_ptr && !cvars::log_mask_ips) {
     XELOGI("NetDll_accept: {}:{}({})", ip_to_string(addr_ptr->address_ip),
@@ -2301,7 +2301,7 @@ int_result_t NetDll_select_entry(dword_t caller, dword_t nfds,
   fd_set native_readfds = {0};
   if (readfds) {
     if (!verify_x_fd_set(readfds)) {
-      XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+      XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
       return -1;
     }
 
@@ -2312,7 +2312,7 @@ int_result_t NetDll_select_entry(dword_t caller, dword_t nfds,
   fd_set native_writefds = {0};
   if (writefds) {
     if (!verify_x_fd_set(writefds)) {
-      XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+      XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
       return -1;
     }
 
@@ -2323,7 +2323,7 @@ int_result_t NetDll_select_entry(dword_t caller, dword_t nfds,
   fd_set native_exceptfds = {0};
   if (exceptfds) {
     if (!verify_x_fd_set(exceptfds)) {
-      XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+      XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
       return -1;
     }
 
@@ -2346,7 +2346,7 @@ int_result_t NetDll_select_entry(dword_t caller, dword_t nfds,
              exceptfds ? &native_exceptfds : nullptr, timeout_in);
 
   if (handles_count == X_SOCKET_ERROR) {
-    XThread::SetLastError(XSocket::GetLastWSAError());
+    XThread::SetLastError(XSocket::XWSAGetLastError());
   }
 
   if (readfds) {
@@ -2374,13 +2374,13 @@ dword_result_t NetDll_recv_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int ret = socket->Recv(buf_ptr, buf_len, flags);
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   } else if (ret >= 0 && !cvars::log_mask_ips) {
     XELOGI("NetDll_recv: Received {} bytes from: Any:{}({})", ret,
            socket->bound_port(), socket->GetProtocolUPnPString());
@@ -2401,7 +2401,7 @@ dword_result_t NetDll_recvfrom_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -2413,7 +2413,7 @@ dword_result_t NetDll_recvfrom_entry(dword_t caller, dword_t socket_handle,
   }
 
   if (ret == -1) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   } else if (ret >= 0 && !cvars::log_mask_ips && from_ptr) {
     XELOGI("NetDll_recvfrom: Received {} bytes from: {}:{}({})", ret,
            ip_to_string(from_ptr->address_ip), from_ptr->address_port.get(),
@@ -2430,13 +2430,13 @@ dword_result_t NetDll_send_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int ret = socket->Send(buf_ptr, buf_len, flags);
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   } else if (ret >= 0 && !cvars::log_mask_ips) {
     XELOGI("NetDll_send: Send {} bytes to: Any:{}({})", ret,
            socket->bound_port(), socket->GetProtocolUPnPString());
@@ -2454,13 +2454,13 @@ dword_result_t NetDll_sendto_entry(dword_t caller, dword_t socket_handle,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int ret = socket->SendTo(buf_ptr, buf_len, flags, to_ptr, to_len);
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   } else if (ret >= 0 && to_ptr && !cvars::log_mask_ips) {
     XELOGI("NetDll_sendto: Send {} bytes to: {}:{}({})", ret,
            ip_to_string(to_ptr->address_ip), to_ptr->address_port.get(),
@@ -2478,13 +2478,13 @@ dword_result_t NetDll_WSAEventSelect_entry(dword_t caller,
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   auto ev = kernel_state()->object_table()->LookupObject<XEvent>(event_handle);
   if (!ev) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
@@ -2492,7 +2492,7 @@ dword_result_t NetDll_WSAEventSelect_entry(dword_t caller,
                                    flags);
 
   if (ret < 0) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
   }
 
   return ret;
@@ -2521,21 +2521,21 @@ dword_result_t NetDll_getpeername_entry(dword_t caller, dword_t socket_handle,
                                         pointer_t<XSOCKADDR_IN> addr_ptr,
                                         lpdword_t addrlen_ptr) {
   if (!addr_ptr) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAEFAULT));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAEFAULT));
     return -1;
   }
 
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int native_len = *addrlen_ptr;
   X_STATUS status = socket->GetPeerName(addr_ptr, &native_len);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 
@@ -2550,21 +2550,21 @@ dword_result_t NetDll_getsockname_entry(dword_t caller, dword_t socket_handle,
   InitalizeSockaddr(addr_ptr);
 
   if (!addr_ptr) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAEFAULT));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAEFAULT));
     return -1;
   }
 
   auto socket =
       kernel_state()->object_table()->LookupObject<XSocket>(socket_handle);
   if (!socket) {
-    XThread::SetLastError(uint32_t(X_WSAError::X_WSAENOTSOCK));
+    XThread::SetLastError(uint32_t(X_WSA_ERROR::X_WSAENOTSOCK));
     return -1;
   }
 
   int native_len = *addrlen_ptr;
   X_STATUS status = socket->GetSockName(addr_ptr, &native_len);
   if (XFAILED(status)) {
-    XThread::SetLastError(socket->GetLastWSAError());
+    XThread::SetLastError(socket->XWSAGetLastError());
     return -1;
   }
 

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -585,8 +585,6 @@ dword_result_t NetDll_WSACancelOverlappedIO_entry(dword_t caller,
 
   int ret = socket->WSACancelOverlappedIO();
 
-  XThread::SetLastError(socket->XWSAGetLastError());
-
   return ret;
 }
 DECLARE_XAM_EXPORT1(NetDll_WSACancelOverlappedIO, kNetworking, kImplemented)

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -106,11 +106,13 @@ X_STATUS XSocket::Close() {
     // Wait for PollWSARecvFrom to return before closing
     if (receive_polling_task_.valid()) {
       receive_polling_task_.wait();
+      receive_polling_task_ = {};
     }
 
     // Wait for PollWSAWSASend to return before closing
     if (send_polling_task_.valid()) {
       send_polling_task_.wait();
+      send_polling_task_ = {};
     }
   }
 
@@ -620,18 +622,6 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
       send_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
                      send_async_data);
-    } else {
-      std::future_status status = send_polling_task_.wait_for(0ms);
-
-      if (status == std::future_status::ready) {
-        uint32_t result = send_polling_task_.get();
-
-        if (result == X_SOCKET_ERROR &&
-            wsa_error != X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-          XELOGI("{} Async:: failed with error code {}", __func__,
-                 static_cast<uint32_t>(wsa_error));
-        }
-      }
     }
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
@@ -853,18 +843,6 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
       receive_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
                      receive_async_data);
-    } else {
-      std::future_status status = receive_polling_task_.wait_for(0ms);
-
-      if (status == std::future_status::ready) {
-        uint32_t result = receive_polling_task_.get();
-
-        if (result == X_SOCKET_ERROR &&
-            wsa_error != X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-          XELOGI("{} Async:: failed with error code {}", __func__,
-                 static_cast<uint32_t>(wsa_error));
-        }
-      }
     }
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
@@ -920,21 +898,39 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
 
   bool io_type = pending_overlapped_io_[overlapped_ptr];
 
-  if (wait) {
-    if (io_type) {
-      XELOGI("{}:: WSASendTo blocking until completion!", __func__);
-      if (send_polling_task_.valid()) {
+  if (io_type) {
+    std::lock_guard lock(send_socket_mutex_);
+
+    if (send_polling_task_.valid()) {
+      if (wait) {
+        XELOGI("{}:: WSASendTo blocking until completion!", __func__);
         send_polling_task_.wait();
+      } else if (send_polling_task_.wait_for(0ms) !=
+                 std::future_status::ready) {
+        XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
+        return false;
       }
-    } else {
-      XELOGI("{}:: WSARecvFrom Blocking until completion!", __func__);
-      if (receive_polling_task_.valid()) {
+
+      int32_t result = send_polling_task_.get();
+    }
+  } else {
+    std::lock_guard lock(receive_socket_mutex_);
+
+    if (receive_polling_task_.valid()) {
+      if (wait) {
+        XELOGI("{}:: WSARecvFrom Blocking until completion!", __func__);
         receive_polling_task_.wait();
+      } else if (receive_polling_task_.wait_for(0ms) !=
+                 std::future_status::ready) {
+        XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
+        return false;
       }
+
+      int32_t result = receive_polling_task_.get();
     }
   }
 
-  // Read result after wait is completed if any.
+  // Read result after future is ready.
   X_WSA_ERROR internal_result =
       X_WSA_ERROR(X_WIN32_FROM_HRESULT(overlapped_ptr->internal.get()));
 
@@ -958,12 +954,6 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
                  overlapped_ptr->internal_high.get(),
                  overlapped_ptr->internal.get());
         }
-      }
-
-      if (overlapped_ptr->internal_high == 0) {
-        XELOGI("{}:: 0 bytes sent!", __func__);
-        XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
-        return false;
       }
 
       *bytes_transferred = overlapped_ptr->internal_high;
@@ -998,11 +988,13 @@ int XSocket::WSACancelOverlappedIO() {
     // Wait for PollWSARecvFrom to cancel
     if (receive_polling_task_.valid()) {
       receive_polling_task_.wait();
+      receive_polling_task_ = {};
     }
 
     // Wait for PollWSAWSASend to cancel
     if (send_polling_task_.valid()) {
       send_polling_task_.wait();
+      send_polling_task_ = {};
     }
   }
 

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -453,7 +453,8 @@ int XSocket::WSAPollWrite(bool wait, X_WSA_ERROR* error) {
   return activity;
 }
 
-int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
+int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data,
+                           uint32_t* num_bytes_sent) {
   // critical section - lock until we return
   std::unique_lock<std::mutex> lock;
 
@@ -491,7 +492,7 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
     XELOGE("WSAPollWrite failed with error {}", error);
 
     return X_SOCKET_ERROR;
-  } else if (result == 0) {
+  } else if (result == X_ERROR_SUCCESS) {
     // There's no available space for writing therefore return and start
     // pending operation.
     send_async_data.overlapped->internal = X_STATUS_PENDING;
@@ -552,10 +553,17 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
     }
 
     // send_async_data.overlapped->internal_high = buffers[0].len;
-  } else if (result == 0) {
+  } else if (result == X_ERROR_SUCCESS) {
     send_async_data.overlapped->internal_high = bytes_sent;
-    *send_async_data.num_bytes_sent = bytes_sent;
 
+    if (num_bytes_sent) {
+      *num_bytes_sent = bytes_sent;
+    }
+  }
+
+  send_async_data.overlapped->offset = 0;
+
+  if (result == X_ERROR_SUCCESS) {
     // If no event handle is provided then title can check for completion via
     // internal on change.
     send_async_data.overlapped->internal =
@@ -564,12 +572,8 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
     xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
   }
 
-  send_async_data.overlapped->offset = 0;
-
   return result;
 }
-
-uint32_t WSASendTo_bytes_sent = 0;
 
 int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
                        xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
@@ -590,7 +594,6 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
               num_buffers * sizeof(XWSABUF));
 
   send_async_data.num_buffers = num_buffers;
-  send_async_data.num_bytes_sent = &WSASendTo_bytes_sent;
   send_async_data.to = to_ptr;
   send_async_data.to_len = to_len;
 
@@ -602,16 +605,18 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
     pending_overlapped_io_[send_async_data.overlapped] = true;
   }
 
-  // Check for immediate completion, otherwise perform overlapped completion.
-  const int result = PollWSASendTo(false, send_async_data);
+  uint32_t num_bytes_sent = 0;
 
-  if (result == 0) {
+  // Check for immediate completion, otherwise perform overlapped completion.
+  const int result = PollWSASendTo(false, send_async_data, &num_bytes_sent);
+
+  if (result == X_ERROR_SUCCESS) {
     if (cvars::logging) {
       XELOGI("{} completed immediately", __func__);
     }
 
     if (num_bytes_sent_ptr) {
-      *num_bytes_sent_ptr = *send_async_data.num_bytes_sent;
+      *num_bytes_sent_ptr = num_bytes_sent;
     }
 
     return result;
@@ -624,7 +629,7 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
     if (!send_polling_task_.valid()) {
       send_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
-                     send_async_data);
+                     send_async_data, nullptr);
     }
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
@@ -710,7 +715,7 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
     XELOGE("WSAPollRead failed with error {}", error);
 
     return X_SOCKET_ERROR;
-  } else if (result == 0) {
+  } else if (result == X_ERROR_SUCCESS) {
     // There's no available data for reading therefore return and start pending
     // operation.
     receive_async_data.overlapped->internal = X_STATUS_PENDING;
@@ -732,22 +737,17 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
 
   DWORD bytes_received = 0;
   DWORD flags = 0;
+  int from_len = *receive_async_data.from_len;
 
-  result = ::WSARecvFrom(native_handle_, &recv_buffer,
-                         receive_async_data.num_buffers, &bytes_received,
-                         &flags, receive_async_data.from ? &saddr : nullptr,
-                         &receive_async_data.from_len, nullptr, nullptr);
-
-  if (receive_async_data.from) {
-    // Copy behavior from recvfrom.
-    // Verified on console.
-    if (proto_ == X_IPPROTO_TCP) {
-      socklen_t peer_addar_len = sizeof(sockaddr);
-      getpeername(native_handle_, &saddr, &peer_addar_len);
-    }
-
-    receive_async_data.from->to_guest(&saddr);
+  // num_bytes_recv and flags are only updated on immediate completion.
+  if (!wait && receive_async_data.flags) {
+    flags = receive_async_data.flags->get();
   }
+
+  result = ::WSARecvFrom(
+      native_handle_, &recv_buffer, receive_async_data.num_buffers,
+      &bytes_received, &flags, receive_async_data.from ? &saddr : nullptr,
+      receive_async_data.from_len ? &from_len : nullptr, nullptr, nullptr);
 
   if (result == X_SOCKET_ERROR) {
     if (XWSAGetLastError() == (uint32_t)X_WSA_ERROR::X_WSA_IO_PENDING ||
@@ -760,10 +760,36 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
       // receive_async_data.overlapped->internal =
       //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
     }
-  } else if (result == 0) {
-    receive_async_data.overlapped->internal_high = bytes_received;
-    *receive_async_data.num_bytes_recv = bytes_received;
+  } else if (result == X_ERROR_SUCCESS) {
+    if (receive_async_data.from) {
+      // Copy behavior from recvfrom.
+      // Verified on console.
+      if (proto_ == X_IPPROTO_TCP) {
+        socklen_t peer_addar_len = sizeof(sockaddr);
+        getpeername(native_handle_, &saddr, &peer_addar_len);
+      }
 
+      receive_async_data.from->to_guest(&saddr);
+    }
+
+    if (receive_async_data.from_len) {
+      *receive_async_data.from_len = from_len;
+    }
+
+    if (!wait && receive_async_data.num_bytes_recv) {
+      *receive_async_data.num_bytes_recv = bytes_received;
+    }
+
+    receive_async_data.overlapped->internal_high = bytes_received;
+  }
+
+  if (!wait && receive_async_data.flags) {
+    *receive_async_data.flags = flags;
+  }
+
+  receive_async_data.overlapped->offset = flags;
+
+  if (result == X_ERROR_SUCCESS) {
     // If no event handle is provided then title can check for completion via
     // internal on change.
     receive_async_data.overlapped->internal =
@@ -773,14 +799,8 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
                            nullptr);
   }
 
-  *receive_async_data.flags = flags;
-  receive_async_data.overlapped->offset = flags;
-
   return result;
 }
-
-uint32_t WSARecvFrom_flags = 0;
-uint32_t WSARecvFrom_bytes_recv = 0;
 
 int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                          xe::be<uint32_t>* num_bytes_recv_ptr,
@@ -805,10 +825,10 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   std::memcpy(receive_async_data.buffers.get(), buffers, sizeof(XWSABUF));
 
   receive_async_data.num_buffers = num_buffers;
-  receive_async_data.flags = &WSARecvFrom_flags;
-  receive_async_data.num_bytes_recv = &WSARecvFrom_bytes_recv;
+  receive_async_data.flags = flags_ptr;
+  receive_async_data.num_bytes_recv = num_bytes_recv_ptr;
   receive_async_data.from = from_ptr;
-  receive_async_data.from_len = *fromlen_ptr;
+  receive_async_data.from_len = fromlen_ptr;
 
   XWSAOVERLAPPED tmp_overlapped = {};
   receive_async_data.overlapped =
@@ -821,16 +841,10 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   // Check for immediate completion, otherwise perform overlapped completion.
   int result = PollWSARecvFrom(false, receive_async_data);
 
-  if (result == 0) {
+  if (result == X_ERROR_SUCCESS) {
     if (cvars::logging) {
       XELOGI("{} completed immediately", __func__);
     }
-
-    if (num_bytes_recv_ptr) {
-      *num_bytes_recv_ptr = *receive_async_data.num_bytes_recv;
-    }
-
-    *flags_ptr = *receive_async_data.flags;
 
     return result;
   }
@@ -840,6 +854,9 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR(X_STATUS_PENDING)) {
     if (!receive_polling_task_.valid()) {
+      receive_async_data.flags = nullptr;
+      receive_async_data.num_bytes_recv = nullptr;
+
       receive_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
                      receive_async_data);

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -459,23 +459,13 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data,
   // critical section - lock until we return
   std::unique_lock<std::mutex> lock;
 
-  if (wait) {
-    // Sync is already locked, therefore only lock for async
-    lock = std::unique_lock(send_socket_mutex_);
-  }
-
-  // Unlock while WSAPoll is blocking
-  if (wait) {
-    lock.unlock();
-  }
-
   X_WSA_ERROR poll_write_error = X_WSA_ERROR::X_WSA_NO_ERROR;
 
   int result = WSAPollWrite(wait, &poll_write_error);
 
-  // Lock again after WSAPoll returned
   if (wait) {
-    lock.lock();
+    // Sync is already locked, therefore only lock for async
+    lock = std::unique_lock(send_socket_mutex_);
   }
 
   if (result == X_SOCKET_ERROR) {
@@ -602,8 +592,12 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   send_async_data.overlapped =
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
 
-  if (overlapped_ptr) {
-    pending_overlapped_io_[send_async_data.overlapped] = true;
+  {
+    std::unique_lock lock(map_mutex_);
+
+    if (overlapped_ptr && !pending_overlapped_io_.contains(overlapped_ptr)) {
+      pending_overlapped_io_[send_async_data.overlapped] = true;
+    }
   }
 
   uint32_t num_bytes_sent = 0;
@@ -683,23 +677,13 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   // critical section - lock until we return
   std::unique_lock<std::mutex> lock;
 
-  if (wait) {
-    // Sync is already locked, therefore only lock for async
-    lock = std::unique_lock(receive_socket_mutex_);
-  }
-
-  // Unlock while WSAPoll is blocking
-  if (wait) {
-    lock.unlock();
-  }
-
   X_WSA_ERROR poll_read_error = X_WSA_ERROR::X_WSA_NO_ERROR;
 
   int result = WSAPollRead(wait, &poll_read_error);
 
-  // Lock again after WSAPoll returned
   if (wait) {
-    lock.lock();
+    // Sync is already locked, therefore only lock for async
+    lock = std::unique_lock(receive_socket_mutex_);
   }
 
   if (result == X_SOCKET_ERROR) {
@@ -836,8 +820,12 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   receive_async_data.overlapped =
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
 
-  if (overlapped_ptr) {
-    pending_overlapped_io_[receive_async_data.overlapped] = false;
+  {
+    std::unique_lock lock(map_mutex_);
+
+    if (overlapped_ptr && !pending_overlapped_io_.contains(overlapped_ptr)) {
+      pending_overlapped_io_[receive_async_data.overlapped] = false;
+    }
   }
 
   // Check for immediate completion, otherwise perform overlapped completion.
@@ -855,6 +843,14 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
       X_WSA_ERROR(receive_async_data.overlapped->internal.get());
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR(X_STATUS_PENDING)) {
+    // Fix:
+    // FM2, Halo Wars, FlatOut: Ultimate Carnage, Shadowrun
+    // if (receive_polling_task_.valid()) {
+    //  if (receive_polling_task_.wait_for(0ms) == std::future_status::ready) {
+    //    receive_polling_task_ = {};
+    //  }
+    // }
+
     if (!receive_polling_task_.valid()) {
       receive_async_data.flags = nullptr;
       receive_async_data.num_bytes_recv = nullptr;
@@ -863,6 +859,15 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
                      receive_async_data);
     }
+
+    // Fix:
+    // Split/Second, Pure, Top Gun, Ghostbusters
+    // if (receive_polling_task_.valid()) {
+    //  if (receive_polling_task_.wait_for(0ms) == std::future_status::ready)
+    //  {
+    //    receive_polling_task_ = {};
+    //  }
+    // }
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
   } else {
@@ -901,6 +906,9 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return false;
   }
 
+  std::unique_lock<std::mutex> task_mutex;
+  std::unique_lock lock(map_mutex_);
+
   // 4D530808 does this.
   if (!pending_overlapped_io_.contains(overlapped_ptr)) {
     XELOGI("Overlap not in operation!");
@@ -913,9 +921,9 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
 
   bool io_type = pending_overlapped_io_[overlapped_ptr];
 
-  if (io_type) {
-    std::lock_guard lock(send_socket_mutex_);
+  lock.unlock();
 
+  if (io_type) {
     if (send_polling_task_.valid()) {
       if (wait) {
         XELOGI("{}:: WSASendTo blocking until completion!", __func__);
@@ -927,10 +935,12 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
       }
 
       int32_t result = send_polling_task_.get();
+    } else {
+      XELOGI("{}:: WSASendTo already completed!", __func__);
     }
-  } else {
-    std::lock_guard lock(receive_socket_mutex_);
 
+    task_mutex = std::unique_lock(send_socket_mutex_);
+  } else {
     if (receive_polling_task_.valid()) {
       if (wait) {
         XELOGI("{}:: WSARecvFrom Blocking until completion!", __func__);
@@ -942,7 +952,11 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
       }
 
       int32_t result = receive_polling_task_.get();
+    } else {
+      XELOGI("{}:: WSARecvFrom already completed!", __func__);
     }
+
+    task_mutex = std::unique_lock(receive_socket_mutex_);
   }
 
   // Read result after future is ready.
@@ -1013,6 +1027,8 @@ int XSocket::WSACancelOverlappedIO() {
       send_polling_task_ = {};
     }
   }
+
+  std::unique_lock lock(map_mutex_);
 
   for (auto& [overlapped_ptr, type] : pending_overlapped_io_) {
     xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -18,6 +18,8 @@
 
 DECLARE_bool(bind_interface);
 
+DECLARE_bool(logging);
+
 using namespace std::chrono_literals;
 
 namespace xe {
@@ -97,8 +99,6 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
 }
 
 X_STATUS XSocket::Close() {
-  XELOGI("Socket closing!");
-
   // Cancel overlap tasks if running
   if (polling_task_.valid()) {
     cancel_overlapped_ = true;
@@ -120,8 +120,6 @@ X_STATUS XSocket::Close() {
   }
 
   socket_closed_ = true;
-
-  // pending_overlapped_io_.clear();
 
   return X_STATUS_SUCCESS;
 }
@@ -206,7 +204,7 @@ int XSocket::SetOption(uint32_t level, uint32_t optname, void* optval_ptr,
 
   if (ret < 0) {
     // TODO: WSAGetLastError()
-    XELOGE("XSocket::SetOption: failed with error {:08X}", GetLastWSAError());
+    XELOGE("XSocket::SetOption: failed with error {:08X}", XWSAGetLastError());
     return -1;
   }
 
@@ -425,8 +423,8 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   if (!buffers || !num_buffers || !num_bytes_sent_ptr || flags ||
       to_ptr && (to_len < sizeof(XSOCKADDR_IN) ||
                  to_ptr->address_family != X_AF_INET)) {
-    SetLastWSAError(X_WSAError::X_WSA_INVALID_PARAMETER);
-    return -1;
+    XWSASetLastError(X_WSA_ERROR::X_WSA_INVALID_PARAMETER);
+    return X_SOCKET_ERROR;
   }
 
   if (overlapped_ptr) {
@@ -450,21 +448,21 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   int result = SendTo(combined_buffer_mem.data(), combined_buffer_size, flags,
                       to_ptr, to_len);
 
-  if (result == -1) {
-    uint32_t error = WSAGetLastError();
+  if (result == X_SOCKET_ERROR) {
+    uint32_t error = XWSAGetLastError();
 
-    if (error == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+    if (error == (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
       XELOGI("{} is pending...", __func__);
-      SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
+      XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
     } else {
       XELOGE("{} failed with error {}", __func__, error);
-      SetLastWSAError((X_WSAError)error);
+      XWSASetLastError((X_WSA_ERROR)error);
     }
   } else {
     if (overlapped_ptr) {
       // Hack
       overlapped_ptr->offset_high = 1;
-      overlapped_ptr->internal = result;
+      overlapped_ptr->internal_high = result;
 
       if (overlapped_ptr->event_handle) {
         xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
@@ -481,7 +479,7 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
 }
 
 // If wait is true then block until data is available for writing
-int XSocket::WSAPollWrite(bool wait, X_WSAError* error) {
+int XSocket::WSAPollWrite(bool wait, X_WSA_ERROR* error) {
   WSAPOLLFD fds = {};
   fds.fd = native_handle_;
   fds.events = POLLOUT;
@@ -493,21 +491,23 @@ int XSocket::WSAPollWrite(bool wait, X_WSAError* error) {
 
     if (cancel_overlapped_) {
       if (error) {
-        *error = X_WSAError::X_WSA_OPERATION_ABORTED;
-        activity = -1;
+        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
+        activity = X_SOCKET_ERROR;
       }
     }
 
-    // if (wait) {
-    //   XELOGI("{} Blocking...", __func__);
-    // }
+    if (cvars::logging) {
+      if (wait) {
+        XELOGI("{} Blocking...", __func__);
+      }
+    }
   } while (activity == 0 && wait);
 
   return activity;
 }
 
 // If wait is true then block until data is available for reading
-int XSocket::WSAPollRead(bool wait, X_WSAError* error) {
+int XSocket::WSAPollRead(bool wait, X_WSA_ERROR* error) {
   WSAPOLLFD fds = {};
   fds.fd = native_handle_;
   fds.events = POLLIN;
@@ -519,14 +519,16 @@ int XSocket::WSAPollRead(bool wait, X_WSAError* error) {
 
     if (cancel_overlapped_) {
       if (error) {
-        *error = X_WSAError::X_WSA_OPERATION_ABORTED;
-        activity = -1;
+        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
+        activity = X_SOCKET_ERROR;
       }
     }
 
-    // if (wait) {
-    //   XELOGI("{} Blocking...", __func__);
-    // }
+    if (cvars::logging) {
+      if (wait) {
+        XELOGI("{} Blocking...", __func__);
+      }
+    }
   } while (activity == 0 && wait);
 
   return activity;
@@ -534,39 +536,40 @@ int XSocket::WSAPollRead(bool wait, X_WSAError* error) {
 
 int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   if (wait) {
-    receive_async_data.overlapped->internal_high =
-        (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
+    // Change?
+    receive_async_data.overlapped->internal =
+        (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK;
   }
 
-  X_WSAError poll_read_error = X_WSAError::X_WSA_NO_ERROR;
+  X_WSA_ERROR poll_read_error = X_WSA_ERROR::X_WSA_NO_ERROR;
 
   int result = WSAPollRead(wait, &poll_read_error);
 
-  if (result == -1) {
+  if (result == X_SOCKET_ERROR) {
     // Checking for available data for reading failed.
     uint32_t error = 0;
 
-    if (poll_read_error != X_WSAError::X_WSA_NO_ERROR) {
+    if (poll_read_error != X_WSA_ERROR::X_WSA_NO_ERROR) {
       error = (uint32_t)poll_read_error;
     } else {
-      error = WSAGetLastError();
+      error = XWSAGetLastError();
     }
 
-    receive_async_data.overlapped->internal_high = error;
+    receive_async_data.overlapped->internal = error;
 
-    XELOGE("PollRead failed with error {}", error);
+    XELOGE("WSAPollRead failed with error {}", error);
 
     std::unique_lock lock(receive_completion_mutex_);
     receive_cv_.notify_all();
-    return -1;
+    return X_SOCKET_ERROR;
   } else if (result == 0) {
     // There's no available data for reading therefore would block.
-    receive_async_data.overlapped->internal_high =
-        (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
+    receive_async_data.overlapped->internal =
+        (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK;
 
     std::unique_lock lock(receive_completion_mutex_);
     receive_cv_.notify_all();
-    return -1;
+    return X_SOCKET_ERROR;
   }
 
   // critical section - lock until we return
@@ -601,13 +604,14 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
     delete saddr;
   }
 
-  if (result == -1) {
-    XELOGI("WSARecvFrom failed with error {}", GetLastWSAError());
+  if (result == X_SOCKET_ERROR) {
+    XELOGI("WSARecvFrom failed with error {}", XWSAGetLastError());
 
-    receive_async_data.overlapped->internal_high = GetLastWSAError();
+    receive_async_data.overlapped->internal = XWSAGetLastError();
   } else if (result == 0) {
-    receive_async_data.overlapped->internal_high = 0;
-    receive_async_data.overlapped->internal = bytes_received;
+    receive_async_data.overlapped->internal =
+        (uint32_t)X_WSA_ERROR::X_WSA_NO_ERROR;
+    receive_async_data.overlapped->internal_high = bytes_received;
 
     *receive_async_data.num_bytes_recv = bytes_received;
 
@@ -628,8 +632,8 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   return result;
 }
 
-uint32_t flags = 0;
-uint32_t bytes_recv = 0;
+uint32_t WSARecvFrom_flags = 0;
+uint32_t WSARecvFrom_bytes_recv = 0;
 
 int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                          xe::be<uint32_t>* num_bytes_recv_ptr,
@@ -637,8 +641,8 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                          xe::be<uint32_t>* fromlen_ptr,
                          XWSAOVERLAPPED* overlapped_ptr) {
   if (!buffers || !flags_ptr || (from_ptr && !fromlen_ptr)) {
-    SetLastWSAError(X_WSAError::X_WSA_INVALID_PARAMETER);
-    return -1;
+    XWSASetLastError(X_WSA_ERROR::X_WSA_INVALID_PARAMETER);
+    return X_SOCKET_ERROR;
   }
 
   // On win32 we could pipe all this directly to WSARecvFrom.
@@ -654,13 +658,13 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   std::memcpy(receive_async_data.buffers.get(), buffers, sizeof(XWSABUF));
 
   receive_async_data.num_buffers = num_buffers;
-  receive_async_data.flags = &flags;
-  receive_async_data.num_bytes_recv = &bytes_recv;
+  receive_async_data.flags = &WSARecvFrom_flags;
+  receive_async_data.num_bytes_recv = &WSARecvFrom_bytes_recv;
   receive_async_data.from = from_ptr;
   receive_async_data.from_len = *fromlen_ptr;
 
   if (!overlapped_ptr) {
-    XELOGI("{}:: without overlapped_ptr!", __func__);
+    XELOGD("{}:: without overlapped_ptr!", __func__);
   }
 
   // Wait for PollWSARecvFrom to finish writing to overlapped_ptr
@@ -678,7 +682,9 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   uint32_t result = PollWSARecvFrom(false, receive_async_data);
 
   if (result == 0) {
-    XELOGI("{} completed immediately", __func__);
+    if (cvars::logging) {
+      XELOGI("{} completed immediately", __func__);
+    }
 
     if (num_bytes_recv_ptr) {
       *num_bytes_recv_ptr = *receive_async_data.num_bytes_recv;
@@ -689,17 +695,17 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     return result;
   }
 
-  X_WSAError wsa_error =
-      (X_WSAError)receive_async_data.overlapped->internal_high.get();
+  X_WSA_ERROR wsa_error =
+      (X_WSA_ERROR)receive_async_data.overlapped->internal.get();
 
-  if (!overlapped_ptr && wsa_error == X_WSAError::X_WSAEWOULDBLOCK) {
-    SetLastWSAError(X_WSAError::X_WSAEWOULDBLOCK);
+  if (!overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+    XWSASetLastError(X_WSA_ERROR::X_WSAEWOULDBLOCK);
     return result;
   }
 
-  SetLastWSAError(wsa_error);
+  XWSASetLastError(wsa_error);
 
-  if (overlapped_ptr && wsa_error == X_WSAError::X_WSAEWOULDBLOCK) {
+  if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     if (!polling_task_.valid()) {
       if (overlapped_ptr->event_handle) {
         xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
@@ -713,28 +719,28 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
       if (status == std::future_status::ready) {
         uint32_t result = polling_task_.get();
 
-        uint32_t error_code = GetLastWSAError();
+        uint32_t error_code = XWSAGetLastError();
 
-        if (error_code != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+        if (error_code != (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
           XELOGI("{} Async:: failed with error code {}", __func__, error_code);
         }
       }
     }
 
-    SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
+    XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
   } else {
     // An error occurred that's not X_WSAEWOULDBLOCK
     XELOGI("{}:: failed!", __func__);
 
     // Check WSA error is not corrupted!
     if (wsa_error !=
-        (X_WSAError)receive_async_data.overlapped->internal_high.get()) {
+        (X_WSA_ERROR)receive_async_data.overlapped->internal.get()) {
       XELOGI("{}:: Overlapped Corruption!!", __func__);
     }
 
-    if (wsa_error == X_WSAError::X_WSA_OPERATION_ABORTED) {
-      XELOGI("{}:: Operation Aborted!", __func__);
-      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+    if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
+      XELOGD("{}:: Operation Aborted!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
     }
   }
 
@@ -745,7 +751,7 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
                                      xe::be<uint32_t>* bytes_transferred,
                                      bool wait, xe::be<uint32_t>* flags_ptr) {
   if (!overlapped_ptr || !bytes_transferred || !flags_ptr) {
-    SetLastWSAError(X_WSAError::X_WSA_INVALID_PARAMETER);
+    XWSASetLastError(X_WSA_ERROR::X_WSA_INVALID_PARAMETER);
     return false;
   }
 
@@ -765,49 +771,48 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     receive_cv_.wait(lock);
   }
 
-  X_WSAError wsa_error = (X_WSAError)overlapped_ptr->internal_high.get();
+  X_WSA_ERROR wsa_error = (X_WSA_ERROR)overlapped_ptr->internal.get();
 
   switch (wsa_error) {
-    case X_WSAError::X_WSA_OPERATION_ABORTED: {
-      XELOGI("{}:: Operation Aborted!", __func__);
-      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+    case X_WSA_ERROR::X_WSA_OPERATION_ABORTED: {
+      XELOGD("{}:: Operation Aborted!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
       return false;
     } break;
-    case X_WSAError::X_WSAECANCELLED: {
-      XELOGI("{}:: Operation Cancelled!", __func__);
-      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
-      return false;
-    } break;
-    case X_WSAError::X_WSAEWOULDBLOCK: {
-      SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+    case X_WSA_ERROR::X_WSAEWOULDBLOCK: {
+      XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
       return false;
     } break;
     default:
       break;
   }
 
-  if (overlapped_ptr->offset_high == 1) {
-    XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
-           overlapped_ptr->internal.get(), overlapped_ptr->internal_high.get());
-  } else {
-    XELOGI("{}:: WSARecvFrom bytes received {} with status {}!", __func__,
-           overlapped_ptr->internal.get(), overlapped_ptr->internal_high.get());
+  if (cvars::logging) {
+    if (overlapped_ptr->offset_high == 1) {
+      XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
+             overlapped_ptr->internal_high.get(),
+             overlapped_ptr->internal.get());
+    } else {
+      XELOGI("{}:: WSARecvFrom bytes received {} with status {}!", __func__,
+             overlapped_ptr->internal_high.get(),
+             overlapped_ptr->internal.get());
+    }
   }
 
   if (static_cast<uint32_t>(wsa_error) == 0) {
-    if (overlapped_ptr->internal == 0) {
-      XELOGI("{}:: bytes sent 0!", __func__);
-      SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+    if (overlapped_ptr->internal_high == 0) {
+      XELOGI("{}:: 0 bytes sent!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
       return false;
     }
 
-    *bytes_transferred = overlapped_ptr->internal;
+    *bytes_transferred = overlapped_ptr->internal_high;
     *flags_ptr = overlapped_ptr->offset;
   } else {
     XELOGI("{}:: failed with error code {}", __func__,
-           overlapped_ptr->internal_high.get());
+           overlapped_ptr->internal.get());
 
-    SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+    XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
     return false;
   }
 
@@ -824,12 +829,12 @@ int XSocket::WSACancelOverlappedIO() {
       xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
     }
 
-    overlapped_ptr->internal_high = (uint32_t)X_WSAError::X_WSAECANCELLED;
+    overlapped_ptr->internal = (uint32_t)X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
   }
 
   pending_overlapped_io_.clear();
 
-  SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+  XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
 
   return 0;
 }
@@ -919,16 +924,69 @@ X_STATUS XSocket::GetSockName(XSOCKADDR_IN* name, int* name_len) {
   return X_STATUS_SUCCESS;
 }
 
-uint32_t XSocket::GetLastWSAError() {
-  // Todo(Gliniak): Provide error mapping table
+bool XSocket::XWSAIsKnownError(X_WSA_ERROR wsa_error) {
   // Xbox error codes might not match with what we receive from OS
+  switch (wsa_error) {
+    case X_WSA_ERROR::X_WSA_NO_ERROR:
+    case X_WSA_ERROR::X_WSA_INVALID_PARAMETER:
+    case X_WSA_ERROR::X_WSA_OPERATION_ABORTED:
+    case X_WSA_ERROR::X_WSA_IO_INCOMPLETE:
+    case X_WSA_ERROR::X_WSA_IO_PENDING:
+    case X_WSA_ERROR::X_WSAEACCES:
+    case X_WSA_ERROR::X_WSAEFAULT:
+    case X_WSA_ERROR::X_WSAEINVAL:
+    case X_WSA_ERROR::X_WSAEWOULDBLOCK:
+    case X_WSA_ERROR::X_WSAEINPROGRESS:
+    case X_WSA_ERROR::X_WSAEALREADY:
+    case X_WSA_ERROR::X_WSAENOTSOCK:
+    case X_WSA_ERROR::X_WSAEMSGSIZE:
+    case X_WSA_ERROR::X_WSAENOPROTOOPT:
+    case X_WSA_ERROR::X_WSAEPROTONOSUPPORT:
+    case X_WSA_ERROR::X_WSAESOCKTNOSUPPORT:
+    case X_WSA_ERROR::X_WSAEAFNOSUPPORT:
+    case X_WSA_ERROR::X_WSAEADDRINUSE:
+    case X_WSA_ERROR::X_WSAEADDRNOTAVAIL:
+    case X_WSA_ERROR::X_WSAENETDOWN:
+    case X_WSA_ERROR::X_WSAECONNRESET:
+    case X_WSA_ERROR::X_WSAENOBUFS:
+    case X_WSA_ERROR::X_WSAEISCONN:
+    case X_WSA_ERROR::X_WSAENOTCONN:
+    case X_WSA_ERROR::X_WSAESHUTDOWN:
+    case X_WSA_ERROR::X_WSAETIMEDOUT:
+    case X_WSA_ERROR::X_WSAECONNREFUSED:
+    case X_WSA_ERROR::X_WSAEHOSTUNREACH:
+    case X_WSA_ERROR::X_WSASYSNOTREADY:
+    case X_WSA_ERROR::X_WSAVERNOTSUPPORTED:
+    case X_WSA_ERROR::X_WSANOTINITIALISED:
+    case X_WSA_ERROR::X_WSAECANCELLED:
+    case X_WSA_ERROR::X_WSASYSCALLFAILURE:
+    case X_WSA_ERROR::X_WSAHOST_NOT_FOUND:
+    case X_WSA_ERROR::X_WSATRY_AGAIN:
+    case X_WSA_ERROR::X_WSANO_DATA:
+      return true;
+      break;
+    default:
+      XELOGE("Unsupported X_WSA_ERROR: {}", static_cast<uint32_t>(wsa_error));
+      break;
+  }
+
+  return false;
+}
+
+uint32_t XSocket::XWSAGetLastError() {
 #ifdef XE_PLATFORM_WIN32
-  return WSAGetLastError();
+  const uint32_t last_error = WSAGetLastError();
+
+  bool known = XWSAIsKnownError(static_cast<X_WSA_ERROR>(last_error));
+
+  return last_error;
 #endif
   return errno;
 }
 
-void XSocket::SetLastWSAError(X_WSAError error) const {
+void XSocket::XWSASetLastError(X_WSA_ERROR error) const {
+  bool known = XWSAIsKnownError(error);
+
 #ifdef XE_PLATFORM_WIN32
   WSASetLastError((int)error);
 #endif

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -97,25 +97,31 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
 }
 
 X_STATUS XSocket::Close() {
-  std::unique_lock lock(receive_mutex_);
-  if (active_overlapped_ && !(active_overlapped_->offset_high & 1)) {
-    active_overlapped_->offset_high |= 2;
-  }
-  lock.unlock();
+  XELOGI("Socket closing!");
 
+  // Cancel overlap tasks if running
+  if (polling_task_.valid()) {
+    cancel_overlapped_ = true;
+  }
+
+  // Wait for PollWSARecvFrom to complete before closing
   std::unique_lock socket_lock(receive_socket_mutex_);
+
+  int ret = 0;
+
 #if XE_PLATFORM_WIN32
-  int ret = closesocket(native_handle_);
+  ret = closesocket(native_handle_);
 #else
-  int ret = close(native_handle_);
+  ret = close(native_handle_);
 #endif
-  socket_lock.unlock();
 
   if (ret != 0) {
     return X_STATUS_UNSUCCESSFUL;
   }
 
   socket_closed_ = true;
+
+  // pending_overlapped_io_.clear();
 
   return X_STATUS_SUCCESS;
 }
@@ -227,6 +233,7 @@ X_STATUS XSocket::IOControl(uint32_t cmd, uint32_t* arg_ptr) {
     // TODO: Get last error
     return X_STATUS_UNSUCCESSFUL;
   }
+
   return X_STATUS_SUCCESS;
 #else
   int native_cmd = cmd;
@@ -411,145 +418,218 @@ int XSocket::RecvFrom(uint8_t* buf, uint32_t buf_len, uint32_t flags,
   return ret;
 }
 
-struct WSARecvFromData {
-  XWSABUF* buffers;
-  uint32_t num_buffers;
-  uint32_t flags;
-  XSOCKADDR_IN* from;
-  xe::be<uint32_t>* from_len;
-  XWSAOVERLAPPED* overlapped;
-};
+int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
+                       xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
+                       XSOCKADDR_IN* to_ptr, uint32_t to_len,
+                       XWSAOVERLAPPED* overlapped_ptr) {
+  if (!buffers || !num_buffers || !num_bytes_sent_ptr || flags ||
+      to_ptr && (to_len < sizeof(XSOCKADDR_IN) ||
+                 to_ptr->address_family != X_AF_INET)) {
+    SetLastWSAError(X_WSAError::X_WSA_INVALID_PARAMETER);
+    return -1;
+  }
+
+  if (overlapped_ptr) {
+    pending_overlapped_io_.insert(overlapped_ptr);
+  }
+
+  std::vector<uint8_t> combined_buffer_mem;
+  uint32_t combined_buffer_size = 0;
+  uint32_t combined_buffer_offset = 0;
+  for (uint32_t i = 0; i < num_buffers; i++) {
+    combined_buffer_size += buffers[i].len;
+    combined_buffer_mem.resize(combined_buffer_size);
+    uint8_t* combined_buffer = combined_buffer_mem.data();
+
+    std::memcpy(combined_buffer + combined_buffer_offset,
+                kernel_memory()->TranslateVirtual(buffers[i].buf_ptr),
+                buffers[i].len);
+    combined_buffer_offset += buffers[i].len;
+  }
+
+  int result = SendTo(combined_buffer_mem.data(), combined_buffer_size, flags,
+                      to_ptr, to_len);
+
+  if (result == -1) {
+    uint32_t error = WSAGetLastError();
+
+    if (error == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+      XELOGI("{} is pending...", __func__);
+      SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
+    } else {
+      XELOGE("{} failed with error {}", __func__, error);
+      SetLastWSAError((X_WSAError)error);
+    }
+  } else {
+    if (overlapped_ptr) {
+      // Hack
+      overlapped_ptr->offset_high = 1;
+      overlapped_ptr->internal = result;
+
+      if (overlapped_ptr->event_handle) {
+        xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
+      }
+    }
+
+    if (num_bytes_sent_ptr) {
+      *num_bytes_sent_ptr = result;
+    }
+  }
+
+  // Immediately complete overlapped
+  return 0;
+}
+
+// If wait is true then block until data is available for writing
+int XSocket::WSAPollWrite(bool wait, X_WSAError* error) {
+  WSAPOLLFD fds = {};
+  fds.fd = native_handle_;
+  fds.events = POLLOUT;
+
+  int activity = 0;
+
+  do {
+    activity = WSAPoll(&fds, 1, wait ? 1000 : 0);
+
+    if (cancel_overlapped_) {
+      if (error) {
+        *error = X_WSAError::X_WSA_OPERATION_ABORTED;
+        activity = -1;
+      }
+    }
+
+    // if (wait) {
+    //   XELOGI("{} Blocking...", __func__);
+    // }
+  } while (activity == 0 && wait);
+
+  return activity;
+}
+
+// If wait is true then block until data is available for reading
+int XSocket::WSAPollRead(bool wait, X_WSAError* error) {
+  WSAPOLLFD fds = {};
+  fds.fd = native_handle_;
+  fds.events = POLLIN;
+
+  int activity = 0;
+
+  do {
+    activity = WSAPoll(&fds, 1, wait ? 1000 : 0);
+
+    if (cancel_overlapped_) {
+      if (error) {
+        *error = X_WSAError::X_WSA_OPERATION_ABORTED;
+        activity = -1;
+      }
+    }
+
+    // if (wait) {
+    //   XELOGI("{} Blocking...", __func__);
+    // }
+  } while (activity == 0 && wait);
+
+  return activity;
+}
 
 int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
-  receive_async_data.overlapped->internal_high = 0;
-
-  struct pollfd fds[1];
-  fds->fd = native_handle_;
-  fds->events = POLLIN;
-
-  DWORD bytes_received = 0;
-  DWORD flags = receive_async_data.flags;
-  auto buffers = new WSABUF[receive_async_data.num_buffers];
-
-  int ret;
-  do {
-#ifdef XE_PLATFORM_WIN32
-    ret = WSAPoll(fds, 1, wait ? 1000 : 0);
-#else
-    ret = poll(fds, 1, wait ? 1000 : 0);
-#endif
-
-    if (receive_async_data.overlapped->offset_high & 2) {
-      receive_async_data.overlapped->internal_high =
-          (uint32_t)X_WSAError::X_WSA_OPERATION_ABORTED;
-      ret = -1;
-      goto threadexit;
-    }
-  } while (ret == 0 && wait);
-
-  if (ret < 0) {
-    receive_async_data.overlapped->internal_high = WSAGetLastError();
-    XELOGE("XSocket receive thread failed polling with error {}",
-           static_cast<uint32_t>(receive_async_data.overlapped->internal_high));
-    goto threadexit;
-  } else if (ret == 0) {
+  if (wait) {
     receive_async_data.overlapped->internal_high =
         (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
-    ret = -1;
-    goto threadexit;
   }
 
-#ifdef XE_PLATFORM_WIN32
-  for (auto i = 0u; i < receive_async_data.num_buffers; i++) {
-    buffers[i].len = receive_async_data.buffers[i].len;
-    buffers[i].buf =
-        reinterpret_cast<CHAR*>(kernel_state()->memory()->TranslateVirtual(
-            receive_async_data.buffers[i].buf_ptr));
-  }
+  X_WSAError poll_read_error = X_WSAError::X_WSA_NO_ERROR;
 
-  {
-    std::unique_lock socket_lock(receive_socket_mutex_);
+  int result = WSAPollRead(wait, &poll_read_error);
 
-    sockaddr* sa = nullptr;
-    if (receive_async_data.from) {
-      sockaddr addr = receive_async_data.from->to_host();
-      sa = const_cast<sockaddr*>(&addr);
-    }
+  if (result == -1) {
+    // Checking for available data for reading failed.
+    uint32_t error = 0;
 
-    ret = ::WSARecvFrom(native_handle_, buffers, receive_async_data.num_buffers,
-                        &bytes_received, &flags, sa,
-                        (LPINT)receive_async_data.from_len, nullptr, nullptr);
-    if (ret < 0) {
-      receive_async_data.overlapped->internal_high = GetLastWSAError();
+    if (poll_read_error != X_WSAError::X_WSA_NO_ERROR) {
+      error = (uint32_t)poll_read_error;
     } else {
-      receive_async_data.overlapped->internal = bytes_received;
+      error = WSAGetLastError();
     }
-    receive_async_data.from->to_guest(sa);
-    socket_lock.unlock();
+
+    receive_async_data.overlapped->internal_high = error;
+
+    XELOGE("PollRead failed with error {}", error);
+
+    std::unique_lock lock(receive_completion_mutex_);
+    receive_cv_.notify_all();
+    return -1;
+  } else if (result == 0) {
+    // There's no available data for reading therefore would block.
+    receive_async_data.overlapped->internal_high =
+        (uint32_t)X_WSAError::X_WSAEWOULDBLOCK;
+
+    std::unique_lock lock(receive_completion_mutex_);
+    receive_cv_.notify_all();
+    return -1;
   }
 
-  receive_async_data.overlapped->offset = flags;
-#else
-  auto buffers = new iovec[receive_async_data.num_buffers];
-  for (auto i = 0u; i < receive_async_data.num_buffers; i++) {
-    buffers[i].iov_len = receive_async_data.buffers[i].len;
-    buffers[i].iov_base = kernel_state()->memory()->TranslateVirtual(
-        receive_async_data.buffers[i].buf_ptr);
-  }
+  // critical section - lock until we return
+  std::unique_lock<std::mutex> socket_lock;
 
-  msghdr msg;
-  std::memset(&msg, 0, sizeof(msg));
-  msg.msg_name = &n_from;
-  msg.msg_namelen = n_from_len;
-  msg.msg_iov = buffers;
-  msg.msg_iovlen = receive_async_data.num_buffers;
-
-  {
-    std::unique_lock socket_lock(receive_socket_mutex_);
-    ret = recvmsg(native_handle_, &msg, receive_async_data.flags);
-    if (ret < 0) {
-      receive_async_data.overlapped->internal_high = GetLastWSAError();
-    } else {
-      receive_async_data.overlapped->internal = ret;
-    }
-    socket_lock.unlock();
-  }
-
-  flags = 0;
-  // MSG_PARTIAL Doesn't exist on linux?
-  if (msg.msg_flags & MSG_TRUNC) {
-    flags |= MSG_PARTIAL;
-  }
-  if (msg.msg_flags & MSG_OOB) {
-    flags |= MSG_OOB;
-  }
-  receive_async_data.overlapped->offset = flags;
-
-  if (ret >= 0) {
-    SetLastWSAError((X_WSAError)0);
-    ret = 0;
-  }
-#endif
-  delete[] buffers;
-
-threadexit:
-  std::unique_lock lock(receive_mutex_);
   if (wait) {
-    delete[] receive_async_data.buffers;
+    socket_lock = std::unique_lock(receive_socket_mutex_);
   }
 
-  receive_async_data.overlapped->offset_high |= 1;
+  WSABUF recv_buffer = {};
 
-  if (wait && receive_async_data.overlapped->event_handle) {
-    xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
-                           nullptr);
+  recv_buffer.buf = kernel_state()->memory()->TranslateVirtual<CHAR*>(
+      receive_async_data.buffers->buf_ptr);
+  recv_buffer.len = receive_async_data.buffers->len;
+
+  sockaddr* saddr = nullptr;
+
+  if (receive_async_data.from) {
+    saddr = new sockaddr();
   }
+
+  DWORD bytes_received = 0;
+  DWORD flags = 0;
+
+  result =
+      ::WSARecvFrom(native_handle_, &recv_buffer,
+                    receive_async_data.num_buffers, &bytes_received, &flags,
+                    saddr, &receive_async_data.from_len, nullptr, nullptr);
+
+  if (saddr) {
+    receive_async_data.from->to_guest(saddr);
+    delete saddr;
+  }
+
+  if (result == -1) {
+    XELOGI("WSARecvFrom failed with error {}", GetLastWSAError());
+
+    receive_async_data.overlapped->internal_high = GetLastWSAError();
+  } else if (result == 0) {
+    receive_async_data.overlapped->internal_high = 0;
+    receive_async_data.overlapped->internal = bytes_received;
+
+    *receive_async_data.num_bytes_recv = bytes_received;
+
+    if (wait) {
+      if (receive_async_data.overlapped->event_handle) {
+        xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
+                               nullptr);
+      }
+    }
+  }
+
+  *receive_async_data.flags = flags;
+
+  receive_async_data.overlapped->offset = flags;
 
   receive_cv_.notify_all();
-  lock.unlock();
 
-  return ret;
+  return result;
 }
+
+uint32_t flags = 0;
+uint32_t bytes_recv = 0;
 
 int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                          xe::be<uint32_t>* num_bytes_recv_ptr,
@@ -565,64 +645,100 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   // We would however need find a way to call the completion callback without
   // relying on the caller to set the "alertable" flag to true when waiting. We
   // also need to do our own async handling anyway for Linux so we might as well
-  // make the code paths the same to improve symmetry in behaviour.
+  // make the code paths the same to improve symmetry in behavior.
 
-  WSARecvFromData receive_async_data;
-  receive_async_data.buffers = buffers;
+  WSARecvFromData receive_async_data = {};
+
+  // These may have been on the stack - copy them.
+  receive_async_data.buffers = std::make_shared<XWSABUF>();
+  std::memcpy(receive_async_data.buffers.get(), buffers, sizeof(XWSABUF));
+
   receive_async_data.num_buffers = num_buffers;
-  receive_async_data.flags = *flags_ptr;
+  receive_async_data.flags = &flags;
+  receive_async_data.num_bytes_recv = &bytes_recv;
   receive_async_data.from = from_ptr;
-  receive_async_data.from_len = fromlen_ptr;
+  receive_async_data.from_len = *fromlen_ptr;
 
-  XWSAOVERLAPPED tmp_overlapped;
-  std::memset(&tmp_overlapped, 0, sizeof(tmp_overlapped));
+  if (!overlapped_ptr) {
+    XELOGI("{}:: without overlapped_ptr!", __func__);
+  }
+
+  // Wait for PollWSARecvFrom to finish writing to overlapped_ptr
+  std::unique_lock socket_lock = std::unique_lock(receive_socket_mutex_);
+
+  XWSAOVERLAPPED tmp_overlapped = {};
   receive_async_data.overlapped =
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
 
-  int ret = PollWSARecvFrom(false, receive_async_data);
-
-  if (ret < 0) {
-    auto wsa_error = receive_async_data.overlapped->internal_high.get();
-    SetLastWSAError((X_WSAError)wsa_error);
-
-    if (overlapped_ptr && wsa_error == (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
-      receive_mutex_.lock();
-
-      if (!active_overlapped_ || active_overlapped_->offset_high & 1) {
-        // These may have been on the stack - copy them.
-        receive_async_data.buffers = new XWSABUF[num_buffers];
-        std::memcpy(receive_async_data.buffers, buffers,
-                    num_buffers * sizeof(XWSABUF));
-
-        overlapped_ptr->offset_high = 0;
-        if (overlapped_ptr->event_handle) {
-          xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
-        }
-        active_overlapped_ = overlapped_ptr;
-
-        if (!polling_task_.valid()) {
-          polling_task_ =
-              std::async(std::launch::async, &XSocket::PollWSARecvFrom, this,
-                         true, receive_async_data);
-        } else {
-          auto status = polling_task_.wait_for(0ms);
-          if (status == std::future_status::ready) {
-            auto result = polling_task_.get();
-          }
-        }
-        SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
-      }
-
-      receive_mutex_.unlock();
-    }
-  } else {
-    if (num_bytes_recv_ptr) {
-      *num_bytes_recv_ptr = receive_async_data.overlapped->internal;
-    }
-    *flags_ptr = receive_async_data.overlapped->offset;
+  if (overlapped_ptr) {
+    pending_overlapped_io_.insert(receive_async_data.overlapped);
   }
 
-  return ret;
+  // Check for immediate completion, otherwise perform overlapped completion
+  uint32_t result = PollWSARecvFrom(false, receive_async_data);
+
+  if (result == 0) {
+    XELOGI("{} completed immediately", __func__);
+
+    if (num_bytes_recv_ptr) {
+      *num_bytes_recv_ptr = *receive_async_data.num_bytes_recv;
+    }
+
+    *flags_ptr = *receive_async_data.flags;
+
+    return result;
+  }
+
+  X_WSAError wsa_error =
+      (X_WSAError)receive_async_data.overlapped->internal_high.get();
+
+  if (!overlapped_ptr && wsa_error == X_WSAError::X_WSAEWOULDBLOCK) {
+    SetLastWSAError(X_WSAError::X_WSAEWOULDBLOCK);
+    return result;
+  }
+
+  SetLastWSAError(wsa_error);
+
+  if (overlapped_ptr && wsa_error == X_WSAError::X_WSAEWOULDBLOCK) {
+    if (!polling_task_.valid()) {
+      if (overlapped_ptr->event_handle) {
+        xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
+      }
+
+      polling_task_ = std::async(std::launch::async, &XSocket::PollWSARecvFrom,
+                                 this, true, receive_async_data);
+    } else {
+      std::future_status status = polling_task_.wait_for(0ms);
+
+      if (status == std::future_status::ready) {
+        uint32_t result = polling_task_.get();
+
+        uint32_t error_code = GetLastWSAError();
+
+        if (error_code != (uint32_t)X_WSAError::X_WSAEWOULDBLOCK) {
+          XELOGI("{} Async:: failed with error code {}", __func__, error_code);
+        }
+      }
+    }
+
+    SetLastWSAError(X_WSAError::X_WSA_IO_PENDING);
+  } else {
+    // An error occurred that's not X_WSAEWOULDBLOCK
+    XELOGI("{}:: failed!", __func__);
+
+    // Check WSA error is not corrupted!
+    if (wsa_error !=
+        (X_WSAError)receive_async_data.overlapped->internal_high.get()) {
+      XELOGI("{}:: Overlapped Corruption!!", __func__);
+    }
+
+    if (wsa_error == X_WSAError::X_WSA_OPERATION_ABORTED) {
+      XELOGI("{}:: Operation Aborted!", __func__);
+      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+    }
+  }
+
+  return result;
 }
 
 bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
@@ -633,28 +749,89 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return false;
   }
 
-  std::unique_lock lock(receive_mutex_);
-  if (!(overlapped_ptr->offset_high & 1)) {
-    if (wait) {
-      receive_cv_.wait(lock);
-    } else {
+  if (!pending_overlapped_io_.contains(overlapped_ptr)) {
+    XELOGI("Overlap not in operation!");
+
+    *bytes_transferred = 0;
+    *flags_ptr = 0;
+
+    return true;
+  }
+
+  if (wait) {
+    std::unique_lock lock(receive_completion_mutex_);
+
+    XELOGI("{}:: Blocking until completion!", __func__);
+    receive_cv_.wait(lock);
+  }
+
+  X_WSAError wsa_error = (X_WSAError)overlapped_ptr->internal_high.get();
+
+  switch (wsa_error) {
+    case X_WSAError::X_WSA_OPERATION_ABORTED: {
+      XELOGI("{}:: Operation Aborted!", __func__);
+      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+      return false;
+    } break;
+    case X_WSAError::X_WSAECANCELLED: {
+      XELOGI("{}:: Operation Cancelled!", __func__);
+      SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+      return false;
+    } break;
+    case X_WSAError::X_WSAEWOULDBLOCK: {
+      SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
+      return false;
+    } break;
+    default:
+      break;
+  }
+
+  if (overlapped_ptr->offset_high == 1) {
+    XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
+           overlapped_ptr->internal.get(), overlapped_ptr->internal_high.get());
+  } else {
+    XELOGI("{}:: WSARecvFrom bytes received {} with status {}!", __func__,
+           overlapped_ptr->internal.get(), overlapped_ptr->internal_high.get());
+  }
+
+  if (static_cast<uint32_t>(wsa_error) == 0) {
+    if (overlapped_ptr->internal == 0) {
+      XELOGI("{}:: bytes sent 0!", __func__);
       SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
       return false;
     }
-  }
 
-  if (overlapped_ptr->internal_high != 0) {
-    SetLastWSAError((X_WSAError)overlapped_ptr->internal_high.get());
-    active_overlapped_ = nullptr;
+    *bytes_transferred = overlapped_ptr->internal;
+    *flags_ptr = overlapped_ptr->offset;
+  } else {
+    XELOGI("{}:: failed with error code {}", __func__,
+           overlapped_ptr->internal_high.get());
+
+    SetLastWSAError(X_WSAError::X_WSA_IO_INCOMPLETE);
     return false;
   }
 
-  *bytes_transferred = overlapped_ptr->internal;
-  *flags_ptr = overlapped_ptr->offset;
-
-  active_overlapped_ = nullptr;
-
   return true;
+}
+
+int XSocket::WSACancelOverlappedIO() {
+  if (polling_task_.valid()) {
+    cancel_overlapped_ = true;
+  }
+
+  for (auto& overlapped_ptr : pending_overlapped_io_) {
+    if (overlapped_ptr->event_handle) {
+      xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
+    }
+
+    overlapped_ptr->internal_high = (uint32_t)X_WSAError::X_WSAECANCELLED;
+  }
+
+  pending_overlapped_io_.clear();
+
+  SetLastWSAError(X_WSAError::X_WSAECANCELLED);
+
+  return 0;
 }
 
 int XSocket::Send(const uint8_t* buf, uint32_t buf_len, uint32_t flags) {

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -105,12 +105,12 @@ X_STATUS XSocket::Close() {
 
     // Wait for PollWSARecvFrom to return before closing
     if (receive_polling_task_.valid()) {
-      std::unique_lock receive_lock(receive_socket_mutex_);
+      receive_polling_task_.wait();
     }
 
     // Wait for PollWSAWSASend to return before closing
     if (send_polling_task_.valid()) {
-      std::unique_lock send_lock(send_socket_mutex_);
+      send_polling_task_.wait();
     }
   }
 
@@ -458,9 +458,6 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
   if (wait) {
     // Sync is already locked, therefore only lock for async
     lock = std::unique_lock(send_socket_mutex_);
-
-    send_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
   }
 
   // Unlock while WSAPoll is blocking
@@ -491,16 +488,12 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
 
     XELOGE("WSAPollWrite failed with error {}", error);
 
-    std::unique_lock lock(send_completion_mutex_);
-    send_cv_.notify_all();
     return X_SOCKET_ERROR;
   } else if (result == 0) {
     // There's no available data for reading therefore would block.
     send_async_data.overlapped->internal =
         static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
 
-    std::unique_lock lock(send_completion_mutex_);
-    send_cv_.notify_all();
     return X_SOCKET_ERROR;
   }
 
@@ -560,13 +553,11 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
     send_async_data.overlapped->internal_high = bytes_sent;
 
     *send_async_data.num_bytes_sent = bytes_sent;
+
+    xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
   }
 
   send_async_data.overlapped->offset = 0;
-
-  xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
-
-  send_cv_.notify_all();
 
   return result;
 }
@@ -595,9 +586,6 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   send_async_data.num_bytes_sent = &WSASendTo_bytes_sent;
   send_async_data.to = to_ptr;
   send_async_data.to_len = to_len;
-
-  // Wait for PollWSASendTo to finish writing to overlapped_ptr
-  std::unique_lock socket_lock = std::unique_lock(send_socket_mutex_);
 
   XWSAOVERLAPPED tmp_overlapped = {};
   send_async_data.overlapped =
@@ -629,9 +617,6 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     if (!send_polling_task_.valid()) {
-      // Not needed?
-      // xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
-
       send_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
                      send_async_data);
@@ -704,9 +689,6 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   if (wait) {
     // Sync is already locked, therefore only lock for async
     lock = std::unique_lock(receive_socket_mutex_);
-
-    receive_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
   }
 
   // Unlock while WSAPoll is blocking
@@ -737,16 +719,12 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
 
     XELOGE("WSAPollRead failed with error {}", error);
 
-    std::unique_lock lock(receive_completion_mutex_);
-    receive_cv_.notify_all();
     return X_SOCKET_ERROR;
   } else if (result == 0) {
     // There's no available data for reading therefore would block.
     receive_async_data.overlapped->internal =
         static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
 
-    std::unique_lock lock(receive_completion_mutex_);
-    receive_cv_.notify_all();
     return X_SOCKET_ERROR;
   }
 
@@ -797,15 +775,14 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
     receive_async_data.overlapped->internal_high = bytes_received;
 
     *receive_async_data.num_bytes_recv = bytes_received;
+
+    xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
+                           nullptr);
   }
 
   *receive_async_data.flags = flags;
 
   receive_async_data.overlapped->offset = flags;
-
-  xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle, nullptr);
-
-  receive_cv_.notify_all();
 
   return result;
 }
@@ -841,9 +818,6 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   receive_async_data.from = from_ptr;
   receive_async_data.from_len = *fromlen_ptr;
 
-  // Wait for PollWSARecvFrom to finish writing to overlapped_ptr
-  std::unique_lock socket_lock = std::unique_lock(receive_socket_mutex_);
-
   XWSAOVERLAPPED tmp_overlapped = {};
   receive_async_data.overlapped =
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
@@ -876,9 +850,6 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     if (!receive_polling_task_.valid()) {
-      // Not needed?
-      // xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
-
       receive_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
                      receive_async_data);
@@ -951,15 +922,15 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
 
   if (wait) {
     if (io_type) {
-      std::unique_lock lock(send_completion_mutex_);
-
       XELOGI("{}:: WSASendTo blocking until completion!", __func__);
-      send_cv_.wait(lock);
+      if (send_polling_task_.valid()) {
+        send_polling_task_.wait();
+      }
     } else {
-      std::unique_lock lock(receive_completion_mutex_);
-
       XELOGI("{}:: WSARecvFrom Blocking until completion!", __func__);
-      receive_cv_.wait(lock);
+      if (receive_polling_task_.valid()) {
+        receive_polling_task_.wait();
+      }
     }
   }
 
@@ -998,6 +969,8 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
       *bytes_transferred = overlapped_ptr->internal_high;
       *flags_ptr = overlapped_ptr->offset;
 
+      xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
+
       return true;
     } break;
     case X_WSA_ERROR::X_WSA_OPERATION_ABORTED: {
@@ -1024,12 +997,12 @@ int XSocket::WSACancelOverlappedIO() {
 
     // Wait for PollWSARecvFrom to cancel
     if (receive_polling_task_.valid()) {
-      std::unique_lock receive_lock(receive_socket_mutex_);
+      receive_polling_task_.wait();
     }
 
     // Wait for PollWSAWSASend to cancel
     if (send_polling_task_.valid()) {
-      std::unique_lock send_lock(send_socket_mutex_);
+      send_polling_task_.wait();
     }
   }
 

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -550,7 +550,10 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
       XELOGI("WSASendTo failed with error {}", XWSAGetLastError());
     }
 
+    // send_async_data.overlapped->internal =
+    //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
     send_async_data.overlapped->internal = XWSAGetLastError();
+    // send_async_data.overlapped->internal_high = buffers[0].len;
   } else if (result == 0) {
     send_async_data.overlapped->internal =
         static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
@@ -559,11 +562,9 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
     *send_async_data.num_bytes_sent = bytes_sent;
   }
 
-  if (wait) {
-    if (send_async_data.overlapped->event_handle) {
-      xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
-    }
-  }
+  send_async_data.overlapped->offset = 0;
+
+  xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
 
   send_cv_.notify_all();
 
@@ -595,10 +596,6 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   send_async_data.to = to_ptr;
   send_async_data.to_len = to_len;
 
-  if (!overlapped_ptr) {
-    XELOGD("{}:: without overlapped_ptr!", __func__);
-  }
-
   // Wait for PollWSASendTo to finish writing to overlapped_ptr
   std::unique_lock socket_lock = std::unique_lock(send_socket_mutex_);
 
@@ -628,18 +625,12 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
   X_WSA_ERROR wsa_error =
       (X_WSA_ERROR)send_async_data.overlapped->internal.get();
 
-  if (!overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-    XWSASetLastError(X_WSA_ERROR::X_WSAEWOULDBLOCK);
-    return result;
-  }
-
   XWSASetLastError(wsa_error);
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     if (!send_polling_task_.valid()) {
-      if (overlapped_ptr->event_handle) {
-        xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
-      }
+      // Not needed?
+      // xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
 
       send_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
@@ -691,7 +682,7 @@ int XSocket::WSAPollRead(bool wait, X_WSA_ERROR* error) {
 
     if (cancel_overlapped_) {
       if (error) {
-        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
+        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;  // X_WSAECANCELLED?
         activity = X_SOCKET_ERROR;
       }
     }
@@ -765,23 +756,29 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
       receive_async_data.buffers->buf_ptr);
   recv_buffer.len = receive_async_data.buffers->len;
 
-  sockaddr* saddr = nullptr;
+  sockaddr saddr = {};
 
   if (receive_async_data.from) {
-    saddr = new sockaddr();
+    saddr = receive_async_data.from->to_host();
   }
 
   DWORD bytes_received = 0;
   DWORD flags = 0;
 
-  result =
-      ::WSARecvFrom(native_handle_, &recv_buffer,
-                    receive_async_data.num_buffers, &bytes_received, &flags,
-                    saddr, &receive_async_data.from_len, nullptr, nullptr);
+  result = ::WSARecvFrom(native_handle_, &recv_buffer,
+                         receive_async_data.num_buffers, &bytes_received,
+                         &flags, receive_async_data.from ? &saddr : nullptr,
+                         &receive_async_data.from_len, nullptr, nullptr);
 
-  if (saddr) {
-    receive_async_data.from->to_guest(saddr);
-    delete saddr;
+  if (receive_async_data.from) {
+    // Copy behavior from recvfrom.
+    // Verified on console.
+    if (proto_ == X_IPPROTO_TCP) {
+      socklen_t peer_addar_len = sizeof(sockaddr);
+      getpeername(native_handle_, &saddr, &peer_addar_len);
+    }
+
+    receive_async_data.from->to_guest(&saddr);
   }
 
   if (result == X_SOCKET_ERROR) {
@@ -790,7 +787,10 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
       XELOGI("WSARecvFrom failed with error {}", XWSAGetLastError());
     }
 
+    // X_STATUS_PENDING?
     receive_async_data.overlapped->internal = XWSAGetLastError();
+    // receive_async_data.overlapped->internal =
+    //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
   } else if (result == 0) {
     receive_async_data.overlapped->internal =
         static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
@@ -803,12 +803,7 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
 
   receive_async_data.overlapped->offset = flags;
 
-  if (wait) {
-    if (receive_async_data.overlapped->event_handle) {
-      xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
-                             nullptr);
-    }
-  }
+  xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle, nullptr);
 
   receive_cv_.notify_all();
 
@@ -846,10 +841,6 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   receive_async_data.from = from_ptr;
   receive_async_data.from_len = *fromlen_ptr;
 
-  if (!overlapped_ptr) {
-    XELOGD("{}:: without overlapped_ptr!", __func__);
-  }
-
   // Wait for PollWSARecvFrom to finish writing to overlapped_ptr
   std::unique_lock socket_lock = std::unique_lock(receive_socket_mutex_);
 
@@ -881,18 +872,12 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   X_WSA_ERROR wsa_error =
       (X_WSA_ERROR)receive_async_data.overlapped->internal.get();
 
-  if (!overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-    XWSASetLastError(X_WSA_ERROR::X_WSAEWOULDBLOCK);
-    return result;
-  }
-
   XWSASetLastError(wsa_error);
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
     if (!receive_polling_task_.valid()) {
-      if (overlapped_ptr->event_handle) {
-        xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
-      }
+      // Not needed?
+      // xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
 
       receive_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
@@ -940,13 +925,24 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return false;
   }
 
-  // Win32 returns true in such case so we can assume and copy this behavior.
+  const uint32_t overlapped_address =
+      kernel_state()->memory()->HostToGuestVirtual(
+          std::to_address(overlapped_ptr));
+
+  if (cancelled_overlapped_io_.contains(overlapped_address)) {
+    XELOGD("{}:: Operation Cancelled!", __func__);
+    X_WSA_ERROR internal_result =
+        X_WSA_ERROR(X_WIN32_FROM_HRESULT(overlapped_ptr->internal.get()));
+    XWSASetLastError(internal_result);
+    return false;
+  }
+
   // 4D530808 does this.
   if (!pending_overlapped_io_.contains(overlapped_ptr)) {
     XELOGI("Overlap not in operation!");
 
-    *bytes_transferred = 0;
-    *flags_ptr = 0;
+    *bytes_transferred = overlapped_ptr->internal_high;
+    *flags_ptr = overlapped_ptr->offset;
 
     return true;
   }
@@ -967,58 +963,59 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     }
   }
 
-  X_WSA_ERROR wsa_error = (X_WSA_ERROR)overlapped_ptr->internal.get();
+  // Read result after wait is completed if any.
+  X_WSA_ERROR internal_result =
+      X_WSA_ERROR(X_WIN32_FROM_HRESULT(overlapped_ptr->internal.get()));
 
-  switch (wsa_error) {
+  bool valid_hresult =
+      X_HRESULT_FACILITY(overlapped_ptr->internal.get()) == X_FACILITY_WIN32;
+
+  // If result is invalid HRESULT then recover it.
+  // if (!valid_hresult) {
+  //   internal_result = X_WSA_ERROR(XThread::GetLastError());
+  // }
+
+  switch (internal_result) {
+    case X_WSA_ERROR::X_WSA_NO_ERROR: {
+      if (cvars::logging) {
+        if (io_type) {
+          XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
+                 overlapped_ptr->internal_high.get(),
+                 overlapped_ptr->internal.get());
+        } else {
+          XELOGI("{}:: WSARecvFrom bytes received {} with status {}!", __func__,
+                 overlapped_ptr->internal_high.get(),
+                 overlapped_ptr->internal.get());
+        }
+      }
+
+      if (overlapped_ptr->internal_high == 0) {
+        XELOGI("{}:: 0 bytes sent!", __func__);
+        XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
+        return false;
+      }
+
+      *bytes_transferred = overlapped_ptr->internal_high;
+      *flags_ptr = overlapped_ptr->offset;
+
+      return true;
+    } break;
     case X_WSA_ERROR::X_WSA_OPERATION_ABORTED: {
       XELOGD("{}:: Operation Aborted!", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
-      return false;
-    } break;
-    case X_WSA_ERROR::X_WSAECANCELLED: {
-      XELOGD("{}:: Operation Cancelled!", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
-      return false;
+      XWSASetLastError(internal_result);
     } break;
     case X_WSA_ERROR::X_WSAEWOULDBLOCK: {
       XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
-      return false;
     } break;
-    default:
+    default: {
+      XWSASetLastError(internal_result);
+      XELOGI("{}:: failed with error code {}", __func__,
+             overlapped_ptr->internal.get());
       break;
-  }
-
-  if (cvars::logging) {
-    if (io_type) {
-      XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
-             overlapped_ptr->internal_high.get(),
-             overlapped_ptr->internal.get());
-    } else {
-      XELOGI("{}:: WSARecvFrom bytes received {} with status {}!", __func__,
-             overlapped_ptr->internal_high.get(),
-             overlapped_ptr->internal.get());
     }
   }
 
-  if (static_cast<uint32_t>(wsa_error) == 0) {
-    if (overlapped_ptr->internal_high == 0) {
-      XELOGI("{}:: 0 bytes sent!", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
-      return false;
-    }
-
-    *bytes_transferred = overlapped_ptr->internal_high;
-    *flags_ptr = overlapped_ptr->offset;
-  } else {
-    XELOGI("{}:: failed with error code {}", __func__,
-           overlapped_ptr->internal.get());
-
-    // What error should be set here?
-    XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
-    return false;
-  }
-
-  return true;
+  return false;
 }
 
 int XSocket::WSACancelOverlappedIO() {
@@ -1037,17 +1034,21 @@ int XSocket::WSACancelOverlappedIO() {
   }
 
   for (auto& [overlapped_ptr, type] : pending_overlapped_io_) {
-    if (overlapped_ptr->event_handle) {
-      xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
-    }
+    xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
 
     overlapped_ptr->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSAECANCELLED);
+        X_HRESULT_FROM_WIN32(uint32_t(X_WSA_ERROR::X_WSAECANCELLED));
+
+    const uint32_t overlapped_address =
+        kernel_state()->memory()->HostToGuestVirtual(
+            std::to_address(overlapped_ptr));
+
+    cancelled_overlapped_io_.insert(overlapped_address);
   }
 
   pending_overlapped_io_.clear();
 
-  XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
+  XWSASetLastError(X_WSA_ERROR::X_WSA_NO_ERROR);
 
   return 0;
 }
@@ -1187,14 +1188,17 @@ bool XSocket::XWSAIsKnownError(X_WSA_ERROR wsa_error) {
 }
 
 uint32_t XSocket::XWSAGetLastError() {
+  uint32_t last_error = 0;
+
 #ifdef XE_PLATFORM_WIN32
-  const uint32_t last_error = WSAGetLastError();
+  last_error = WSAGetLastError();
+#else
+  last_error = errno;
+#endif
 
   bool known = XWSAIsKnownError(static_cast<X_WSA_ERROR>(last_error));
 
   return last_error;
-#endif
-  return errno;
 }
 
 void XSocket::XWSASetLastError(X_WSA_ERROR error) const {

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -100,12 +100,19 @@ X_STATUS XSocket::Initialize(AddressFamily af, Type type, Protocol proto) {
 
 X_STATUS XSocket::Close() {
   // Cancel overlap tasks if running
-  if (polling_task_.valid()) {
+  if (receive_polling_task_.valid() || send_polling_task_.valid()) {
     cancel_overlapped_ = true;
-  }
 
-  // Wait for PollWSARecvFrom to complete before closing
-  std::unique_lock socket_lock(receive_socket_mutex_);
+    // Wait for PollWSARecvFrom to return before closing
+    if (receive_polling_task_.valid()) {
+      std::unique_lock receive_lock(receive_socket_mutex_);
+    }
+
+    // Wait for PollWSAWSASend to return before closing
+    if (send_polling_task_.valid()) {
+      std::unique_lock send_lock(send_socket_mutex_);
+    }
+  }
 
   int ret = 0;
 
@@ -416,68 +423,6 @@ int XSocket::RecvFrom(uint8_t* buf, uint32_t buf_len, uint32_t flags,
   return ret;
 }
 
-int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
-                       xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
-                       XSOCKADDR_IN* to_ptr, uint32_t to_len,
-                       XWSAOVERLAPPED* overlapped_ptr) {
-  if (!buffers || !num_buffers || !num_bytes_sent_ptr || flags ||
-      to_ptr && (to_len < sizeof(XSOCKADDR_IN) ||
-                 to_ptr->address_family != X_AF_INET)) {
-    XWSASetLastError(X_WSA_ERROR::X_WSA_INVALID_PARAMETER);
-    return X_SOCKET_ERROR;
-  }
-
-  if (overlapped_ptr) {
-    pending_overlapped_io_.insert(overlapped_ptr);
-  }
-
-  std::vector<uint8_t> combined_buffer_mem;
-  uint32_t combined_buffer_size = 0;
-  uint32_t combined_buffer_offset = 0;
-  for (uint32_t i = 0; i < num_buffers; i++) {
-    combined_buffer_size += buffers[i].len;
-    combined_buffer_mem.resize(combined_buffer_size);
-    uint8_t* combined_buffer = combined_buffer_mem.data();
-
-    std::memcpy(combined_buffer + combined_buffer_offset,
-                kernel_memory()->TranslateVirtual(buffers[i].buf_ptr),
-                buffers[i].len);
-    combined_buffer_offset += buffers[i].len;
-  }
-
-  int result = SendTo(combined_buffer_mem.data(), combined_buffer_size, flags,
-                      to_ptr, to_len);
-
-  if (result == X_SOCKET_ERROR) {
-    uint32_t error = XWSAGetLastError();
-
-    if (error == (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-      XELOGI("{} is pending...", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
-    } else {
-      XELOGE("{} failed with error {}", __func__, error);
-      XWSASetLastError((X_WSA_ERROR)error);
-    }
-  } else {
-    if (overlapped_ptr) {
-      // Hack
-      overlapped_ptr->offset_high = 1;
-      overlapped_ptr->internal_high = result;
-
-      if (overlapped_ptr->event_handle) {
-        xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
-      }
-    }
-
-    if (num_bytes_sent_ptr) {
-      *num_bytes_sent_ptr = result;
-    }
-  }
-
-  // Immediately complete overlapped
-  return 0;
-}
-
 // If wait is true then block until data is available for writing
 int XSocket::WSAPollWrite(bool wait, X_WSA_ERROR* error) {
   WSAPOLLFD fds = {};
@@ -504,6 +449,233 @@ int XSocket::WSAPollWrite(bool wait, X_WSA_ERROR* error) {
   } while (activity == 0 && wait);
 
   return activity;
+}
+
+int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
+  // critical section - lock until we return
+  std::unique_lock<std::mutex> lock;
+
+  if (wait) {
+    // Sync is already locked, therefore only lock for async
+    lock = std::unique_lock(send_socket_mutex_);
+
+    send_async_data.overlapped->internal =
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
+  }
+
+  // Unlock while WSAPoll is blocking
+  if (wait) {
+    lock.unlock();
+  }
+
+  X_WSA_ERROR poll_write_error = X_WSA_ERROR::X_WSA_NO_ERROR;
+
+  int result = WSAPollWrite(wait, &poll_write_error);
+
+  // Lock again after WSAPoll returned
+  if (wait) {
+    lock.lock();
+  }
+
+  if (result == X_SOCKET_ERROR) {
+    // Checking for available data for reading failed.
+    uint32_t error = 0;
+
+    if (poll_write_error != X_WSA_ERROR::X_WSA_NO_ERROR) {
+      error = static_cast<uint32_t>(poll_write_error);
+    } else {
+      error = XWSAGetLastError();
+    }
+
+    send_async_data.overlapped->internal = error;
+
+    XELOGE("WSAPollWrite failed with error {}", error);
+
+    std::unique_lock lock(send_completion_mutex_);
+    send_cv_.notify_all();
+    return X_SOCKET_ERROR;
+  } else if (result == 0) {
+    // There's no available data for reading therefore would block.
+    send_async_data.overlapped->internal =
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
+
+    std::unique_lock lock(send_completion_mutex_);
+    send_cv_.notify_all();
+    return X_SOCKET_ERROR;
+  }
+
+  std::unique_ptr<WSABUF[]> buffers(new WSABUF[send_async_data.num_buffers]());
+
+  for (uint32_t i = 0; i < send_async_data.num_buffers; i++) {
+    buffers[i].len = send_async_data.buffers[i].len;
+    buffers[i].buf = kernel_state()->memory()->TranslateVirtual<CHAR*>(
+        send_async_data.buffers[i].buf_ptr);
+  }
+
+  sockaddr saddr = send_async_data.to->to_host();
+  sockaddr_in* addr_in = reinterpret_cast<sockaddr_in*>(&saddr);
+
+  DWORD bytes_sent = 0;
+  DWORD flags = 0;
+
+  const auto upnp = kernel_state()->emulator()->GetUPnP();
+
+  if (upnp) {
+    addr_in->sin_port = upnp->GetMappedBindPort(addr_in->sin_port);
+  }
+
+  // Ensure the bound interface can route to the loopback interface/itself
+  if (cvars::bind_interface) {
+    if (addr_in->sin_addr.s_addr == xe::byte_swap(LOOPBACK)) {
+      const auto network_adapter =
+          kernel_state()->emulator()->GetNetworkAdapterManager();
+
+      addr_in->sin_addr = network_adapter->GetSelectedAdapterLocalIP().sin_addr;
+    }
+  }
+
+  result = ::WSASendTo(native_handle_, buffers.get(),
+                       send_async_data.num_buffers, &bytes_sent, 0, &saddr,
+                       send_async_data.to_len, nullptr, nullptr);
+
+  // Implicit Bind
+  if (!bound_port_) {
+    bound_port_ = GetImplicitlyBoundPort();
+    bound_ = true;
+  }
+
+  if (result == X_SOCKET_ERROR) {
+    if (XWSAGetLastError() !=
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK)) {
+      XELOGI("WSASendTo failed with error {}", XWSAGetLastError());
+    }
+
+    send_async_data.overlapped->internal = XWSAGetLastError();
+  } else if (result == 0) {
+    send_async_data.overlapped->internal =
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
+    send_async_data.overlapped->internal_high = bytes_sent;
+
+    *send_async_data.num_bytes_sent = bytes_sent;
+  }
+
+  if (wait) {
+    if (send_async_data.overlapped->event_handle) {
+      xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
+    }
+  }
+
+  send_cv_.notify_all();
+
+  return result;
+}
+
+uint32_t WSASendTo_bytes_sent = 0;
+
+int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
+                       xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
+                       XSOCKADDR_IN* to_ptr, uint32_t to_len,
+                       XWSAOVERLAPPED* overlapped_ptr) {
+  if (!buffers || !num_buffers || !num_bytes_sent_ptr || flags ||
+      to_ptr && (to_len < sizeof(XSOCKADDR_IN) ||
+                 to_ptr->address_family != X_AF_INET)) {
+    XWSASetLastError(X_WSA_ERROR::X_WSA_INVALID_PARAMETER);
+    return X_SOCKET_ERROR;
+  }
+
+  WSASendToData send_async_data = {};
+
+  // These may have been on the stack - copy them.
+  send_async_data.buffers = std::make_shared<XWSABUF[]>(num_buffers);
+  std::memcpy(send_async_data.buffers.get(), buffers,
+              num_buffers * sizeof(XWSABUF));
+
+  send_async_data.num_buffers = num_buffers;
+  send_async_data.num_bytes_sent = &WSASendTo_bytes_sent;
+  send_async_data.to = to_ptr;
+  send_async_data.to_len = to_len;
+
+  if (!overlapped_ptr) {
+    XELOGD("{}:: without overlapped_ptr!", __func__);
+  }
+
+  // Wait for PollWSASendTo to finish writing to overlapped_ptr
+  std::unique_lock socket_lock = std::unique_lock(send_socket_mutex_);
+
+  XWSAOVERLAPPED tmp_overlapped = {};
+  send_async_data.overlapped =
+      overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
+
+  if (overlapped_ptr) {
+    pending_overlapped_io_[send_async_data.overlapped] = true;
+  }
+
+  // Check for immediate completion, otherwise perform overlapped completion
+  uint32_t result = PollWSASendTo(false, send_async_data);
+
+  if (result == 0) {
+    if (cvars::logging) {
+      XELOGI("{} completed immediately", __func__);
+    }
+
+    if (num_bytes_sent_ptr) {
+      *num_bytes_sent_ptr = *send_async_data.num_bytes_sent;
+    }
+
+    return result;
+  }
+
+  X_WSA_ERROR wsa_error =
+      (X_WSA_ERROR)send_async_data.overlapped->internal.get();
+
+  if (!overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+    XWSASetLastError(X_WSA_ERROR::X_WSAEWOULDBLOCK);
+    return result;
+  }
+
+  XWSASetLastError(wsa_error);
+
+  if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+    if (!send_polling_task_.valid()) {
+      if (overlapped_ptr->event_handle) {
+        xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
+      }
+
+      send_polling_task_ =
+          std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
+                     send_async_data);
+    } else {
+      std::future_status status = send_polling_task_.wait_for(0ms);
+
+      if (status == std::future_status::ready) {
+        uint32_t result = send_polling_task_.get();
+
+        if (result == X_SOCKET_ERROR &&
+            wsa_error != X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+          XELOGI("{} Async:: failed with error code {}", __func__,
+                 static_cast<uint32_t>(wsa_error));
+        }
+      }
+    }
+
+    XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
+  } else {
+    // An error occurred that's not X_WSAEWOULDBLOCK
+    XELOGI("{}:: failed with error code {}", __func__,
+           static_cast<uint32_t>(wsa_error));
+
+    // Check WSA error is not corrupted!
+    if (wsa_error != (X_WSA_ERROR)send_async_data.overlapped->internal.get()) {
+      XELOGI("{}:: Overlapped Corruption!!", __func__);
+    }
+
+    if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
+      XELOGD("{}:: Operation Aborted!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
+    }
+  }
+
+  return result;
 }
 
 // If wait is true then block until data is available for reading
@@ -535,22 +707,37 @@ int XSocket::WSAPollRead(bool wait, X_WSA_ERROR* error) {
 }
 
 int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
+  // critical section - lock until we return
+  std::unique_lock<std::mutex> lock;
+
   if (wait) {
-    // Change?
+    // Sync is already locked, therefore only lock for async
+    lock = std::unique_lock(receive_socket_mutex_);
+
     receive_async_data.overlapped->internal =
-        (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK;
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
+  }
+
+  // Unlock while WSAPoll is blocking
+  if (wait) {
+    lock.unlock();
   }
 
   X_WSA_ERROR poll_read_error = X_WSA_ERROR::X_WSA_NO_ERROR;
 
   int result = WSAPollRead(wait, &poll_read_error);
 
+  // Lock again after WSAPoll returned
+  if (wait) {
+    lock.lock();
+  }
+
   if (result == X_SOCKET_ERROR) {
     // Checking for available data for reading failed.
     uint32_t error = 0;
 
     if (poll_read_error != X_WSA_ERROR::X_WSA_NO_ERROR) {
-      error = (uint32_t)poll_read_error;
+      error = static_cast<uint32_t>(poll_read_error);
     } else {
       error = XWSAGetLastError();
     }
@@ -565,18 +752,11 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   } else if (result == 0) {
     // There's no available data for reading therefore would block.
     receive_async_data.overlapped->internal =
-        (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK;
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
 
     std::unique_lock lock(receive_completion_mutex_);
     receive_cv_.notify_all();
     return X_SOCKET_ERROR;
-  }
-
-  // critical section - lock until we return
-  std::unique_lock<std::mutex> socket_lock;
-
-  if (wait) {
-    socket_lock = std::unique_lock(receive_socket_mutex_);
   }
 
   WSABUF recv_buffer = {};
@@ -605,27 +785,30 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   }
 
   if (result == X_SOCKET_ERROR) {
-    XELOGI("WSARecvFrom failed with error {}", XWSAGetLastError());
+    if (XWSAGetLastError() !=
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK)) {
+      XELOGI("WSARecvFrom failed with error {}", XWSAGetLastError());
+    }
 
     receive_async_data.overlapped->internal = XWSAGetLastError();
   } else if (result == 0) {
     receive_async_data.overlapped->internal =
-        (uint32_t)X_WSA_ERROR::X_WSA_NO_ERROR;
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
     receive_async_data.overlapped->internal_high = bytes_received;
 
     *receive_async_data.num_bytes_recv = bytes_received;
-
-    if (wait) {
-      if (receive_async_data.overlapped->event_handle) {
-        xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
-                               nullptr);
-      }
-    }
   }
 
   *receive_async_data.flags = flags;
 
   receive_async_data.overlapped->offset = flags;
+
+  if (wait) {
+    if (receive_async_data.overlapped->event_handle) {
+      xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
+                             nullptr);
+    }
+  }
 
   receive_cv_.notify_all();
 
@@ -675,7 +858,7 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
       overlapped_ptr ? overlapped_ptr : &tmp_overlapped;
 
   if (overlapped_ptr) {
-    pending_overlapped_io_.insert(receive_async_data.overlapped);
+    pending_overlapped_io_[receive_async_data.overlapped] = false;
   }
 
   // Check for immediate completion, otherwise perform overlapped completion
@@ -706,23 +889,24 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
   XWSASetLastError(wsa_error);
 
   if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-    if (!polling_task_.valid()) {
+    if (!receive_polling_task_.valid()) {
       if (overlapped_ptr->event_handle) {
         xboxkrnl::xeNtClearEvent(overlapped_ptr->event_handle);
       }
 
-      polling_task_ = std::async(std::launch::async, &XSocket::PollWSARecvFrom,
-                                 this, true, receive_async_data);
+      receive_polling_task_ =
+          std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
+                     receive_async_data);
     } else {
-      std::future_status status = polling_task_.wait_for(0ms);
+      std::future_status status = receive_polling_task_.wait_for(0ms);
 
       if (status == std::future_status::ready) {
-        uint32_t result = polling_task_.get();
+        uint32_t result = receive_polling_task_.get();
 
-        uint32_t error_code = XWSAGetLastError();
-
-        if (error_code != (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
-          XELOGI("{} Async:: failed with error code {}", __func__, error_code);
+        if (result == X_SOCKET_ERROR &&
+            wsa_error != X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+          XELOGI("{} Async:: failed with error code {}", __func__,
+                 static_cast<uint32_t>(wsa_error));
         }
       }
     }
@@ -730,7 +914,8 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
   } else {
     // An error occurred that's not X_WSAEWOULDBLOCK
-    XELOGI("{}:: failed!", __func__);
+    XELOGI("{}:: failed with error code {}", __func__,
+           static_cast<uint32_t>(wsa_error));
 
     // Check WSA error is not corrupted!
     if (wsa_error !=
@@ -755,6 +940,8 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return false;
   }
 
+  // Win32 returns true in such case so we can assume and copy this behavior.
+  // 4D530808 does this.
   if (!pending_overlapped_io_.contains(overlapped_ptr)) {
     XELOGI("Overlap not in operation!");
 
@@ -764,11 +951,20 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     return true;
   }
 
-  if (wait) {
-    std::unique_lock lock(receive_completion_mutex_);
+  bool io_type = pending_overlapped_io_[overlapped_ptr];
 
-    XELOGI("{}:: Blocking until completion!", __func__);
-    receive_cv_.wait(lock);
+  if (wait) {
+    if (io_type) {
+      std::unique_lock lock(send_completion_mutex_);
+
+      XELOGI("{}:: WSASendTo blocking until completion!", __func__);
+      send_cv_.wait(lock);
+    } else {
+      std::unique_lock lock(receive_completion_mutex_);
+
+      XELOGI("{}:: WSARecvFrom Blocking until completion!", __func__);
+      receive_cv_.wait(lock);
+    }
   }
 
   X_WSA_ERROR wsa_error = (X_WSA_ERROR)overlapped_ptr->internal.get();
@@ -777,6 +973,11 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     case X_WSA_ERROR::X_WSA_OPERATION_ABORTED: {
       XELOGD("{}:: Operation Aborted!", __func__);
       XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
+      return false;
+    } break;
+    case X_WSA_ERROR::X_WSAECANCELLED: {
+      XELOGD("{}:: Operation Cancelled!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
       return false;
     } break;
     case X_WSA_ERROR::X_WSAEWOULDBLOCK: {
@@ -788,7 +989,7 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
   }
 
   if (cvars::logging) {
-    if (overlapped_ptr->offset_high == 1) {
+    if (io_type) {
       XELOGI("{}:: WSASendTo bytes sent {} with status {}!", __func__,
              overlapped_ptr->internal_high.get(),
              overlapped_ptr->internal.get());
@@ -812,6 +1013,7 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
     XELOGI("{}:: failed with error code {}", __func__,
            overlapped_ptr->internal.get());
 
+    // What error should be set here?
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
     return false;
   }
@@ -820,21 +1022,32 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
 }
 
 int XSocket::WSACancelOverlappedIO() {
-  if (polling_task_.valid()) {
+  if (receive_polling_task_.valid() || send_polling_task_.valid()) {
     cancel_overlapped_ = true;
+
+    // Wait for PollWSARecvFrom to cancel
+    if (receive_polling_task_.valid()) {
+      std::unique_lock receive_lock(receive_socket_mutex_);
+    }
+
+    // Wait for PollWSAWSASend to cancel
+    if (send_polling_task_.valid()) {
+      std::unique_lock send_lock(send_socket_mutex_);
+    }
   }
 
-  for (auto& overlapped_ptr : pending_overlapped_io_) {
+  for (auto& [overlapped_ptr, type] : pending_overlapped_io_) {
     if (overlapped_ptr->event_handle) {
       xboxkrnl::xeNtSetEvent(overlapped_ptr->event_handle, nullptr);
     }
 
-    overlapped_ptr->internal = (uint32_t)X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
+    overlapped_ptr->internal =
+        static_cast<uint32_t>(X_WSA_ERROR::X_WSAECANCELLED);
   }
 
   pending_overlapped_io_.clear();
 
-  XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
+  XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
 
   return 0;
 }

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -492,9 +492,9 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
 
     return X_SOCKET_ERROR;
   } else if (result == 0) {
-    // There's no available data for reading therefore would block.
-    send_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
+    // There's no available space for writing therefore return and start
+    // pending operation.
+    send_async_data.overlapped->internal = X_STATUS_PENDING;
 
     return X_SOCKET_ERROR;
   }
@@ -540,21 +540,26 @@ int XSocket::PollWSASendTo(bool wait, WSASendToData send_async_data) {
   }
 
   if (result == X_SOCKET_ERROR) {
-    if (XWSAGetLastError() !=
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK)) {
+    if (XWSAGetLastError() == (uint32_t)X_WSA_ERROR::X_WSA_IO_PENDING ||
+        XWSAGetLastError() == (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+      send_async_data.overlapped->internal = X_STATUS_PENDING;
+    } else {
       XELOGI("WSASendTo failed with error {}", XWSAGetLastError());
+      send_async_data.overlapped->internal = XWSAGetLastError();
+
+      // send_async_data.overlapped->internal =
+      //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
     }
 
-    // send_async_data.overlapped->internal =
-    //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
-    send_async_data.overlapped->internal = XWSAGetLastError();
     // send_async_data.overlapped->internal_high = buffers[0].len;
   } else if (result == 0) {
-    send_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
     send_async_data.overlapped->internal_high = bytes_sent;
-
     *send_async_data.num_bytes_sent = bytes_sent;
+
+    // If no event handle is provided then title can check for completion via
+    // internal on change.
+    send_async_data.overlapped->internal =
+        uint32_t(X_WSA_ERROR::X_WSA_NO_ERROR);
 
     xboxkrnl::xeNtSetEvent(send_async_data.overlapped->event_handle, nullptr);
   }
@@ -597,8 +602,8 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
     pending_overlapped_io_[send_async_data.overlapped] = true;
   }
 
-  // Check for immediate completion, otherwise perform overlapped completion
-  uint32_t result = PollWSASendTo(false, send_async_data);
+  // Check for immediate completion, otherwise perform overlapped completion.
+  const int result = PollWSASendTo(false, send_async_data);
 
   if (result == 0) {
     if (cvars::logging) {
@@ -612,12 +617,10 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
     return result;
   }
 
-  X_WSA_ERROR wsa_error =
-      (X_WSA_ERROR)send_async_data.overlapped->internal.get();
+  const X_WSA_ERROR wsa_error =
+      X_WSA_ERROR(send_async_data.overlapped->internal.get());
 
-  XWSASetLastError(wsa_error);
-
-  if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+  if (overlapped_ptr && wsa_error == X_WSA_ERROR(X_STATUS_PENDING)) {
     if (!send_polling_task_.valid()) {
       send_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSASendTo, this, true,
@@ -626,14 +629,11 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
   } else {
-    // An error occurred that's not X_WSAEWOULDBLOCK
+    XWSASetLastError(wsa_error);
+
+    // An error occurred that's not X_STATUS_PENDING
     XELOGI("{}:: failed with error code {}", __func__,
            static_cast<uint32_t>(wsa_error));
-
-    // Check WSA error is not corrupted!
-    if (wsa_error != (X_WSA_ERROR)send_async_data.overlapped->internal.get()) {
-      XELOGI("{}:: Overlapped Corruption!!", __func__);
-    }
 
     if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
       XELOGD("{}:: Operation Aborted!", __func__);
@@ -711,9 +711,9 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
 
     return X_SOCKET_ERROR;
   } else if (result == 0) {
-    // There's no available data for reading therefore would block.
-    receive_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK);
+    // There's no available data for reading therefore return and start pending
+    // operation.
+    receive_async_data.overlapped->internal = X_STATUS_PENDING;
 
     return X_SOCKET_ERROR;
   }
@@ -750,28 +750,30 @@ int XSocket::PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data) {
   }
 
   if (result == X_SOCKET_ERROR) {
-    if (XWSAGetLastError() !=
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSAEWOULDBLOCK)) {
+    if (XWSAGetLastError() == (uint32_t)X_WSA_ERROR::X_WSA_IO_PENDING ||
+        XWSAGetLastError() == (uint32_t)X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+      receive_async_data.overlapped->internal = X_STATUS_PENDING;
+    } else {
       XELOGI("WSARecvFrom failed with error {}", XWSAGetLastError());
+      receive_async_data.overlapped->internal = XWSAGetLastError();
+
+      // receive_async_data.overlapped->internal =
+      //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
     }
-
-    // X_STATUS_PENDING?
-    receive_async_data.overlapped->internal = XWSAGetLastError();
-    // receive_async_data.overlapped->internal =
-    //     X_HRESULT_FROM_WIN32(XWSAGetLastError());
   } else if (result == 0) {
-    receive_async_data.overlapped->internal =
-        static_cast<uint32_t>(X_WSA_ERROR::X_WSA_NO_ERROR);
     receive_async_data.overlapped->internal_high = bytes_received;
-
     *receive_async_data.num_bytes_recv = bytes_received;
+
+    // If no event handle is provided then title can check for completion via
+    // internal on change.
+    receive_async_data.overlapped->internal =
+        uint32_t(X_WSA_ERROR::X_WSA_NO_ERROR);
 
     xboxkrnl::xeNtSetEvent(receive_async_data.overlapped->event_handle,
                            nullptr);
   }
 
   *receive_async_data.flags = flags;
-
   receive_async_data.overlapped->offset = flags;
 
   return result;
@@ -816,8 +818,8 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     pending_overlapped_io_[receive_async_data.overlapped] = false;
   }
 
-  // Check for immediate completion, otherwise perform overlapped completion
-  uint32_t result = PollWSARecvFrom(false, receive_async_data);
+  // Check for immediate completion, otherwise perform overlapped completion.
+  int result = PollWSARecvFrom(false, receive_async_data);
 
   if (result == 0) {
     if (cvars::logging) {
@@ -833,12 +835,10 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     return result;
   }
 
-  X_WSA_ERROR wsa_error =
-      (X_WSA_ERROR)receive_async_data.overlapped->internal.get();
+  const X_WSA_ERROR wsa_error =
+      X_WSA_ERROR(receive_async_data.overlapped->internal.get());
 
-  XWSASetLastError(wsa_error);
-
-  if (overlapped_ptr && wsa_error == X_WSA_ERROR::X_WSAEWOULDBLOCK) {
+  if (overlapped_ptr && wsa_error == X_WSA_ERROR(X_STATUS_PENDING)) {
     if (!receive_polling_task_.valid()) {
       receive_polling_task_ =
           std::async(std::launch::async, &XSocket::PollWSARecvFrom, this, true,
@@ -847,15 +847,11 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
 
     XWSASetLastError(X_WSA_ERROR::X_WSA_IO_PENDING);
   } else {
-    // An error occurred that's not X_WSAEWOULDBLOCK
+    XWSASetLastError(wsa_error);
+
+    // An error occurred that's not X_STATUS_PENDING
     XELOGI("{}:: failed with error code {}", __func__,
            static_cast<uint32_t>(wsa_error));
-
-    // Check WSA error is not corrupted!
-    if (wsa_error !=
-        (X_WSA_ERROR)receive_async_data.overlapped->internal.get()) {
-      XELOGI("{}:: Overlapped Corruption!!", __func__);
-    }
 
     if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
       XELOGD("{}:: Operation Aborted!", __func__);
@@ -967,6 +963,7 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
       XELOGD("{}:: Operation Aborted!", __func__);
       XWSASetLastError(internal_result);
     } break;
+    case X_WSA_ERROR(X_STATUS_PENDING):
     case X_WSA_ERROR::X_WSAEWOULDBLOCK: {
       XWSASetLastError(X_WSA_ERROR::X_WSA_IO_INCOMPLETE);
     } break;

--- a/src/xenia/kernel/xsocket.cc
+++ b/src/xenia/kernel/xsocket.cc
@@ -438,7 +438,8 @@ int XSocket::WSAPollWrite(bool wait, X_WSA_ERROR* error) {
 
     if (cancel_overlapped_) {
       if (error) {
-        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;
+        *error = X_WSA_ERROR::X_WSAECANCELLED;
+        // *error = X_HRESULT_FROM_WIN32( X_WSA_ERROR::X_WSAECANCELLED);
         activity = X_SOCKET_ERROR;
       }
     }
@@ -640,9 +641,9 @@ int XSocket::WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
     XELOGI("{}:: failed with error code {}", __func__,
            static_cast<uint32_t>(wsa_error));
 
-    if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
-      XELOGD("{}:: Operation Aborted!", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
+    if (wsa_error == X_WSA_ERROR::X_WSAECANCELLED) {
+      XELOGD("{}:: Operation Cancelled!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
     }
   }
 
@@ -662,7 +663,8 @@ int XSocket::WSAPollRead(bool wait, X_WSA_ERROR* error) {
 
     if (cancel_overlapped_) {
       if (error) {
-        *error = X_WSA_ERROR::X_WSA_OPERATION_ABORTED;  // X_WSAECANCELLED?
+        *error = X_WSA_ERROR::X_WSAECANCELLED;
+        // *error = X_HRESULT_FROM_WIN32( X_WSA_ERROR::X_WSAECANCELLED);
         activity = X_SOCKET_ERROR;
       }
     }
@@ -870,9 +872,9 @@ int XSocket::WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
     XELOGI("{}:: failed with error code {}", __func__,
            static_cast<uint32_t>(wsa_error));
 
-    if (wsa_error == X_WSA_ERROR::X_WSA_OPERATION_ABORTED) {
-      XELOGD("{}:: Operation Aborted!", __func__);
-      XWSASetLastError(X_WSA_ERROR::X_WSA_OPERATION_ABORTED);
+    if (wsa_error == X_WSA_ERROR::X_WSAECANCELLED) {
+      XELOGD("{}:: Operation Cancelled!", __func__);
+      XWSASetLastError(X_WSA_ERROR::X_WSAECANCELLED);
     }
   }
 
@@ -976,8 +978,8 @@ bool XSocket::WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
 
       return true;
     } break;
-    case X_WSA_ERROR::X_WSA_OPERATION_ABORTED: {
-      XELOGD("{}:: Operation Aborted!", __func__);
+    case X_WSA_ERROR::X_WSAECANCELLED: {
+      XELOGD("{}:: Operation Cancelled!", __func__);
       XWSASetLastError(internal_result);
     } break;
     case X_WSA_ERROR(X_STATUS_PENDING):

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <future>
 #include <queue>
+#include <set>
 
 #include "xenia/base/byte_order.h"
 #include "xenia/kernel/xobject.h"
@@ -37,21 +38,42 @@
 namespace xe {
 namespace kernel {
 enum class X_WSAError : uint32_t {
-  X_WSA_INVALID_PARAMETER = 0x0057,
-  X_WSA_OPERATION_ABORTED = 0x03E3,
-  X_WSA_IO_INCOMPLETE = 0x03E4,
-  X_WSA_IO_PENDING = 0x03E5,
-  X_WSAEACCES = 0x271D,
-  X_WSAEFAULT = 0x271E,
-  X_WSAEINVAL = 0x2726,
-  X_WSAEWOULDBLOCK = 0x2733,
-  X_WSAENOTSOCK = 0x2736,
-  X_WSAEMSGSIZE = 0x2738,
-  X_WSAENETDOWN = 0x2742,
-  X_WSANO_DATA = 0x2AFC,
-  X_WSANOTINITIALISED = 0x276D,
-  X_WSAEADDRINUSE = 0x2740,
-  X_WSAEINPROGRESS = 0x2734,
+  X_WSA_NO_ERROR = 0,
+  X_WSA_INVALID_PARAMETER = 87,
+  X_WSA_OPERATION_ABORTED = 995,
+  X_WSA_IO_INCOMPLETE = 996,
+  X_WSA_IO_PENDING = 997,
+  X_WSAEACCES = 10013,
+  X_WSAEFAULT = 10014,
+  X_WSAEINVAL = 10022,
+  X_WSAEWOULDBLOCK = 10035,
+  X_WSAEINPROGRESS = 10036,
+  X_WSAEALREADY = 10037,
+  X_WSAENOTSOCK = 10038,
+  X_WSAEMSGSIZE = 10040,
+  X_WSAENOPROTOOPT = 10042,
+  X_WSAEPROTONOSUPPORT = 10043,
+  X_WSAESOCKTNOSUPPORT = 10044,
+  X_WSAEAFNOSUPPORT = 10047,
+  X_WSAEADDRINUSE = 10048,
+  X_WSAEADDRNOTAVAIL = 10049,
+  X_WSAENETDOWN = 10050,
+  X_WSAECONNRESET = 10054,
+  X_WSAENOBUFS = 10055,
+  X_WSAEISCONN = 10056,
+  X_WSAENOTCONN = 10057,
+  X_WSAESHUTDOWN = 10058,
+  X_WSAETIMEDOUT = 10060,
+  X_WSAECONNREFUSED = 10061,
+  X_WSAEHOSTUNREACH = 10065,
+  X_WSASYSNOTREADY = 10091,
+  X_WSAVERNOTSUPPORTED = 10092,
+  X_WSANOTINITIALISED = 10093,
+  X_WSAECANCELLED = 10103,
+  X_WSASYSCALLFAILURE = 10107,
+  X_WSAHOST_NOT_FOUND = 11001,
+  X_WSATRY_AGAIN = 11002,
+  X_WSANO_DATA = 11004,
 };
 
 /*
@@ -102,6 +124,16 @@ struct XWSAOVERLAPPED {
   xe::be<uint32_t> event_handle;
 };
 static_assert_size(XWSAOVERLAPPED, 0x14);
+
+struct WSARecvFromData {
+  std::shared_ptr<XWSABUF> buffers;
+  uint32_t num_buffers;
+  uint32_t* num_bytes_recv;
+  uint32_t* flags;
+  XSOCKADDR_IN* from;
+  int from_len;
+  XWSAOVERLAPPED* overlapped;
+};
 
 class XSocket : public XObject {
  public:
@@ -172,16 +204,30 @@ class XSocket : public XObject {
   int WSAEventSelect(uint64_t socket_handle, uint64_t event_handle,
                      uint32_t flags);
 
+  int WSASendTo(XWSABUF* buffers, uint32_t num_buffers,
+                xe::be<uint32_t>* num_bytes_sent_ptr, uint32_t flags,
+                XSOCKADDR_IN* to_ptr, uint32_t to_len,
+                XWSAOVERLAPPED* overlapped_ptr);
+
+  int WSAPollWrite(bool wait, X_WSAError* error);
+
+  int WSAPollRead(bool wait, X_WSAError* error);
+
   int WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                   xe::be<uint32_t>* num_bytes_recv_ptr,
                   xe::be<uint32_t>* flags_ptr, XSOCKADDR_IN* from_ptr,
                   xe::be<uint32_t>* fromlen_ptr,
                   XWSAOVERLAPPED* overlapped_ptr);
+
   bool WSAGetOverlappedResult(XWSAOVERLAPPED* overlapped_ptr,
                               xe::be<uint32_t>* bytes_transferred, bool wait,
                               xe::be<uint32_t>* flags_ptr);
 
+  int WSACancelOverlappedIO();
+
   static uint32_t GetLastWSAError();
+
+  bool blocking_mode_ = true;
 
   struct packet {
     // These values are in network byte order.
@@ -222,14 +268,16 @@ class XSocket : public XObject {
 
   std::future<int> polling_task_;
 
-  std::mutex receive_mutex_;
+  std::mutex receive_completion_mutex_;
   std::condition_variable receive_cv_;
   std::mutex receive_socket_mutex_;
-  XWSAOVERLAPPED* active_overlapped_ = nullptr;
 
   uint16_t GetImplicitlyBoundPort() const;
 
-  int PollWSARecvFrom(bool wait, struct WSARecvFromData data);
+  std::atomic<bool> cancel_overlapped_ = false;
+  std::set<XWSAOVERLAPPED*> pending_overlapped_io_;
+
+  int PollWSARecvFrom(bool wait, WSARecvFromData data);
 
   void SetLastWSAError(X_WSAError) const;
 };

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -129,7 +129,6 @@ static_assert_size(XWSAOVERLAPPED, 0x14);
 struct WSASendToData {
   std::shared_ptr<XWSABUF[]> buffers;
   uint32_t num_buffers;
-  uint32_t* num_bytes_sent;
   XSOCKADDR_IN* to;
   int to_len;
   XWSAOVERLAPPED* overlapped;
@@ -138,10 +137,10 @@ struct WSASendToData {
 struct WSARecvFromData {
   std::shared_ptr<XWSABUF> buffers;
   uint32_t num_buffers;
-  uint32_t* num_bytes_recv;
-  uint32_t* flags;
+  xe::be<uint32_t>* num_bytes_recv;
+  xe::be<uint32_t>* flags;
   XSOCKADDR_IN* from;
-  int from_len;
+  xe::be<uint32_t>* from_len;
   XWSAOVERLAPPED* overlapped;
 };
 
@@ -288,7 +287,8 @@ class XSocket : public XObject {
 
   int WSAPollWrite(bool wait, X_WSA_ERROR* error);
 
-  int PollWSASendTo(bool wait, WSASendToData send_async_data);
+  int PollWSASendTo(bool wait, WSASendToData send_async_data,
+                    uint32_t* num_bytes_sent);
 
   int WSAPollRead(bool wait, X_WSA_ERROR* error);
 

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -275,8 +275,8 @@ class XSocket : public XObject {
   std::mutex incoming_packet_mutex_;
   std::queue<uint8_t*> incoming_packets_;
 
-  std::future<int> send_polling_task_;
-  std::future<int> receive_polling_task_;
+  std::future<int32_t> send_polling_task_;
+  std::future<int32_t> receive_polling_task_;
 
   uint16_t GetImplicitlyBoundPort() const;
 

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <future>
 #include <queue>
+#include <set>
 
 #include "xenia/base/byte_order.h"
 #include "xenia/kernel/xobject.h"
@@ -116,9 +117,9 @@ struct XWSABUF {
 static_assert_size(XWSABUF, 0x8);
 
 struct XWSAOVERLAPPED {
-  xe::be<uint32_t> internal;       // Status Code
-  xe::be<uint32_t> internal_high;  // The amount of bytes sent/recv
-  xe::be<uint32_t> offset;         // Flags maybe?
+  xe::be<uint32_t> internal;       // Status/Error Codes HRESULT
+  xe::be<uint32_t> internal_high;  // Transfer
+  xe::be<uint32_t> offset;         // Flags
   xe::be<uint32_t> offset_high;
   xe::be<uint32_t> event_handle;
 };
@@ -286,6 +287,7 @@ class XSocket : public XObject {
 
   // True is WSASendTo, false is WSARecvFrom
   std::map<XWSAOVERLAPPED*, bool> pending_overlapped_io_;
+  std::set<uint32_t> cancelled_overlapped_io_;
 
   int WSAPollWrite(bool wait, X_WSA_ERROR* error);
 

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -37,7 +37,7 @@
 
 namespace xe {
 namespace kernel {
-enum class X_WSAError : uint32_t {
+enum class X_WSA_ERROR : uint32_t {
   X_WSA_NO_ERROR = 0,
   X_WSA_INVALID_PARAMETER = 87,
   X_WSA_OPERATION_ABORTED = 995,
@@ -117,9 +117,9 @@ struct XWSABUF {
 static_assert_size(XWSABUF, 0x8);
 
 struct XWSAOVERLAPPED {
-  xe::be<uint32_t> internal;
-  xe::be<uint32_t> internal_high;
-  xe::be<uint32_t> offset;
+  xe::be<uint32_t> internal;       // Status Code
+  xe::be<uint32_t> internal_high;  // The amount of bytes sent/recv
+  xe::be<uint32_t> offset;         // Flags
   xe::be<uint32_t> offset_high;
   xe::be<uint32_t> event_handle;
 };
@@ -209,9 +209,9 @@ class XSocket : public XObject {
                 XSOCKADDR_IN* to_ptr, uint32_t to_len,
                 XWSAOVERLAPPED* overlapped_ptr);
 
-  int WSAPollWrite(bool wait, X_WSAError* error);
+  int WSAPollWrite(bool wait, X_WSA_ERROR* error);
 
-  int WSAPollRead(bool wait, X_WSAError* error);
+  int WSAPollRead(bool wait, X_WSA_ERROR* error);
 
   int WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                   xe::be<uint32_t>* num_bytes_recv_ptr,
@@ -225,9 +225,9 @@ class XSocket : public XObject {
 
   int WSACancelOverlappedIO();
 
-  static uint32_t GetLastWSAError();
+  static bool XWSAIsKnownError(X_WSA_ERROR error);
 
-  bool blocking_mode_ = true;
+  static uint32_t XWSAGetLastError();
 
   struct packet {
     // These values are in network byte order.
@@ -279,7 +279,7 @@ class XSocket : public XObject {
 
   int PollWSARecvFrom(bool wait, WSARecvFromData data);
 
-  void SetLastWSAError(X_WSAError) const;
+  void XWSASetLastError(X_WSA_ERROR) const;
 };
 
 }  // namespace kernel

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -283,6 +283,8 @@ class XSocket : public XObject {
 
   // True is WSASendTo, false is WSARecvFrom
   std::map<XWSAOVERLAPPED*, bool> pending_overlapped_io_;
+  std::mutex map_mutex_;
+
   std::set<uint32_t> cancelled_overlapped_io_;
 
   int WSAPollWrite(bool wait, X_WSA_ERROR* error);

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -13,7 +13,6 @@
 #include <cstring>
 #include <future>
 #include <queue>
-#include <set>
 
 #include "xenia/base/byte_order.h"
 #include "xenia/kernel/xobject.h"
@@ -119,11 +118,20 @@ static_assert_size(XWSABUF, 0x8);
 struct XWSAOVERLAPPED {
   xe::be<uint32_t> internal;       // Status Code
   xe::be<uint32_t> internal_high;  // The amount of bytes sent/recv
-  xe::be<uint32_t> offset;         // Flags
+  xe::be<uint32_t> offset;         // Flags maybe?
   xe::be<uint32_t> offset_high;
   xe::be<uint32_t> event_handle;
 };
 static_assert_size(XWSAOVERLAPPED, 0x14);
+
+struct WSASendToData {
+  std::shared_ptr<XWSABUF[]> buffers;
+  uint32_t num_buffers;
+  uint32_t* num_bytes_sent;
+  XSOCKADDR_IN* to;
+  int to_len;
+  XWSAOVERLAPPED* overlapped;
+};
 
 struct WSARecvFromData {
   std::shared_ptr<XWSABUF> buffers;
@@ -209,10 +217,6 @@ class XSocket : public XObject {
                 XSOCKADDR_IN* to_ptr, uint32_t to_len,
                 XWSAOVERLAPPED* overlapped_ptr);
 
-  int WSAPollWrite(bool wait, X_WSA_ERROR* error);
-
-  int WSAPollRead(bool wait, X_WSA_ERROR* error);
-
   int WSARecvFrom(XWSABUF* buffers, uint32_t num_buffers,
                   xe::be<uint32_t>* num_bytes_recv_ptr,
                   xe::be<uint32_t>* flags_ptr, XSOCKADDR_IN* from_ptr,
@@ -266,8 +270,12 @@ class XSocket : public XObject {
   std::mutex incoming_packet_mutex_;
   std::queue<uint8_t*> incoming_packets_;
 
-  std::future<int> polling_task_;
+  std::future<int> send_polling_task_;
+  std::mutex send_completion_mutex_;
+  std::condition_variable send_cv_;
+  std::mutex send_socket_mutex_;
 
+  std::future<int> receive_polling_task_;
   std::mutex receive_completion_mutex_;
   std::condition_variable receive_cv_;
   std::mutex receive_socket_mutex_;
@@ -275,9 +283,17 @@ class XSocket : public XObject {
   uint16_t GetImplicitlyBoundPort() const;
 
   std::atomic<bool> cancel_overlapped_ = false;
-  std::set<XWSAOVERLAPPED*> pending_overlapped_io_;
 
-  int PollWSARecvFrom(bool wait, WSARecvFromData data);
+  // True is WSASendTo, false is WSARecvFrom
+  std::map<XWSAOVERLAPPED*, bool> pending_overlapped_io_;
+
+  int WSAPollWrite(bool wait, X_WSA_ERROR* error);
+
+  int PollWSASendTo(bool wait, WSASendToData send_async_data);
+
+  int WSAPollRead(bool wait, X_WSA_ERROR* error);
+
+  int PollWSARecvFrom(bool wait, WSARecvFromData receive_async_data);
 
   void XWSASetLastError(X_WSA_ERROR) const;
 };

--- a/src/xenia/kernel/xsocket.h
+++ b/src/xenia/kernel/xsocket.h
@@ -37,6 +37,7 @@
 
 namespace xe {
 namespace kernel {
+// https://learn.microsoft.com/en-us/windows/win32/winsock/windows-sockets-error-codes-2
 enum class X_WSA_ERROR : uint32_t {
   X_WSA_NO_ERROR = 0,
   X_WSA_INVALID_PARAMETER = 87,
@@ -247,6 +248,9 @@ class XSocket : public XObject {
   bool QueuePacket(uint32_t src_ip, uint16_t src_port, const uint8_t* buf,
                    size_t len);
 
+  std::mutex send_socket_mutex_;
+  std::mutex receive_socket_mutex_;
+
  private:
   XSocket(KernelState* kernel_state, uint64_t native_handle);
   uint64_t native_handle_ = -1;
@@ -272,14 +276,7 @@ class XSocket : public XObject {
   std::queue<uint8_t*> incoming_packets_;
 
   std::future<int> send_polling_task_;
-  std::mutex send_completion_mutex_;
-  std::condition_variable send_cv_;
-  std::mutex send_socket_mutex_;
-
   std::future<int> receive_polling_task_;
-  std::mutex receive_completion_mutex_;
-  std::condition_variable receive_cv_;
-  std::mutex receive_socket_mutex_;
 
   uint16_t GetImplicitlyBoundPort() const;
 

--- a/src/xenia/xbox.h
+++ b/src/xenia/xbox.h
@@ -122,6 +122,9 @@ typedef uint32_t X_HRESULT;
                                   : (static_cast<X_HRESULT>(((x) & 0xFFFF) | (X_FACILITY_WIN32 << 16) | \
                                     0x80000000L)))
 
+#define X_HRESULT_FACILITY(hr) (((hr) >> 16) & 0x1fff)
+#define X_WIN32_FROM_HRESULT(hr) (X_HRESULT_FACILITY(hr) == X_FACILITY_WIN32 ? ((hr) & 0xFFFF) : hr)
+
 #define X_E_FALSE                               static_cast<X_HRESULT>(0x80000000L)
 #define X_E_SUCCESS                             X_HRESULT_FROM_WIN32(X_ERROR_SUCCESS)
 #define X_E_ACCESS_DENIED                       X_HRESULT_FROM_WIN32(X_ERROR_ACCESS_DENIED)


### PR DESCRIPTION
Attempt at implementing [WSASendTo](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendto) & [WSARecvFrom](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsarecvfrom) which many games use, therefore currently don't work.
This implementation is still unstable, therefore expect random disconnections. However some games should start working.

### Current Implementation Issues:
- Determine when `receive_polling_task_` should be reset or how **WSARecvFrom** threading should work.
- **Scott Pilgrim vs. the World** sometimes fails to bind ports to sockets this is possibly related to mutexes.
- Linux Compatibility

Download [here](https://nightly.link/AdrianCassar/xenia-canary/workflows/Orchestrator/netplay_canary_experimental_WSASendTo_PoC_Final/xenia_canary_netplay_windows.zip).