### PR TITLE
[XAM] Broadcast sign in changed for kXNotifyLive and kXNotifySystem

### DIFF
--- a/src/xenia/kernel/kernel_state.cc
+++ b/src/xenia/kernel/kernel_state.cc
@@ -938,9 +938,15 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
     // XN_SYS_UI (on, off)
     listener->EnqueueNotification(kXNotificationSystemUI, 1);
     listener->EnqueueNotification(kXNotificationSystemUI, 0);
+
+    const auto signed_in_players =
+        xam_state()->profile_manager()->GetUsedUserSlots().to_ulong();
+
     // XN_SYS_SIGNINCHANGED x2
-    listener->EnqueueNotification(kXNotificationSystemSignInChanged, 1);
-    listener->EnqueueNotification(kXNotificationSystemSignInChanged, 1);
+    listener->EnqueueNotification(kXNotificationSystemSignInChanged,
+                                  signed_in_players);
+    listener->EnqueueNotification(kXNotificationSystemSignInChanged,
+                                  signed_in_players);
 
     listener->EnqueueNotification(kXNotificationSystemTrayStateChanged,
                                   X_DVD_DISC_STATE::XBOX_360_GAME_DISC);
@@ -961,6 +967,19 @@ void KernelState::RegisterNotifyListener(XNotifyListener* listener) {
                                   live_connection_state);
     listener->EnqueueNotification(kXNotificationLiveLinkStateChanged,
                                   ethernet_link_state);
+  }
+
+  // 4E4D07ED, 58410869. Fixes creating Xbox Live sessions.
+  // Sign in related
+  if (!has_notified_system_and_live_ &&
+      listener->mask() == (kXNotifySystem | kXNotifyLive)) {
+    has_notified_system_and_live_ = true;
+
+    const auto signed_in_players =
+        xam_state()->profile_manager()->GetUsedUserSlots().to_ulong();
+
+    listener->EnqueueNotification(kXNotificationSystemSignInChanged,
+                                  signed_in_players);
   }
 }
 

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -361,6 +361,7 @@ class KernelState {
   std::vector<object_ref<XNotifyListener>> notify_listeners_;
   bool has_notified_startup_ = false;
   bool has_notified_live_startup_ = false;
+  bool has_notified_system_and_live_ = false;
 
   object_ref<UserModule> executable_module_;
   std::vector<object_ref<KernelModule>> kernel_modules_;

--- a/src/xenia/kernel/xam/profile_manager.h
+++ b/src/xenia/kernel/xam/profile_manager.h
@@ -96,6 +96,8 @@ class ProfileManager {
   uint8_t GetUserIndexAssignedToProfile(const uint64_t xuid) const;
   uint8_t GetUserIndexAssignedToLiveProfile(const uint64_t xuid_online) const;
 
+  std::bitset<XUserMaxUserCount> GetUsedUserSlots() const;
+
   const std::map<uint64_t, X_XAMACCOUNTINFO>* GetAccounts() {
     return &accounts_;
   }
@@ -134,7 +136,6 @@ class ProfileManager {
   std::vector<uint64_t> FindProfiles() const;
 
   uint8_t FindFirstFreeProfileSlot() const;
-  std::bitset<XUserMaxUserCount> GetUsedUserSlots() const;
 
   uint64_t GenerateXuid() const {
     std::random_device rd;


### PR DESCRIPTION
Fixed `Smash Court Tennis 3` and `Sensible World of Soccer` creating Xbox Live sessions due to sign in detection issues.