### PR TITLE
[XAM] Refactored XUserReadStats, XSessionFlushStats, XSessionWriteStats, XSessionModifySkill and XamUserCreateStatsEnumerator

### DIFF
--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -927,18 +927,32 @@ void XLiveAPI::SessionWriteStats(uint64_t sessionId, XGI_STATS_WRITE stats) {
   }
 }
 
-std::unique_ptr<HTTPResponseObjectJSON> XLiveAPI::LeaderboardsFind(
-    const uint8_t* data) {
+std::unique_ptr<LeaderboardObjectJSON> XLiveAPI::LeaderboardsFind(
+    const XGI_XUSER_READ_STATS stats) {
   std::string endpoint = fmt::format("leaderboards/find");
 
-  std::unique_ptr<HTTPResponseObjectJSON> response = Post(endpoint, data);
+  auto read_stats = ReadUserStatsObjectJSON(stats);
+
+  std::string read_user_stats_json = "";
+  bool valid = read_stats.Serialize(read_user_stats_json);
+  assert_true(valid);
+
+  std::unique_ptr<LeaderboardObjectJSON> leaderboards =
+      std::make_unique<LeaderboardObjectJSON>();
+
+  std::unique_ptr<HTTPResponseObjectJSON> response =
+      Post(endpoint, reinterpret_cast<uint8_t*>(read_user_stats_json.data()));
 
   if (response->StatusCode() != HTTP_STATUS_CODE::HTTP_CREATED) {
     XELOGE("LeaderboardsFind error message: {}", response->Message());
     assert_always();
+
+    return leaderboards;
   }
 
-  return response;
+  leaderboards = response->Deserialize<LeaderboardObjectJSON>();
+
+  return leaderboards;
 }
 
 void XLiveAPI::DeleteSession(uint64_t sessionId) {

--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -894,14 +894,14 @@ std::unique_ptr<ArbitrationObjectJSON> XLiveAPI::XSessionArbitration(
   return arbitration;
 }
 
-void XLiveAPI::SessionFlushStats(uint64_t sessionId,
+bool XLiveAPI::SessionFlushStats(uint64_t sessionId,
                                  view_properties_unordered_map stats) {
   std::string endpoint =
       fmt::format("title/{:08X}/sessions/{:016x}/leaderboards",
                   kernel_state()->title_id(), sessionId);
 
   if (stats.empty()) {
-    return;
+    return true;
   }
 
   LeaderboardObjectJSON leaderboard = LeaderboardObjectJSON(stats);
@@ -921,8 +921,10 @@ void XLiveAPI::SessionFlushStats(uint64_t sessionId,
     XELOGE("{} error message: {}", __func__, response->Message());
     // assert_always();
 
-    return;
+    return false;
   }
+
+  return true;
 }
 
 std::unique_ptr<LeaderboardObjectJSON> XLiveAPI::LeaderboardsFind(

--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -894,33 +894,31 @@ std::unique_ptr<ArbitrationObjectJSON> XLiveAPI::XSessionArbitration(
   return arbitration;
 }
 
-void XLiveAPI::SessionWriteStats(uint64_t sessionId, XGI_STATS_WRITE stats) {
+void XLiveAPI::SessionFlushStats(uint64_t sessionId,
+                                 view_properties_unordered_map stats) {
   std::string endpoint =
       fmt::format("title/{:08X}/sessions/{:016x}/leaderboards",
                   kernel_state()->title_id(), sessionId);
 
-  XSESSION_VIEW_PROPERTIES* view_properties =
-      kernel_state()->memory()->TranslateVirtual<XSESSION_VIEW_PROPERTIES*>(
-          stats.views_ptr);
+  if (stats.empty()) {
+    return;
+  }
 
-  std::vector<XSESSION_VIEW_PROPERTIES> properties(
-      view_properties, view_properties + stats.num_views);
-
-  LeaderboardObjectJSON leaderboard = LeaderboardObjectJSON(stats, properties);
+  LeaderboardObjectJSON leaderboard = LeaderboardObjectJSON(stats);
 
   std::string output;
   bool valid = leaderboard.Serialize(output);
   assert_true(valid);
 
   if (cvars::logging) {
-    XELOGI("SessionWriteStats:\n\n{}", output);
+    XELOGI("{}:\n\n{}", __func__, output);
   }
 
   std::unique_ptr<HTTPResponseObjectJSON> response =
       Post(endpoint, (uint8_t*)output.c_str());
 
   if (response->StatusCode() != HTTP_STATUS_CODE::HTTP_CREATED) {
-    XELOGE("SessionWriteStats error message: {}", response->Message());
+    XELOGE("{} error message: {}", __func__, response->Message());
     // assert_always();
 
     return;

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -110,7 +110,7 @@ class XLiveAPI {
   static std::unique_ptr<ArbitrationObjectJSON> XSessionArbitration(
       uint64_t sessionId);
 
-  static void SessionFlushStats(uint64_t sessionId,
+  static bool SessionFlushStats(uint64_t sessionId,
                                 view_properties_unordered_map stats);
 
   static std::unique_ptr<LeaderboardObjectJSON> LeaderboardsFind(

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -29,6 +29,7 @@
 #include "xenia/kernel/json/player_object_json.h"
 #include "xenia/kernel/json/presence_object_json.h"
 #include "xenia/kernel/json/properties_object_json.h"
+#include "xenia/kernel/json/read_user_stats_object_json.h"
 #include "xenia/kernel/json/services_json.h"
 #include "xenia/kernel/json/session_object_json.h"
 #include "xenia/kernel/json/xstorage_file_info_object_json.h"
@@ -111,8 +112,8 @@ class XLiveAPI {
 
   static void SessionWriteStats(uint64_t sessionId, XGI_STATS_WRITE stats);
 
-  static std::unique_ptr<HTTPResponseObjectJSON> LeaderboardsFind(
-      const uint8_t* data);
+  static std::unique_ptr<LeaderboardObjectJSON> LeaderboardsFind(
+      const XGI_XUSER_READ_STATS stats);
 
   static void DeleteSession(uint64_t sessionId);
 

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -110,7 +110,8 @@ class XLiveAPI {
   static std::unique_ptr<ArbitrationObjectJSON> XSessionArbitration(
       uint64_t sessionId);
 
-  static void SessionWriteStats(uint64_t sessionId, XGI_STATS_WRITE stats);
+  static void SessionFlushStats(uint64_t sessionId,
+                                view_properties_unordered_map stats);
 
   static std::unique_ptr<LeaderboardObjectJSON> LeaderboardsFind(
       const XGI_XUSER_READ_STATS stats);

--- a/src/xenia/kernel/json/leaderboard_object_json.cc
+++ b/src/xenia/kernel/json/leaderboard_object_json.cc
@@ -13,9 +13,13 @@
 
 namespace xe {
 namespace kernel {
+LeaderboardObjectJSON::LeaderboardObjectJSON()
+    : stats_({}), view_properties_({}), read_results_({}) {}
+
 LeaderboardObjectJSON::LeaderboardObjectJSON(
     XGI_STATS_WRITE stats,
-    std::vector<XSESSION_VIEW_PROPERTIES> view_properties) {
+    std::vector<XSESSION_VIEW_PROPERTIES> view_properties)
+    : stats_({}), view_properties_({}), read_results_({}) {
   stats_ = stats;
   view_properties_ = view_properties;
 }
@@ -23,7 +27,127 @@ LeaderboardObjectJSON::LeaderboardObjectJSON(
 LeaderboardObjectJSON::~LeaderboardObjectJSON() {}
 
 bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
-  return false;
+  if (!obj.IsArray()) {
+    return false;
+  }
+
+  if (!obj.GetArray().Begin()->IsObject()) {
+    return false;
+  }
+
+  const auto leaderboards = obj.GetArray();
+  const uint32_t views_count = leaderboards.Size();
+
+  const uint32_t views_address = kernel_state()->memory()->SystemHeapAlloc(
+      sizeof(X_USER_STATS_VIEW) * views_count);
+
+  X_USER_STATS_VIEW* views_ptr =
+      kernel_state()->memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
+          views_address);
+
+  read_results_.num_views = views_count;
+  read_results_.views_ptr = views_address;
+
+  for (uint32_t view_index = 0; const auto& view : leaderboards) {
+    X_USER_STATS_VIEW* view_ptr = views_ptr + view_index;
+
+    const uint32_t view_id = view["id"].GetUint();
+    const auto players = view["players"].GetArray();
+    const uint32_t rows_count = players.Size();
+
+    const uint32_t rows_address = kernel_state()->memory()->SystemHeapAlloc(
+        sizeof(X_USER_STATS_ROW) * rows_count);
+
+    X_USER_STATS_ROW* rows_ptr =
+        kernel_state()->memory()->TranslateVirtual<X_USER_STATS_ROW*>(
+            rows_address);
+
+    view_ptr->view_id = view_id;
+    view_ptr->rows_ptr = rows_address;
+    view_ptr->total_view_rows = rows_count;
+    view_ptr->num_rows = rows_count;
+
+    for (uint32_t row_index = 0; const auto& player : players) {
+      X_USER_STATS_ROW* row_ptr = rows_ptr + row_index;
+
+      const uint64_t xuid = xe::string_util::from_string<uint64_t>(
+          player["xuid"].GetString(), true);
+      const std::string gamertag = player["gamertag"].GetString();
+      const auto columns = player["stats"].GetArray();
+      const uint32_t columns_count = columns.Size();
+
+      assert_true(IsValidXUID(xuid));
+
+      row_ptr->xuid = xuid;
+      std::memcpy(row_ptr->gamertag, gamertag.c_str(),
+                  static_cast<uint32_t>(gamertag.size()));
+      row_ptr->num_columns = columns_count;
+
+      // 0 if not in leaderboard
+      row_ptr->rank = static_cast<uint32_t>(row_index) + 1;
+      row_ptr->i64Rating = 0;
+
+      uint32_t columns_address = columns_address =
+          kernel_state()->memory()->SystemHeapAlloc(
+              sizeof(X_USER_STATS_COLUMN) * columns_count);
+
+      X_USER_STATS_COLUMN* columns_ptr = columns_ptr =
+          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_COLUMN*>(
+              columns_address);
+
+      row_ptr->columns_ptr = columns_address;
+
+      for (uint32_t column_index = 0; const auto& column_data : columns) {
+        X_USER_STATS_COLUMN* column_ptr = columns_ptr + column_index;
+
+        // Ordinal
+        const uint32_t column_id = column_data["id"].GetUint();
+        const xam::X_USER_DATA_TYPE type =
+            static_cast<xam::X_USER_DATA_TYPE>(column_data["type"].GetUint());
+
+        if (columns_ptr) {
+          column_ptr->column_id = column_id;
+          column_ptr->value.type = type;
+
+          // WSTRING and BINARY are unsupported
+          switch (type) {
+            case xam::X_USER_DATA_TYPE::CONTEXT:
+              column_ptr->value.data.u32 = column_data["value"].GetUint();
+              break;
+            case xam::X_USER_DATA_TYPE::INT32:
+              column_ptr->value.data.u32 = column_data["value"].GetInt();
+              break;
+            case xam::X_USER_DATA_TYPE::INT64:
+              column_ptr->value.data.s64 = column_data["value"].GetInt64();
+              break;
+            case xam::X_USER_DATA_TYPE::DOUBLE:
+              column_ptr->value.data.f64 = column_data["value"].GetDouble();
+              break;
+            case xam::X_USER_DATA_TYPE::FLOAT:
+              column_ptr->value.data.f32 = column_data["value"].GetFloat();
+              break;
+            case xam::X_USER_DATA_TYPE::DATETIME:
+              column_ptr->value.data.filetime = column_data["value"].GetInt64();
+              break;
+            case xam::X_USER_DATA_TYPE::UNSET:
+              // Ignore don't read missing/placeholder stat
+            default:
+              XELOGW("Unimplemented stat type for read: {}",
+                     static_cast<uint32_t>(type));
+              assert_always();
+          }
+        }
+
+        column_index++;
+      }
+
+      row_index++;
+    }
+
+    view_index++;
+  }
+
+  return true;
 }
 
 bool LeaderboardObjectJSON::Serialize(
@@ -37,6 +161,8 @@ bool LeaderboardObjectJSON::Serialize(
 
   for (auto& user_property : view_properties_) {
     const std::string leaderboard_id = std::to_string(user_property.view_id);
+
+    assert_false(user_property.view_id == kTrueSkillViewId);
 
     writer->Key(leaderboard_id);
     writer->StartObject();
@@ -74,23 +200,17 @@ bool LeaderboardObjectJSON::Serialize(
           writer->String("value");
           writer->Int(stat.data.data.s32);
         } break;
+        case xam::X_USER_DATA_TYPE::DATETIME:
         case xam::X_USER_DATA_TYPE::INT64: {
           writer->String("value");
           writer->Uint64(stat.data.data.s64);
         } break;
+        case xam::X_USER_DATA_TYPE::FLOAT:
         case xam::X_USER_DATA_TYPE::DOUBLE: {
           writer->String("value");
           writer->Double(stat.data.data.f64);
         } break;
-        case xam::X_USER_DATA_TYPE::FLOAT: {
-          XELOGW("Unimplemented statistic type: FLOAT");
-        } break;
-        case xam::X_USER_DATA_TYPE::DATETIME: {
-          XELOGW("Unimplemented statistic type: DATETIME");
-        } break;
-        case xam::X_USER_DATA_TYPE::UNSET: {
-          // Ignore
-        } break;
+        case xam::X_USER_DATA_TYPE::UNSET:
         case xam::X_USER_DATA_TYPE::WSTRING:
         case xam::X_USER_DATA_TYPE::BINARY:
         default:

--- a/src/xenia/kernel/json/leaderboard_object_json.cc
+++ b/src/xenia/kernel/json/leaderboard_object_json.cc
@@ -8,11 +8,13 @@
  */
 
 #include "xenia/kernel/json/leaderboard_object_json.h"
+#include "xenia/emulator.h"
 #include "xenia/kernel/util/shim_utils.h"
 
 namespace xe {
 namespace kernel {
-LeaderboardObjectJSON::LeaderboardObjectJSON() : read_results_({}) {}
+LeaderboardObjectJSON::LeaderboardObjectJSON()
+    : stats_({}), read_results_({}) {}
 
 LeaderboardObjectJSON::LeaderboardObjectJSON(
     view_properties_unordered_map stats)
@@ -25,6 +27,10 @@ bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
     return false;
   }
 
+  if (obj.GetArray().Empty()) {
+    return false;
+  }
+
   if (!obj.GetArray().Begin()->IsObject()) {
     return false;
   }
@@ -32,37 +38,40 @@ bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
   const auto leaderboards = obj.GetArray();
   const uint32_t views_count = leaderboards.Size();
 
-  const uint32_t views_address = kernel_state()->memory()->SystemHeapAlloc(
-      sizeof(X_USER_STATS_VIEW) * views_count);
+  // TODO(Adrian)
+  // Instead of allocating more memory use provided buffer from XGI call.
+  const uint32_t views_address =
+      kernel_memory()->SystemHeapAlloc(sizeof(X_USER_STATS_VIEW) * views_count);
 
   X_USER_STATS_VIEW* views_ptr =
-      kernel_state()->memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
-          views_address);
+      kernel_memory()->TranslateVirtual<X_USER_STATS_VIEW*>(views_address);
 
   read_results_.num_views = views_count;
   read_results_.views_ptr = views_address;
 
   for (uint32_t view_index = 0; const auto& view : leaderboards) {
-    X_USER_STATS_VIEW* view_ptr = views_ptr + view_index;
+    X_USER_STATS_VIEW& view_ptr = views_ptr[view_index];
 
     const uint32_t view_id = view["id"].GetUint();
     const auto players = view["players"].GetArray();
     const uint32_t rows_count = players.Size();
 
-    const uint32_t rows_address = kernel_state()->memory()->SystemHeapAlloc(
-        sizeof(X_USER_STATS_ROW) * rows_count);
+    const auto spa_stats_view =
+        kernel_state()->emulator()->game_info_database()->GetStatsView(view_id);
+
+    const uint32_t rows_address =
+        kernel_memory()->SystemHeapAlloc(sizeof(X_USER_STATS_ROW) * rows_count);
 
     X_USER_STATS_ROW* rows_ptr =
-        kernel_state()->memory()->TranslateVirtual<X_USER_STATS_ROW*>(
-            rows_address);
+        kernel_memory()->TranslateVirtual<X_USER_STATS_ROW*>(rows_address);
 
-    view_ptr->view_id = view_id;
-    view_ptr->rows_ptr = rows_address;
-    view_ptr->total_view_rows = rows_count;
-    view_ptr->num_rows = rows_count;
+    view_ptr.view_id = view_id;
+    view_ptr.rows_ptr = rows_address;
+    view_ptr.total_view_rows = rows_count;
+    view_ptr.num_rows = rows_count;
 
     for (uint32_t row_index = 0; const auto& player : players) {
-      X_USER_STATS_ROW* row_ptr = rows_ptr + row_index;
+      X_USER_STATS_ROW& row_ptr = rows_ptr[row_index];
 
       const uint64_t xuid = xe::string_util::from_string<uint64_t>(
           player["xuid"].GetString(), true);
@@ -72,64 +81,105 @@ bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
 
       assert_true(IsValidXUID(xuid));
 
-      row_ptr->xuid = xuid;
-      std::memcpy(row_ptr->gamertag, gamertag.c_str(),
-                  static_cast<uint32_t>(gamertag.size()));
-      row_ptr->num_columns = columns_count;
+      row_ptr.xuid = xuid;
 
-      // 0 if not in leaderboard
-      row_ptr->rank = static_cast<uint32_t>(row_index) + 1;
-      row_ptr->i64Rating = 0;
+      // 58410968 and 555307DB use gamertags from XFriendsCreateEnumerator.
+      // xam::GamertagAttributeId
+      xe::string_util::copy_truncating(row_ptr.gamertag, gamertag.c_str(),
+                                       sizeof(row_ptr.gamertag));
 
-      uint32_t columns_address = columns_address =
-          kernel_state()->memory()->SystemHeapAlloc(
-              sizeof(X_USER_STATS_COLUMN) * columns_count);
+      row_ptr.num_columns = columns_count;
 
-      X_USER_STATS_COLUMN* columns_ptr = columns_ptr =
-          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_COLUMN*>(
+      // If rank or i64Rating is 0 then gamer is not in leaderboard.
+
+      // xam::RankAttributeId
+      row_ptr.rank = row_index + 1;
+
+      // 58410A3B provides data in a custom format for i64Rating therefore,
+      // placeholder data is interpreted as corrupted.
+
+      // xam::RatingAttributeId
+      row_ptr.i64Rating = 1;
+
+      // In such case request system attributes Rank, i64Rating and Gamertag.
+      // 545107FC, 454108D4, 58410A57, 584108FF, 41560834 do not use columns.
+      // 58410A3B expects no columns to read i64Rating.
+      if (!columns_count) {
+        row_index++;
+        continue;
+      }
+
+      const uint32_t columns_size = sizeof(X_USER_STATS_COLUMN) * columns_count;
+
+      const uint32_t columns_address =
+          kernel_memory()->SystemHeapAlloc(columns_size);
+
+      X_USER_STATS_COLUMN* columns_ptr =
+          kernel_memory()->TranslateVirtual<X_USER_STATS_COLUMN*>(
               columns_address);
 
-      row_ptr->columns_ptr = columns_address;
+      row_ptr.columns_ptr = columns_address;
 
       for (uint32_t column_index = 0; const auto& column_data : columns) {
-        X_USER_STATS_COLUMN* column_ptr = columns_ptr + column_index;
+        X_USER_STATS_COLUMN& column_ptr = columns_ptr[column_index];
 
-        // Ordinal
+        // Attribute ID
         const uint32_t column_id = column_data["id"].GetUint();
-        const xam::X_USER_DATA_TYPE type =
+        xam::X_USER_DATA_TYPE type =
             static_cast<xam::X_USER_DATA_TYPE>(column_data["type"].GetUint());
 
-        if (columns_ptr) {
-          column_ptr->column_id = column_id;
-          column_ptr->value.type = type;
+        if (IsTrueSkillViewID(view_id)) {
+          type = GetTrueSkillColumnType(column_id);
+        }
 
-          // WSTRING and BINARY are unsupported
-          switch (type) {
-            case xam::X_USER_DATA_TYPE::CONTEXT:
-              column_ptr->value.data.u32 = column_data["value"].GetUint();
-              break;
-            case xam::X_USER_DATA_TYPE::INT32:
-              column_ptr->value.data.u32 = column_data["value"].GetInt();
-              break;
-            case xam::X_USER_DATA_TYPE::INT64:
-              column_ptr->value.data.s64 = column_data["value"].GetInt64();
-              break;
-            case xam::X_USER_DATA_TYPE::DOUBLE:
-              column_ptr->value.data.f64 = column_data["value"].GetDouble();
-              break;
-            case xam::X_USER_DATA_TYPE::FLOAT:
-              column_ptr->value.data.f32 = column_data["value"].GetFloat();
-              break;
-            case xam::X_USER_DATA_TYPE::DATETIME:
-              column_ptr->value.data.filetime = column_data["value"].GetInt64();
-              break;
-            case xam::X_USER_DATA_TYPE::UNSET:
-              // Ignore don't read missing/placeholder stat
-              break;
-            default:
-              XELOGW("Unimplemented stat type for read: {}",
-                     static_cast<uint32_t>(type));
+        column_ptr.column_id = column_id;
+        column_ptr.value.type = type;
+
+        // Placeholder data may be interpreted as corrupted.
+        column_ptr.value.data = {};
+
+        // WSTRING and BINARY are unsupported
+        switch (type) {
+          case xam::X_USER_DATA_TYPE::CONTEXT:
+            column_ptr.value.data.u32 = column_data["value"].GetUint();
+            break;
+          case xam::X_USER_DATA_TYPE::INT32:
+            column_ptr.value.data.u32 = column_data["value"].GetInt();
+            break;
+          case xam::X_USER_DATA_TYPE::INT64:
+            column_ptr.value.data.s64 = column_data["value"].GetInt64();
+            break;
+          case xam::X_USER_DATA_TYPE::DOUBLE:
+            column_ptr.value.data.f64 = column_data["value"].GetDouble();
+            break;
+          case xam::X_USER_DATA_TYPE::FLOAT:
+            column_ptr.value.data.f32 = column_data["value"].GetFloat();
+            break;
+          case xam::X_USER_DATA_TYPE::DATETIME:
+            column_ptr.value.data.filetime = column_data["value"].GetInt64();
+            break;
+          case xam::X_USER_DATA_TYPE::UNSET: {
+            // Ignore don't read missing/placeholder stat
+            // Currently we do not store this information on the backend so
+            // instead we can determine the property type locally ourself.
+            // 5454082B expects correct type otherwise stats appear corrupted.
+            if (spa_stats_view.has_value()) {
+              for (const auto& column :
+                   spa_stats_view.value().shared_view.column_entries) {
+                if (column.attribute_id == column_id) {
+                  column_ptr.value.type =
+                      xam::UserData::get_type(column.property_id);
+                }
+              }
+            } else {
+              column_ptr.value.type = xam::X_USER_DATA_TYPE::INT32;
               assert_always();
+            }
+          } break;
+          default: {
+            XELOGW("Unimplemented stat type for read: {}",
+                   static_cast<uint32_t>(type));
+            assert_always();
           }
         }
 
@@ -151,13 +201,19 @@ bool LeaderboardObjectJSON::Serialize(
     return false;
   }
 
-  // TODO: Support multiple local players in a session
+  // TODO(Adrian):
+  // Support multiple local players in a session
+  // Write default system defined columns
+  // Write TrueSkill defined columns
+  //
+  // If columns are not written then we cannot read them.
 
   for (uint32_t view_index = 0; const auto& [xuid, views] : stats_) {
     const std::string xuid_str = fmt::format("{:016X}", xuid);
 
     if (view_index >= 1) {
       // Sending multiple players stats is unsupported
+      XELOGI("Flushing multiple players stats is currently unsupported!");
       assert_always();
       continue;
     }
@@ -170,7 +226,9 @@ bool LeaderboardObjectJSON::Serialize(
     for (const auto& [view_id, properties] : views) {
       const std::string leaderboard_id = std::to_string(view_id);
 
-      assert_false(view_id == kTrueSkillViewId);
+      if (IsTrueSkillViewID(view_id)) {
+        XELOGI("Flush Stats: TrueSkill View ID: {:08X}", view_id);
+      }
 
       writer->String(leaderboard_id);
       writer->StartObject();

--- a/src/xenia/kernel/json/leaderboard_object_json.cc
+++ b/src/xenia/kernel/json/leaderboard_object_json.cc
@@ -9,20 +9,14 @@
 
 #include "xenia/kernel/json/leaderboard_object_json.h"
 #include "xenia/kernel/util/shim_utils.h"
-#include "xenia/kernel/xam/user_data.h"
 
 namespace xe {
 namespace kernel {
-LeaderboardObjectJSON::LeaderboardObjectJSON()
-    : stats_({}), view_properties_({}), read_results_({}) {}
+LeaderboardObjectJSON::LeaderboardObjectJSON() : read_results_({}) {}
 
 LeaderboardObjectJSON::LeaderboardObjectJSON(
-    XGI_STATS_WRITE stats,
-    std::vector<XSESSION_VIEW_PROPERTIES> view_properties)
-    : stats_({}), view_properties_({}), read_results_({}) {
-  stats_ = stats;
-  view_properties_ = view_properties;
-}
+    view_properties_unordered_map stats)
+    : stats_(stats), read_results_({}) {}
 
 LeaderboardObjectJSON::~LeaderboardObjectJSON() {}
 
@@ -131,6 +125,7 @@ bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
               break;
             case xam::X_USER_DATA_TYPE::UNSET:
               // Ignore don't read missing/placeholder stat
+              break;
             default:
               XELOGW("Unimplemented stat type for read: {}",
                      static_cast<uint32_t>(type));
@@ -152,87 +147,96 @@ bool LeaderboardObjectJSON::Deserialize(const rapidjson::Value& obj) {
 
 bool LeaderboardObjectJSON::Serialize(
     rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const {
-  const std::string xuid = fmt::format("{:016X}", stats_.xuid.get());
+  if (stats_.empty()) {
+    return false;
+  }
 
-  writer->StartObject();
+  // TODO: Support multiple local players in a session
 
-  writer->Key("leaderboards");
-  writer->StartObject();
+  for (uint32_t view_index = 0; const auto& [xuid, views] : stats_) {
+    const std::string xuid_str = fmt::format("{:016X}", xuid);
 
-  for (auto& user_property : view_properties_) {
-    const std::string leaderboard_id = std::to_string(user_property.view_id);
+    if (view_index >= 1) {
+      // Sending multiple players stats is unsupported
+      assert_always();
+      continue;
+    }
 
-    assert_false(user_property.view_id == kTrueSkillViewId);
-
-    writer->Key(leaderboard_id);
     writer->StartObject();
 
-    writer->Key("stats");
+    writer->String("leaderboards");
     writer->StartObject();
 
-    for (uint32_t i = 0; i < user_property.properties_count; i++) {
-      const xam::XUSER_PROPERTY* statistics_ptr =
-          kernel_state()->memory()->TranslateVirtual<xam::XUSER_PROPERTY*>(
-              user_property.properties_ptr);
+    for (const auto& [view_id, properties] : views) {
+      const std::string leaderboard_id = std::to_string(view_id);
 
-      const xam::XUSER_PROPERTY& stat = statistics_ptr[i];
+      assert_false(view_id == kTrueSkillViewId);
 
-      const std::string property_id =
-          fmt::format("{:08X}", stat.property_id.get());
-
-      // 41560901 doesn't set property type
-      xam::X_USER_DATA_TYPE property_type =
-          xam::UserData::get_type(stat.property_id);
-
-      // Write each stat ID
-      writer->Key(property_id);
+      writer->String(leaderboard_id);
       writer->StartObject();
 
-      writer->Key("type");
-      writer->Int(static_cast<uint32_t>(property_type));
+      writer->String("stats");
+      writer->StartObject();
 
-      switch (property_type) {
-        case xam::X_USER_DATA_TYPE::CONTEXT: {
-          writer->String("value");
-          writer->Uint(stat.data.data.u32);
-        } break;
-        case xam::X_USER_DATA_TYPE::INT32: {
-          writer->String("value");
-          writer->Int(stat.data.data.s32);
-        } break;
-        case xam::X_USER_DATA_TYPE::DATETIME:
-        case xam::X_USER_DATA_TYPE::INT64: {
-          writer->String("value");
-          writer->Uint64(stat.data.data.s64);
-        } break;
-        case xam::X_USER_DATA_TYPE::FLOAT:
-        case xam::X_USER_DATA_TYPE::DOUBLE: {
-          writer->String("value");
-          writer->Double(stat.data.data.f64);
-        } break;
-        case xam::X_USER_DATA_TYPE::UNSET:
-        case xam::X_USER_DATA_TYPE::WSTRING:
-        case xam::X_USER_DATA_TYPE::BINARY:
-        default:
-          XELOGW("Unsupported statistic type for write {}",
-                 static_cast<uint32_t>(stat.data.type));
-          break;
+      for (const auto& [property_id, property] : properties) {
+        const std::string property_id_str = fmt::format("{:08X}", property_id);
+
+        // 41560901 doesn't set property type
+        xam::X_USER_DATA_TYPE property_type =
+            xam::UserData::get_type(property_id);
+
+        // Write each stat ID
+        writer->String(property_id_str);
+        writer->StartObject();
+
+        writer->String("type");
+        writer->Int(static_cast<uint32_t>(property_type));
+
+        switch (property_type) {
+          case xam::X_USER_DATA_TYPE::CONTEXT: {
+            writer->String("value");
+            writer->Uint(property.get_data()->data.u32);
+          } break;
+          case xam::X_USER_DATA_TYPE::INT32: {
+            writer->String("value");
+            writer->Int(property.get_data()->data.s32);
+          } break;
+          case xam::X_USER_DATA_TYPE::DATETIME:
+          case xam::X_USER_DATA_TYPE::INT64: {
+            writer->String("value");
+            writer->Uint64(property.get_data()->data.s64);
+          } break;
+          case xam::X_USER_DATA_TYPE::FLOAT:
+          case xam::X_USER_DATA_TYPE::DOUBLE: {
+            writer->String("value");
+            writer->Double(property.get_data()->data.f64);
+          } break;
+          case xam::X_USER_DATA_TYPE::UNSET:
+          case xam::X_USER_DATA_TYPE::WSTRING:
+          case xam::X_USER_DATA_TYPE::BINARY:
+          default:
+            XELOGW("Unsupported stat type for write {}",
+                   static_cast<uint32_t>(property.get_data()->type));
+            break;
+        }
+
+        writer->EndObject();
       }
+
+      writer->EndObject();
 
       writer->EndObject();
     }
 
     writer->EndObject();
 
+    writer->String("xuid");
+    writer->String(xuid_str);
+
     writer->EndObject();
+
+    view_index++;
   }
-
-  writer->EndObject();
-
-  writer->Key("xuid");
-  writer->String(xuid);
-
-  writer->EndObject();
 
   return true;
 }

--- a/src/xenia/kernel/json/leaderboard_object_json.h
+++ b/src/xenia/kernel/json/leaderboard_object_json.h
@@ -20,6 +20,8 @@ class LeaderboardObjectJSON : public BaseObjectJSON {
   using BaseObjectJSON::Deserialize;
   using BaseObjectJSON::Serialize;
 
+  LeaderboardObjectJSON();
+
   LeaderboardObjectJSON(XGI_STATS_WRITE stats,
                         std::vector<XSESSION_VIEW_PROPERTIES> view_properties);
 
@@ -40,9 +42,15 @@ class LeaderboardObjectJSON : public BaseObjectJSON {
   const XGI_STATS_WRITE& Stats() const { return stats_; }
   void Stats(const XGI_STATS_WRITE& stats) { stats_ = stats; }
 
+  const X_USER_STATS_READ_RESULTS& GetReadStatsResults() const {
+    return read_results_;
+  }
+
  private:
   XGI_STATS_WRITE stats_;
   std::vector<XSESSION_VIEW_PROPERTIES> view_properties_;
+
+  X_USER_STATS_READ_RESULTS read_results_;
 };
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/json/leaderboard_object_json.h
+++ b/src/xenia/kernel/json/leaderboard_object_json.h
@@ -39,7 +39,7 @@ class LeaderboardObjectJSON : public BaseObjectJSON {
   }
 
  private:
-  view_properties_unordered_map stats_ = {};
+  view_properties_unordered_map stats_;
   X_USER_STATS_READ_RESULTS read_results_;
 };
 }  // namespace kernel

--- a/src/xenia/kernel/json/leaderboard_object_json.h
+++ b/src/xenia/kernel/json/leaderboard_object_json.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2024 Xenia Emulator. All rights reserved.                        *
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -10,8 +10,8 @@
 #ifndef XENIA_KERNEL_LEADERBOARD_OBJECT_JSON_H_
 #define XENIA_KERNEL_LEADERBOARD_OBJECT_JSON_H_
 
-#include "xenia//kernel/xsession.h"
 #include "xenia/kernel/json/base_object_json.h"
+#include "xenia/kernel/xnet.h"
 
 namespace xe {
 namespace kernel {
@@ -22,8 +22,7 @@ class LeaderboardObjectJSON : public BaseObjectJSON {
 
   LeaderboardObjectJSON();
 
-  LeaderboardObjectJSON(XGI_STATS_WRITE stats,
-                        std::vector<XSESSION_VIEW_PROPERTIES> view_properties);
+  LeaderboardObjectJSON(view_properties_unordered_map stats);
 
   virtual ~LeaderboardObjectJSON();
 
@@ -31,25 +30,16 @@ class LeaderboardObjectJSON : public BaseObjectJSON {
   virtual bool Serialize(
       rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const;
 
-  const std::vector<XSESSION_VIEW_PROPERTIES>& ViewProperties() const {
-    return view_properties_;
+  const view_properties_unordered_map& GetStatsToWrite() const {
+    return stats_;
   }
-  void ViewProperties(
-      const std::vector<XSESSION_VIEW_PROPERTIES>& view_properties) {
-    view_properties_ = view_properties;
-  }
-
-  const XGI_STATS_WRITE& Stats() const { return stats_; }
-  void Stats(const XGI_STATS_WRITE& stats) { stats_ = stats; }
 
   const X_USER_STATS_READ_RESULTS& GetReadStatsResults() const {
     return read_results_;
   }
 
  private:
-  XGI_STATS_WRITE stats_;
-  std::vector<XSESSION_VIEW_PROPERTIES> view_properties_;
-
+  view_properties_unordered_map stats_ = {};
   X_USER_STATS_READ_RESULTS read_results_;
 };
 }  // namespace kernel

--- a/src/xenia/kernel/json/read_user_stats_object_json.cc
+++ b/src/xenia/kernel/json/read_user_stats_object_json.cc
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */
@@ -31,20 +31,25 @@ bool ReadUserStatsObjectJSON::Serialize(
   writer->StartArray();
 
   const xe::be<uint64_t>* xuids_ptr =
-      kernel_state()->memory()->TranslateVirtual<xe::be<uint64_t>*>(
+      kernel_memory()->TranslateVirtual<xe::be<uint64_t>*>(
           read_stats_.xuids_ptr);
 
-  const std::vector<xe::be<uint64_t>> xuids(
-      xuids_ptr, xuids_ptr + read_stats_.xuids_count);
+  const uint32_t xuids_count =
+      std::min<uint32_t>(read_stats_.xuids_count, X_STATS_MAX_USER_COUNT);
+
+  const std::vector<uint64_t> xuids(xuids_ptr, xuids_ptr + xuids_count);
 
   for (const uint64_t& xuid : xuids) {
-    writer->String(fmt::format("{:016X}", xuid).c_str());
+    // 41560817 and 584107F2 provide null XUID therefore skip them.
+    if (xuid) {
+      writer->String(fmt::format("{:016X}", xuid).c_str());
+    }
   }
 
   writer->EndArray();
 
-  const uint32_t title_id = read_stats_.titleId ? read_stats_.titleId.get()
-                                                : kernel_state()->title_id();
+  const uint32_t title_id = read_stats_.title_id ? read_stats_.title_id.get()
+                                                 : kernel_state()->title_id();
 
   writer->String("titleId");
   writer->String(fmt::format("{:08x}", title_id).c_str());
@@ -52,11 +57,11 @@ bool ReadUserStatsObjectJSON::Serialize(
   writer->String("queries");
 
   const X_USER_STATS_SPEC* specs_ptr =
-      kernel_state()->memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
+      kernel_memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
           read_stats_.specs_ptr);
 
-  const std::vector<X_USER_STATS_SPEC> specs(
-      specs_ptr, specs_ptr + read_stats_.specs_count);
+  std::vector<X_USER_STATS_SPEC> specs(specs_ptr,
+                                       specs_ptr + read_stats_.specs_count);
 
   writer->StartArray();
   for (const auto& spec : specs) {
@@ -67,8 +72,8 @@ bool ReadUserStatsObjectJSON::Serialize(
 
     writer->String("statisticIds");
     writer->StartArray();
-    const uint32_t num_column_ids =
-        std::min<uint32_t>(spec.num_column_ids, kXUserMaxStatsAttributes);
+    const uint32_t num_column_ids = std::min<uint32_t>(
+        spec.num_column_ids, X_USER_STATS_ATTRIBUTES_IN_SPEC);
 
     for (uint32_t column_index = 0; column_index < num_column_ids;
          column_index++) {

--- a/src/xenia/kernel/json/read_user_stats_object_json.cc
+++ b/src/xenia/kernel/json/read_user_stats_object_json.cc
@@ -1,0 +1,88 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/json/read_user_stats_object_json.h"
+#include "xenia/kernel/util/shim_utils.h"
+
+namespace xe {
+namespace kernel {
+ReadUserStatsObjectJSON::ReadUserStatsObjectJSON(XGI_XUSER_READ_STATS stats) {
+  read_stats_ = stats;
+}
+
+ReadUserStatsObjectJSON::~ReadUserStatsObjectJSON() {}
+
+bool ReadUserStatsObjectJSON::Deserialize(const rapidjson::Value& obj) {
+  return false;
+}
+
+bool ReadUserStatsObjectJSON::Serialize(
+    rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const {
+  writer->StartObject();
+
+  writer->String("players");
+
+  writer->StartArray();
+
+  const xe::be<uint64_t>* xuids_ptr =
+      kernel_state()->memory()->TranslateVirtual<xe::be<uint64_t>*>(
+          read_stats_.xuids_ptr);
+
+  const std::vector<xe::be<uint64_t>> xuids(
+      xuids_ptr, xuids_ptr + read_stats_.xuids_count);
+
+  for (const uint64_t& xuid : xuids) {
+    writer->String(fmt::format("{:016X}", xuid).c_str());
+  }
+
+  writer->EndArray();
+
+  const uint32_t title_id = read_stats_.titleId ? read_stats_.titleId.get()
+                                                : kernel_state()->title_id();
+
+  writer->String("titleId");
+  writer->String(fmt::format("{:08x}", title_id).c_str());
+
+  writer->String("queries");
+
+  const X_USER_STATS_SPEC* specs_ptr =
+      kernel_state()->memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
+          read_stats_.specs_ptr);
+
+  const std::vector<X_USER_STATS_SPEC> specs(
+      specs_ptr, specs_ptr + read_stats_.specs_count);
+
+  writer->StartArray();
+  for (const auto& spec : specs) {
+    writer->StartObject();
+
+    writer->String("id");
+    writer->Uint(spec.view_id);
+
+    writer->String("statisticIds");
+    writer->StartArray();
+    const uint32_t num_column_ids =
+        std::min<uint32_t>(spec.num_column_ids, kXUserMaxStatsAttributes);
+
+    for (uint32_t column_index = 0; column_index < num_column_ids;
+         column_index++) {
+      writer->Uint(spec.column_ids[column_index]);
+    }
+    writer->EndArray();
+
+    writer->EndObject();
+  }
+  writer->EndArray();
+
+  writer->EndObject();
+
+  return true;
+}
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/json/read_user_stats_object_json.h
+++ b/src/xenia/kernel/json/read_user_stats_object_json.h
@@ -2,7 +2,7 @@
  ******************************************************************************
  * Xenia : Xbox 360 Emulator Research Project                                 *
  ******************************************************************************
- * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
  * Released under the BSD license - see LICENSE in the root for more details. *
  ******************************************************************************
  */

--- a/src/xenia/kernel/json/read_user_stats_object_json.h
+++ b/src/xenia/kernel/json/read_user_stats_object_json.h
@@ -1,0 +1,40 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2025 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_READ_USER_STATS_OBJECT_JSON_H_
+#define XENIA_KERNEL_READ_USER_STATS_OBJECT_JSON_H_
+
+#include "xenia/kernel/json/base_object_json.h"
+#include "xenia/kernel/xnet.h"
+
+namespace xe {
+namespace kernel {
+class ReadUserStatsObjectJSON : public BaseObjectJSON {
+ public:
+  using BaseObjectJSON::Deserialize;
+  using BaseObjectJSON::Serialize;
+
+  ReadUserStatsObjectJSON(XGI_XUSER_READ_STATS read_stats);
+
+  virtual ~ReadUserStatsObjectJSON();
+
+  virtual bool Deserialize(const rapidjson::Value& obj);
+  virtual bool Serialize(
+      rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const;
+
+  const XGI_XUSER_READ_STATS& ReadStats() const { return read_stats_; }
+  void ReadStats(const XGI_XUSER_READ_STATS& stats) { read_stats_ = stats; }
+
+ private:
+  XGI_XUSER_READ_STATS read_stats_;
+};
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_READ_USER_STATS_OBJECT_JSON_H_

--- a/src/xenia/kernel/util/game_info_database.cc
+++ b/src/xenia/kernel/util/game_info_database.cc
@@ -181,13 +181,13 @@ GameInfoDatabase::Field GameInfoDatabase::GetField(
   return field;
 }
 
-GameInfoDatabase::StatsView GameInfoDatabase::GetStatsView(
+std::optional<GameInfoDatabase::StatsView> GameInfoDatabase::GetStatsView(
     const uint32_t id) const {
-  StatsView stats_view = {};
-
   if (!is_valid_) {
-    return stats_view;
+    return std::nullopt;
   }
+
+  StatsView stats_view = {};
 
   const auto xdbf_stats_view = spa_gamedata_->GetStatsView(id);
 
@@ -369,7 +369,11 @@ std::vector<GameInfoDatabase::StatsView> GameInfoDatabase::GetStatsViews()
   const auto xdbf_stats_views = spa_gamedata_->GetStatsViews();
 
   for (const auto& entry : *xdbf_stats_views) {
-    stats_views.push_back(GetStatsView(entry.view_entry.id));
+    auto stats_view = GetStatsView(entry.view_entry.id);
+
+    if (stats_view.has_value()) {
+      stats_views.push_back(stats_view.value());
+    }
   }
 
   return stats_views;

--- a/src/xenia/kernel/util/game_info_database.h
+++ b/src/xenia/kernel/util/game_info_database.h
@@ -133,7 +133,8 @@ class GameInfoDatabase {
   Achievement GetAchievement(const uint32_t id) const;
   PropertyBag GetPropertyBag(const xam::PropertyBag& property_bag) const;
   Field GetField(const xam::ViewFieldEntry& field_entry) const;
-  StatsView GetStatsView(const uint32_t id) const;
+  std::optional<GameInfoDatabase::StatsView> GetStatsView(
+      const uint32_t id) const;
 
   // TODO: Implement it in the future.
   std::vector<uint32_t> GetMatchmakingAttributes(const uint32_t id) const;

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -197,19 +197,21 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
 
       // 584107D7 caches results
       X_USER_STATS_READ_RESULTS* results =
-          kernel_state()
-              ->memory()
-              ->TranslateVirtual<X_USER_STATS_READ_RESULTS*>(data->results_ptr);
+          kernel_memory()->TranslateVirtual<X_USER_STATS_READ_RESULTS*>(
+              data->results_ptr);
 
       std::memset(results, 0, sizeof(X_USER_STATS_READ_RESULTS));
 
-      // Max friends plus yourself
-      if (data->xuids_count > X_ONLINE_MAX_FRIENDS + 1) {
+      if (data->xuids_count > X_STATS_MAX_USER_COUNT) {
         return X_E_INVALIDARG;
       }
 
-      // 4D5307EA uses 6 leaderboards?
-      assert_false(data->specs_count > kXUserMaxReadStatsViews + 1);
+      // 4D5307EA reads 6 leaderboards, 5 standard and 1 skill.
+      assert_false(data->specs_count > XUserMaxReadStatsViews + 1);
+
+      if (data->specs_count > XUserMaxReadStatsViews + 1) {
+        return X_E_INVALIDARG;
+      }
 
       std::unique_ptr<LeaderboardObjectJSON> leaderboards =
           XLiveAPI::LeaderboardsFind(*data);
@@ -220,40 +222,39 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
       results->views_ptr = read_results.views_ptr;
       results->num_views = read_results.num_views;
 
-      // Provide pointer regardless
-      if (!results->views_ptr) {
-        results->views_ptr = kernel_state()->memory()->SystemHeapAlloc(
-            sizeof(X_USER_STATS_VIEW));
-
-        // 4D5307EA expects views_ptr but not 1 count.
-        results->num_views = 0;
-
-        return X_E_SUCCESS;
-      }
-
       // Validation
+
+      assert_not_zero(read_results.views_ptr);
+
+      if (!read_results.views_ptr) {
+        return X_ONLINE_E_LOGON_NOT_LOGGED_ON;
+      }
 
       assert_false(results->num_views != data->specs_count);
 
       const X_USER_STATS_SPEC* stats_specs =
-          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
+          kernel_memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
               data->specs_ptr);
 
       const X_USER_STATS_VIEW* views_ptr =
-          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
+          kernel_memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
               results->views_ptr);
 
       // 545107D4 uses same view id twice?
       for (uint32_t spec_index = 0; spec_index < data->specs_count;
            spec_index++) {
-        const X_USER_STATS_SPEC* stat_spec_ptr = stats_specs + spec_index;
-        const X_USER_STATS_VIEW* view_ptr = views_ptr + spec_index;
+        const X_USER_STATS_SPEC stat_spec_ptr = stats_specs[spec_index];
+        const X_USER_STATS_VIEW view_ptr = views_ptr[spec_index];
+        const uint32_t view_id = stat_spec_ptr.view_id;
 
-        assert_false(stat_spec_ptr->view_id == kTrueSkillViewId);
+        const auto spa_stats_view =
+            kernel_state()->emulator()->game_info_database()->GetStatsView(
+                view_id);
 
-        // 545107FC, 454108D4, 58410A57, 584108FF, 41560834 doesn't use columns.
-        assert_false(stat_spec_ptr->num_column_ids < 1 ||
-                     stat_spec_ptr->num_column_ids > kXUserMaxStatsAttributes);
+        // TrueSkill leaderboards are not defined in SPA?
+        if (IsTrueSkillViewID(view_id)) {
+          XELOGI("TrueSkill View ID: {:08X}", view_id);
+        }
       }
 
       return X_E_SUCCESS;

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -256,7 +256,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
         Value statIdsArray(kArrayType);
         for (uint32_t stat_id_index = 0; stat_id_index < num_column_ids;
              stat_id_index++) {
-          statIdsArray.PushBack(queries[queryIndex].column_Ids[stat_id_index],
+          statIdsArray.PushBack(queries[queryIndex].column_ids[stat_id_index],
                                 doc.GetAllocator());
         }
         queryObject.AddMember("statisticIds", statIdsArray, doc.GetAllocator());
@@ -297,16 +297,16 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
                leaderboardsArray.Begin();
            leaderboardObjectPtr != leaderboardsArray.End();
            ++leaderboardObjectPtr) {
-        leaderboard[leaderboardIndex].ViewId =
+        leaderboard[leaderboardIndex].view_id =
             (*leaderboardObjectPtr)["id"].GetUint();
         auto playersArray = (*leaderboardObjectPtr)["players"].GetArray();
-        leaderboard[leaderboardIndex].NumRows = playersArray.Size();
-        leaderboard[leaderboardIndex].TotalViewRows = playersArray.Size();
+        leaderboard[leaderboardIndex].num_rows = playersArray.Size();
+        leaderboard[leaderboardIndex].total_view_rows = playersArray.Size();
         auto players_guest_address = memory_->SystemHeapAlloc(
             sizeof(X_USER_STATS_ROW) * playersArray.Size());
         auto player =
             memory_->TranslateVirtual<X_USER_STATS_ROW*>(players_guest_address);
-        leaderboard[leaderboardIndex].pRows = players_guest_address;
+        leaderboard[leaderboardIndex].rows_ptr = players_guest_address;
 
         uint32_t playerIndex = 0;
         for (Value::ConstValueIterator playerObjectPtr = playersArray.Begin();
@@ -314,7 +314,7 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
           auto gamertag = (*playerObjectPtr)["gamertag"].GetString();
           auto gamertagLength =
               (*playerObjectPtr)["gamertag"].GetStringLength();
-          memcpy(player[playerIndex].szGamertag, gamertag, gamertagLength);
+          memcpy(player[playerIndex].gamertag, gamertag, gamertagLength);
 
           std::vector<uint8_t> xuid;
           string_util::hex_string_to_array(
@@ -322,23 +322,23 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
           memcpy(&player[playerIndex].xuid, xuid.data(), 8);
 
           auto statisticsArray = (*playerObjectPtr)["stats"].GetArray();
-          player[playerIndex].NumColumns = statisticsArray.Size();
+          player[playerIndex].num_columns = statisticsArray.Size();
           auto stats_guest_address = memory_->SystemHeapAlloc(
               sizeof(X_USER_STATS_COLUMN) * statisticsArray.Size());
           auto stat = memory_->TranslateVirtual<X_USER_STATS_COLUMN*>(
               stats_guest_address);
-          player[playerIndex].pColumns = stats_guest_address;
+          player[playerIndex].columns_ptr = stats_guest_address;
 
           uint32_t statIndex = 0;
           for (Value::ConstValueIterator statObjectPtr =
                    statisticsArray.Begin();
                statObjectPtr != statisticsArray.End(); ++statObjectPtr) {
-            stat[statIndex].ColumnId = (*statObjectPtr)["id"].GetUint();
+            stat[statIndex].column_id = (*statObjectPtr)["id"].GetUint();
 
-            stat[statIndex].Value.type = static_cast<X_USER_DATA_TYPE>(
+            stat[statIndex].value.type = static_cast<X_USER_DATA_TYPE>(
                 (*statObjectPtr)["type"].GetUint());
 
-            X_USER_DATA_TYPE stat_type = stat[statIndex].Value.type;
+            X_USER_DATA_TYPE stat_type = stat[statIndex].value.type;
 
             switch (stat_type) {
               case X_USER_DATA_TYPE::CONTEXT: {
@@ -376,15 +376,15 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
 
             switch (stat_type) {
               case X_USER_DATA_TYPE::CONTEXT:
-                stat[statIndex].Value.data.u32 =
+                stat[statIndex].value.data.u32 =
                     (*statObjectPtr)["value"].GetUint();
                 break;
               case X_USER_DATA_TYPE::INT32:
-                stat[statIndex].Value.data.s32 =
+                stat[statIndex].value.data.s32 =
                     (*statObjectPtr)["value"].GetInt();
                 break;
               case X_USER_DATA_TYPE::INT64:
-                stat[statIndex].Value.data.s64 =
+                stat[statIndex].value.data.s64 =
                     (*statObjectPtr)["value"].GetInt64();
                 break;
               case X_USER_DATA_TYPE::UNSET: {
@@ -392,14 +392,14 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
               } break;
               default:
                 XELOGW("Unimplemented stat type for read, will attempt anyway.",
-                       static_cast<uint32_t>(stat[statIndex].Value.type));
+                       static_cast<uint32_t>(stat[statIndex].value.type));
                 if ((*statObjectPtr)["value"].IsNumber()) {
-                  stat[statIndex].Value.data.s64 =
+                  stat[statIndex].value.data.s64 =
                       (*statObjectPtr)["value"].GetUint64();
                 }
             }
 
-            player[playerIndex].Rank = 1;
+            player[playerIndex].rank = 1;
 
             if ((*statObjectPtr)["value"].IsNumber()) {
               // 41560901 uses i64Rating for ranking friends scores

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -11,6 +11,7 @@
 #include "xenia/base/logging.h"
 #include "xenia/emulator.h"
 #include "xenia/kernel/XLiveAPI.h"
+#include "xenia/kernel/json/read_user_stats_object_json.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xsession.h"
 
@@ -75,17 +76,6 @@ struct XGI_XUSER_ANID {
   xe::be<uint32_t> block;            // 1
 };
 static_assert_size(XGI_XUSER_ANID, 0x10);
-
-struct XGI_XUSER_READ_STATS {
-  xe::be<uint32_t> titleId;
-  xe::be<uint32_t> xuids_count;
-  xe::be<uint32_t> xuids_ptr;
-  xe::be<uint32_t> specs_count;
-  xe::be<uint32_t> specs_ptr;
-  xe::be<uint32_t> results_size;
-  xe::be<uint32_t> results_ptr;
-};
-static_assert_size(XGI_XUSER_READ_STATS, 0x1C);
 
 struct XGI_XUSER_STATS_RESET {
   xe::be<uint32_t> user_index;
@@ -202,220 +192,70 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
           reinterpret_cast<XGI_XUSER_READ_STATS*>(buffer);
 
       if (!data->results_ptr) {
-        return 1;
+        return X_E_INVALIDARG;
       }
 
-#pragma region Curl
-      Document doc;
-      doc.SetObject();
+      // 584107D7 caches results
+      X_USER_STATS_READ_RESULTS* results =
+          kernel_state()
+              ->memory()
+              ->TranslateVirtual<X_USER_STATS_READ_RESULTS*>(data->results_ptr);
 
-      Value xuidsJsonArray(kArrayType);
-      auto xuids =
-          memory_->TranslateVirtual<xe::be<uint64_t>*>(data->xuids_ptr);
+      std::memset(results, 0, sizeof(X_USER_STATS_READ_RESULTS));
 
-      for (uint32_t player_index = 0; player_index < data->xuids_count;
-           player_index++) {
-        const xe::be<uint64_t> xuid = xuids[player_index];
-
-        assert_true(IsValidXUID(xuid));
-
-        if (xuid) {
-          std::string xuid_str = string_util::to_hex_string(xuid);
-
-          Value value;
-          value.SetString(xuid_str.c_str(), 16, doc.GetAllocator());
-          xuidsJsonArray.PushBack(value, doc.GetAllocator());
-        }
+      // Max friends plus yourself
+      if (data->xuids_count > X_ONLINE_MAX_FRIENDS + 1) {
+        return X_E_INVALIDARG;
       }
 
-      if (xuidsJsonArray.Empty()) {
+      // 4D5307EA uses 6 leaderboards?
+      assert_false(data->specs_count > kXUserMaxReadStatsViews + 1);
+
+      std::unique_ptr<LeaderboardObjectJSON> leaderboards =
+          XLiveAPI::LeaderboardsFind(*data);
+
+      const X_USER_STATS_READ_RESULTS& read_results =
+          leaderboards->GetReadStatsResults();
+
+      results->views_ptr = read_results.views_ptr;
+      results->num_views = read_results.num_views;
+
+      // Provide pointer regardless
+      if (!results->views_ptr) {
+        results->views_ptr = kernel_state()->memory()->SystemHeapAlloc(
+            sizeof(X_USER_STATS_VIEW));
+
+        // 4D5307EA expects views_ptr but not 1 count.
+        results->num_views = 0;
+
         return X_E_SUCCESS;
       }
 
-      doc.AddMember("players", xuidsJsonArray, doc.GetAllocator());
+      // Validation
 
-      std::string title_id = fmt::format("{:08x}", kernel_state()->title_id());
-      doc.AddMember("titleId", title_id, doc.GetAllocator());
+      assert_false(results->num_views != data->specs_count);
 
-      Value leaderboardQueryJsonArray(kArrayType);
-      auto queries =
-          memory_->TranslateVirtual<X_USER_STATS_SPEC*>(data->specs_ptr);
+      const X_USER_STATS_SPEC* stats_specs =
+          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_SPEC*>(
+              data->specs_ptr);
 
-      for (unsigned int queryIndex = 0; queryIndex < data->specs_count;
-           queryIndex++) {
-        Value queryObject(kObjectType);
-        queryObject.AddMember("id", queries[queryIndex].view_id,
-                              doc.GetAllocator());
+      const X_USER_STATS_VIEW* views_ptr =
+          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
+              results->views_ptr);
 
-        assert_false(queries[queryIndex].num_column_ids >
-                     kXUserMaxStatsAttributes);
+      // 545107D4 uses same view id twice?
+      for (uint32_t spec_index = 0; spec_index < data->specs_count;
+           spec_index++) {
+        const X_USER_STATS_SPEC* stat_spec_ptr = stats_specs + spec_index;
+        const X_USER_STATS_VIEW* view_ptr = views_ptr + spec_index;
 
-        const uint32_t num_column_ids = std::min<uint32_t>(
-            queries[queryIndex].num_column_ids, kXUserMaxStatsAttributes);
+        assert_false(stat_spec_ptr->view_id == kTrueSkillViewId);
 
-        Value statIdsArray(kArrayType);
-        for (uint32_t stat_id_index = 0; stat_id_index < num_column_ids;
-             stat_id_index++) {
-          statIdsArray.PushBack(queries[queryIndex].column_ids[stat_id_index],
-                                doc.GetAllocator());
-        }
-        queryObject.AddMember("statisticIds", statIdsArray, doc.GetAllocator());
-        leaderboardQueryJsonArray.PushBack(queryObject, doc.GetAllocator());
+        // 545107FC, 454108D4, 58410A57, 584108FF, 41560834 doesn't use columns.
+        assert_false(stat_spec_ptr->num_column_ids < 1 ||
+                     stat_spec_ptr->num_column_ids > kXUserMaxStatsAttributes);
       }
 
-      doc.AddMember("queries", leaderboardQueryJsonArray, doc.GetAllocator());
-
-      rapidjson::StringBuffer buffer;
-      PrettyWriter<rapidjson::StringBuffer> writer(buffer);
-      doc.Accept(writer);
-
-      std::unique_ptr<HTTPResponseObjectJSON> chunk =
-          XLiveAPI::LeaderboardsFind((uint8_t*)buffer.GetString());
-
-      if (chunk->RawResponse().response == nullptr ||
-          chunk->StatusCode() != HTTP_STATUS_CODE::HTTP_CREATED) {
-        // FM2 crashes with X_ERROR_FUNCTION_FAILED
-        return X_ERROR_SUCCESS;
-      }
-
-      Document leaderboards;
-      leaderboards.Parse(chunk->RawResponse().response);
-      const Value& leaderboardsArray = leaderboards.GetArray();
-
-      auto leaderboards_guest_address = memory_->SystemHeapAlloc(
-          sizeof(X_USER_STATS_VIEW) * leaderboardsArray.Size());
-      auto leaderboard = memory_->TranslateVirtual<X_USER_STATS_VIEW*>(
-          leaderboards_guest_address);
-      auto resultsHeader =
-          memory_->TranslateVirtual<X_USER_STATS_READ_RESULTS*>(
-              data->results_ptr);
-      resultsHeader->num_views = leaderboardsArray.Size();
-      resultsHeader->views_ptr = leaderboards_guest_address;
-
-      uint32_t leaderboardIndex = 0;
-      for (Value::ConstValueIterator leaderboardObjectPtr =
-               leaderboardsArray.Begin();
-           leaderboardObjectPtr != leaderboardsArray.End();
-           ++leaderboardObjectPtr) {
-        leaderboard[leaderboardIndex].view_id =
-            (*leaderboardObjectPtr)["id"].GetUint();
-        auto playersArray = (*leaderboardObjectPtr)["players"].GetArray();
-        leaderboard[leaderboardIndex].num_rows = playersArray.Size();
-        leaderboard[leaderboardIndex].total_view_rows = playersArray.Size();
-        auto players_guest_address = memory_->SystemHeapAlloc(
-            sizeof(X_USER_STATS_ROW) * playersArray.Size());
-        auto player =
-            memory_->TranslateVirtual<X_USER_STATS_ROW*>(players_guest_address);
-        leaderboard[leaderboardIndex].rows_ptr = players_guest_address;
-
-        uint32_t playerIndex = 0;
-        for (Value::ConstValueIterator playerObjectPtr = playersArray.Begin();
-             playerObjectPtr != playersArray.End(); ++playerObjectPtr) {
-          auto gamertag = (*playerObjectPtr)["gamertag"].GetString();
-          auto gamertagLength =
-              (*playerObjectPtr)["gamertag"].GetStringLength();
-          memcpy(player[playerIndex].gamertag, gamertag, gamertagLength);
-
-          std::vector<uint8_t> xuid;
-          string_util::hex_string_to_array(
-              xuid, (*playerObjectPtr)["xuid"].GetString());
-          memcpy(&player[playerIndex].xuid, xuid.data(), 8);
-
-          auto statisticsArray = (*playerObjectPtr)["stats"].GetArray();
-          player[playerIndex].num_columns = statisticsArray.Size();
-          auto stats_guest_address = memory_->SystemHeapAlloc(
-              sizeof(X_USER_STATS_COLUMN) * statisticsArray.Size());
-          auto stat = memory_->TranslateVirtual<X_USER_STATS_COLUMN*>(
-              stats_guest_address);
-          player[playerIndex].columns_ptr = stats_guest_address;
-
-          uint32_t statIndex = 0;
-          for (Value::ConstValueIterator statObjectPtr =
-                   statisticsArray.Begin();
-               statObjectPtr != statisticsArray.End(); ++statObjectPtr) {
-            stat[statIndex].column_id = (*statObjectPtr)["id"].GetUint();
-
-            stat[statIndex].value.type = static_cast<X_USER_DATA_TYPE>(
-                (*statObjectPtr)["type"].GetUint());
-
-            X_USER_DATA_TYPE stat_type = stat[statIndex].value.type;
-
-            switch (stat_type) {
-              case X_USER_DATA_TYPE::CONTEXT: {
-                XELOGW("Statistic type: CONTEXT");
-              } break;
-              case X_USER_DATA_TYPE::INT32: {
-                XELOGW("Statistic type: INT32");
-              } break;
-              case X_USER_DATA_TYPE::INT64: {
-                XELOGW("Statistic type: INT64");
-              } break;
-              case X_USER_DATA_TYPE::DOUBLE: {
-                XELOGW("Statistic type: DOUBLE");
-              } break;
-              case X_USER_DATA_TYPE::FLOAT: {
-                XELOGW("Statistic type: FLOAT");
-              } break;
-              case X_USER_DATA_TYPE::DATETIME: {
-                XELOGW("Statistic type: DATETIME");
-              } break;
-              case X_USER_DATA_TYPE::UNSET: {
-                // Backend returns placeholder stats for display
-                XELOGW(
-                    "Row Index: {} - Placeholder stat missing stat ID in "
-                    "stats.json",
-                    playerIndex);
-              } break;
-              case X_USER_DATA_TYPE::WSTRING:
-              case X_USER_DATA_TYPE::BINARY:
-              default: {
-                XELOGW("Unsupported statistic type.",
-                       static_cast<uint32_t>(stat_type));
-              } break;
-            }
-
-            switch (stat_type) {
-              case X_USER_DATA_TYPE::CONTEXT:
-                stat[statIndex].value.data.u32 =
-                    (*statObjectPtr)["value"].GetUint();
-                break;
-              case X_USER_DATA_TYPE::INT32:
-                stat[statIndex].value.data.s32 =
-                    (*statObjectPtr)["value"].GetInt();
-                break;
-              case X_USER_DATA_TYPE::INT64:
-                stat[statIndex].value.data.s64 =
-                    (*statObjectPtr)["value"].GetInt64();
-                break;
-              case X_USER_DATA_TYPE::UNSET: {
-                // Ignore don't read missing/placeholder stat
-              } break;
-              default:
-                XELOGW("Unimplemented stat type for read, will attempt anyway.",
-                       static_cast<uint32_t>(stat[statIndex].value.type));
-                if ((*statObjectPtr)["value"].IsNumber()) {
-                  stat[statIndex].value.data.s64 =
-                      (*statObjectPtr)["value"].GetUint64();
-                }
-            }
-
-            player[playerIndex].rank = 1;
-
-            if ((*statObjectPtr)["value"].IsNumber()) {
-              // 41560901 uses i64Rating for ranking friends scores
-              player[playerIndex].i64Rating =
-                  (*statObjectPtr)["value"].GetUint64();
-            }
-
-            statIndex++;
-          }
-
-          playerIndex++;
-        }
-
-        leaderboardIndex++;
-      }
-#pragma endregion
       return X_E_SUCCESS;
     }
     case 0x000B001A: {

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -566,7 +566,15 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
              data->obj_ptr.get(), data->xuid.get(), data->num_views.get(),
              data->views_ptr.get());
 
-      return X_E_SUCCESS;
+      uint8_t* obj_ptr = memory_->TranslateVirtual<uint8_t*>(data->obj_ptr);
+
+      auto session =
+          XObject::GetNativeObject<XSession>(kernel_state(), obj_ptr);
+      if (!session) {
+        return X_STATUS_INVALID_HANDLE;
+      }
+
+      return session->FlushStats();
     }
     case 0x000B001F: {
       assert_true(!buffer_length ||

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -1658,6 +1658,15 @@ X_HRESULT XLiveBaseApp::XUserEstimateRankForRating(uint32_t buffer_ptr) {
   X_USER_ESTIMATE_RANK_RESULTS* estimate_rank_results_ptr =
       unmarshaller.Results<X_USER_ESTIMATE_RANK_RESULTS>();
 
+  for (const auto& rank_estimate : unmarshaller.StatsEstimateRanks()) {
+    const auto stats_view =
+        kernel_state()->emulator()->game_info_database()->GetStatsView(
+            rank_estimate.view_id);
+
+    // Read the leaderboard to determine if clip should be uploaded?
+    // XUserReadStats()
+  }
+
   xe::be<uint32_t>* ranks =
       reinterpret_cast<xe::be<uint32_t>*>(estimate_rank_results_ptr + 1);
 
@@ -2006,6 +2015,8 @@ X_HRESULT XLiveBaseApp::XStorageBuildServerPath(uint32_t buffer_ptr) {
     case X_STORAGE_FACILITY::FACILITY_GAME_CLIP: {
       X_STORAGE_FACILITY_INFO_GAME_CLIP game_clip_info_ptr = {};
 
+      assert_not_zero(args->storage_location_info_ptr);
+
       if (args->storage_location_info_ptr) {
         game_clip_info_ptr =
             *kernel_state_->memory()
@@ -2016,12 +2027,15 @@ X_HRESULT XLiveBaseApp::XStorageBuildServerPath(uint32_t buffer_ptr) {
                game_clip_info_ptr.leaderboard_id.get());
       }
 
-      // Validate ID via XLast
-      assert_false(game_clip_info_ptr.leaderboard_id == 0);
+      const uint32_t view_id = game_clip_info_ptr.leaderboard_id;
 
-      const std::string path = fmt::format(
-          "clips/title/{:08X}/{:016X}/{:08X}/{}", kernel_state()->title_id(),
-          xuid, game_clip_info_ptr.leaderboard_id.get(), filename_str);
+      const auto stats_view =
+          kernel_state()->emulator()->game_info_database()->GetStatsView(
+              view_id);
+
+      const std::string path =
+          fmt::format("clips/title/{:08X}/{:016X}/{:08X}/{}",
+                      kernel_state()->title_id(), xuid, view_id, filename_str);
 
       backend_server_path_str =
           fmt::format("{}/{}", backend_domain_prefix, path);

--- a/src/xenia/kernel/xam/user_data.h
+++ b/src/xenia/kernel/xam/user_data.h
@@ -68,6 +68,16 @@ static_assert_size(X_USER_DATA_UNION, 8);
 struct alignas(8) X_USER_DATA {
   X_USER_DATA_TYPE type;
   X_USER_DATA_UNION data;
+
+  X_USER_DATA() = default;
+
+  X_USER_DATA(X_USER_DATA& other) : type(other.type) {
+    std::memcpy(&data, &other.data, sizeof(X_USER_DATA_UNION));
+  };
+
+  X_USER_DATA(const X_USER_DATA& other) : type(other.type) {
+    std::memcpy(&data, &other.data, sizeof(X_USER_DATA_UNION));
+  };
 };
 static_assert_size(X_USER_DATA, 16);
 

--- a/src/xenia/kernel/xam/user_property.h
+++ b/src/xenia/kernel/xam/user_property.h
@@ -30,6 +30,11 @@ static_assert_size(XUSER_CONTEXT, 0x8);
 struct XUSER_PROPERTY {
   xe::be<uint32_t> property_id;
   X_USER_DATA data;
+
+  XUSER_PROPERTY(XUSER_PROPERTY& other)
+      : property_id(other.property_id), data(other.data) {};
+  XUSER_PROPERTY(const XUSER_PROPERTY& other)
+      : property_id(other.property_id), data(other.data) {};
 };
 static_assert_size(XUSER_PROPERTY, 0x18);
 

--- a/src/xenia/kernel/xam/user_tracker.cc
+++ b/src/xenia/kernel/xam/user_tracker.cc
@@ -241,8 +241,10 @@ void UserTracker::AddDefaultProperties(uint64_t xuid) {
       Property(XPROPERTY_GAMER_LANGUAGE, cvars::user_language);
   Property PLATFORM_TYPE = Property(
       XPROPERTY_PLATFORM_TYPE, static_cast<int32_t>(PLATFORM_TYPE::Xbox360));
-  Property GAMER_MU = Property(XPROPERTY_GAMER_MU, 0.0);
-  Property GAMER_SIGMA = Property(XPROPERTY_GAMER_SIGMA, 0.0);
+  Property GAMER_MU = Property(XPROPERTY_GAMER_MU,
+                               static_cast<double>(X_STATS_SKILL_MU_DEFAULT));
+  Property GAMER_SIGMA = Property(
+      XPROPERTY_GAMER_SIGMA, static_cast<double>(X_STATS_SKILL_SIGMA_DEFAULT));
 
   AddProperty(xuid, &PUID);  // Required - 58410AC2 sets this manually
   AddProperty(xuid, &GAMER_HOST_NAME);  // Required

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/base/logging.h"
+#include "xenia/emulator.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/user_profile.h"
@@ -1233,11 +1234,15 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
     return X_ERROR_INVALID_PARAMETER;
   }
 
-  if (!num_rows || num_rows > kXUserMaxStatsRows) {
+  if (!num_rows || num_rows > X_STATS_MAX_ROW_COUNT) {
     return X_ERROR_INVALID_PARAMETER;
   }
 
   if (!num_stats_specs) {
+    return X_ERROR_INVALID_PARAMETER;
+  }
+
+  if (enumerator_type > X_STATS_ENUMERATOR_TYPE::BY_RATING) {
     return X_ERROR_INVALID_PARAMETER;
   }
 
@@ -1253,28 +1258,29 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
   const X_STATS_ENUMERATOR_TYPE type =
       static_cast<X_STATS_ENUMERATOR_TYPE>(enumerator_type.value());
 
-  // pivot
   uint64_t xuid = 0;
+  uint32_t start_rank = 0;
+  uint64_t start_i64rating = 0;
 
   switch (type) {
     case X_STATS_ENUMERATOR_TYPE::XUID: {
       xuid = pivot_user;
-      XELOGI("XamUserCreateStatsEnumeratorByXuid: {:016X}", xuid);
+      XELOGI("StatsEnumeratorByXUID: {:016X}", xuid);
     } break;
     case X_STATS_ENUMERATOR_TYPE::RANK: {
-      xuid = pivot_user & 0xFFFF;
-      XELOGI("XamUserCreateStatsEnumeratorByRank: {:08X}", xuid);
+      // 58410826 expects row ranks to start at rank_start.
+      start_rank = pivot_user & 0xFFFF;
+      XELOGI("StatsEnumeratorByRank at rank start {}", start_rank);
     } break;
     case X_STATS_ENUMERATOR_TYPE::RANK_PER_SPEC: {
-      xuid = pivot_user;
-      XELOGI("XamUserCreateStatsEnumeratorByRankPreSpec: {:016X}", xuid);
+      start_rank = pivot_user & 0xFFFF;
+      XELOGI("StatsEnumeratorByRankPreSpec");
     } break;
     case X_STATS_ENUMERATOR_TYPE::BY_RATING: {
-      xuid = pivot_user;
-      XELOGI("XamUserCreateStatsEnumeratorByRating: {:016X}", xuid);
+      start_i64rating = pivot_user;
+      XELOGI("StatsEnumeratorByRating at i64Rating of {:016X}",
+             start_i64rating);
     } break;
-    default:
-      break;
   }
 
   const uint32_t page_size =
@@ -1299,20 +1305,32 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
   const X_USER_STATS_SPEC* stat_specs_ptr = stats_ptr;
 
   for (size_t view_index = 0; view_index < num_stats_specs; view_index++) {
-    const X_USER_STATS_SPEC* stat_spec_ptr = stat_specs_ptr + view_index;
-    X_USER_STATS_VIEW* view_ptr = views_ptr + view_index;
+    const X_USER_STATS_SPEC& stat_spec_ptr = stat_specs_ptr[view_index];
+    X_USER_STATS_VIEW& view_ptr = views_ptr[view_index];
+    const uint32_t view_id = stat_spec_ptr.view_id;
 
-    assert_false(stat_spec_ptr->view_id == kTrueSkillViewId);
+    const auto spa_stats_view =
+        kernel_state()->emulator()->game_info_database()->GetStatsView(view_id);
+
+    if (IsTrueSkillViewID(view_id)) {
+      XELOGI("TrueSkill View ID: {:08X}", view_id);
+    }
 
     // 4B5607E8 expects view id otherwise crashes.
-    view_ptr->view_id = stat_spec_ptr->view_id;
-    view_ptr->total_view_rows = rows;
-    view_ptr->num_rows = rows;
+    view_ptr.view_id = view_id;
+    view_ptr.total_view_rows = rows;
+    view_ptr.num_rows = rows;
 
-    total_rows_size += rows * sizeof(X_USER_STATS_ROW);
+    // 545107D1 wants this set to prevent XUserReadStats
+    // from crashing?
+    // view_ptr->num_rows = num_rows.value();
+
+    const uint32_t rows_size = sizeof(X_USER_STATS_ROW) * rows;
+
+    total_rows_size += rows_size;
 
     const uint32_t rows_address =
-        kernel_state()->memory()->SystemHeapAlloc(sizeof(X_USER_STATS_ROW));
+        kernel_state()->memory()->SystemHeapAlloc(rows_size);
 
     X_USER_STATS_ROW* rows_ptr =
         kernel_state()->memory()->TranslateVirtual<X_USER_STATS_ROW*>(
@@ -1320,33 +1338,68 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
 
     // 584111FA and 5841089F want rows pointer even if row count is 0 to prevent
     // crashing.
-    view_ptr->rows_ptr = rows_address;
+    view_ptr.rows_ptr = rows_address;
 
-    for (size_t row_index = 0; row_index < rows; row_index++) {
-      X_USER_STATS_ROW* row_ptr = rows_ptr + row_index;
+    for (uint32_t row_index = 0; row_index < rows; row_index++) {
+      X_USER_STATS_ROW& row_ptr = rows_ptr[row_index];
+
+      const uint32_t entry_count = row_index + 1;
+
+      // Dummy players
+      const std::string gamertag = fmt::format("Xenia User {}", entry_count);
+      xe::string_util::copy_truncating(row_ptr.gamertag, gamertag.c_str(),
+                                       sizeof(row_ptr.gamertag));
+
+      row_ptr.rank = entry_count;
+      row_ptr.i64Rating = entry_count;
+
+      row_ptr.xuid =
+          kernel_state()->xam_state()->profile_manager()->GenerateXuidOnline();
+
+      if (!stat_spec_ptr.num_column_ids) {
+        continue;
+      }
+
+      const uint32_t columns_count = stat_spec_ptr.num_column_ids;
+      const uint32_t columns_size = sizeof(X_USER_STATS_COLUMN) * columns_count;
 
       const uint32_t columns_address =
-          kernel_state()->memory()->SystemHeapAlloc(
-              sizeof(X_USER_STATS_COLUMN));
+          kernel_state()->memory()->SystemHeapAlloc(columns_size);
 
       X_USER_STATS_COLUMN* columns_ptr =
           kernel_state()->memory()->TranslateVirtual<X_USER_STATS_COLUMN*>(
               columns_address);
 
-      total_columns_size +=
-          stat_spec_ptr->num_column_ids * sizeof(X_USER_STATS_COLUMN);
+      total_columns_size += columns_size;
 
-      row_ptr->num_columns = stat_spec_ptr->num_column_ids;
-      row_ptr->columns_ptr = columns_address;
+      row_ptr.num_columns = columns_count;
+      row_ptr.columns_ptr = columns_address;
 
-      for (size_t column_index = 0;
-           column_index < stat_spec_ptr->num_column_ids; column_index++) {
-        X_USER_STATS_COLUMN* column_ptr = columns_ptr + column_index;
+      for (size_t column_index = 0; column_index < columns_count;
+           column_index++) {
+        X_USER_STATS_COLUMN& column_ptr = columns_ptr[column_index];
+        const uint32_t column_id = stat_spec_ptr.column_ids[column_index];
 
-        column_ptr->column_id = stat_spec_ptr->column_ids[column_index];
+        column_ptr.column_id = column_id;
+        column_ptr.value.data = {};
 
-        column_ptr->value.type = X_USER_DATA_TYPE::INT32;
-        column_ptr->value.data.u32 = 0;
+        // Determine the property type
+        if (IsTrueSkillViewID(view_id)) {
+          column_ptr.value.type = GetTrueSkillColumnType(column_ptr.column_id);
+        } else {
+          if (spa_stats_view.has_value()) {
+            for (const auto& column :
+                 spa_stats_view.value().shared_view.column_entries) {
+              if (column.attribute_id == column_id) {
+                column_ptr.value.type =
+                    xam::UserData::get_type(column.property_id);
+              }
+            }
+          } else {
+            column_ptr.value.type = xam::X_USER_DATA_TYPE::INT32;
+            assert_always();
+          }
+        }
       }
     }
   }

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -1302,6 +1302,8 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
     const X_USER_STATS_SPEC* stat_spec_ptr = stat_specs_ptr + view_index;
     X_USER_STATS_VIEW* view_ptr = views_ptr + view_index;
 
+    assert_false(stat_spec_ptr->view_id == kTrueSkillViewId);
+
     // 4B5607E8 expects view id otherwise crashes.
     view_ptr->view_id = stat_spec_ptr->view_id;
     view_ptr->total_view_rows = rows;

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -1214,9 +1214,22 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
     lpdword_t handle_ptr) {
   assert_false(enumerator_type > X_STATS_ENUMERATOR_TYPE::BY_RATING);
 
+  const uint32_t title_id_ =
+      title_id ? title_id.value() : kernel_state()->title_id();
+
+  if (!handle_ptr) {
+    return X_ERROR_INVALID_PARAMETER;
+  }
+
   *handle_ptr = 0;
 
-  if (!pivot_user || !stats_ptr || !buffer_size_ptr || !handle_ptr) {
+  if (!buffer_size_ptr) {
+    return X_ERROR_INVALID_PARAMETER;
+  }
+
+  *buffer_size_ptr = 0;
+
+  if (!pivot_user || !stats_ptr) {
     return X_ERROR_INVALID_PARAMETER;
   }
 
@@ -1259,31 +1272,91 @@ dword_result_t XamUserCreateStatsEnumerator_entry(
     case X_STATS_ENUMERATOR_TYPE::BY_RATING: {
       xuid = pivot_user;
       XELOGI("XamUserCreateStatsEnumeratorByRating: {:016X}", xuid);
-      // auto e = new XStaticEnumerator<X_USER_ESTIMATE_RANK_RESULTS>(
-      //     kernel_state(), 1);
     } break;
     default:
       break;
   }
 
-  const uint32_t views = 1;
+  const uint32_t page_size =
+      kernel_state()->memory()->GetPhysicalHeap()->page_size();
 
-  uint32_t view_address =
-      kernel_state()->memory()->SystemHeapAlloc(sizeof(X_USER_STATS_VIEW));
+  // sizeof(X_USER_STATS_VIEW) becomes page_size of 4096.
+  const uint32_t view_address =
+      kernel_state()->memory()->SystemHeapAlloc(page_size);
 
-  X_USER_STATS_VIEW* view_ptr =
+  X_USER_STATS_VIEW* views_ptr =
       kernel_state()->memory()->TranslateVirtual<X_USER_STATS_VIEW*>(
           view_address);
 
+  uint32_t rows = num_rows.value();
+
+  uint32_t total_rows_size = 0;
+  uint32_t total_columns_size = 0;
+
+  // Tell game we have no rows to display
+  rows = 0;
+
+  const X_USER_STATS_SPEC* stat_specs_ptr = stats_ptr;
+
+  for (size_t view_index = 0; view_index < num_stats_specs; view_index++) {
+    const X_USER_STATS_SPEC* stat_spec_ptr = stat_specs_ptr + view_index;
+    X_USER_STATS_VIEW* view_ptr = views_ptr + view_index;
+
+    // 4B5607E8 expects view id otherwise crashes.
+    view_ptr->view_id = stat_spec_ptr->view_id;
+    view_ptr->total_view_rows = rows;
+    view_ptr->num_rows = rows;
+
+    total_rows_size += rows * sizeof(X_USER_STATS_ROW);
+
+    const uint32_t rows_address =
+        kernel_state()->memory()->SystemHeapAlloc(sizeof(X_USER_STATS_ROW));
+
+    X_USER_STATS_ROW* rows_ptr =
+        kernel_state()->memory()->TranslateVirtual<X_USER_STATS_ROW*>(
+            rows_address);
+
+    // 584111FA and 5841089F want rows pointer even if row count is 0 to prevent
+    // crashing.
+    view_ptr->rows_ptr = rows_address;
+
+    for (size_t row_index = 0; row_index < rows; row_index++) {
+      X_USER_STATS_ROW* row_ptr = rows_ptr + row_index;
+
+      const uint32_t columns_address =
+          kernel_state()->memory()->SystemHeapAlloc(
+              sizeof(X_USER_STATS_COLUMN));
+
+      X_USER_STATS_COLUMN* columns_ptr =
+          kernel_state()->memory()->TranslateVirtual<X_USER_STATS_COLUMN*>(
+              columns_address);
+
+      total_columns_size +=
+          stat_spec_ptr->num_column_ids * sizeof(X_USER_STATS_COLUMN);
+
+      row_ptr->num_columns = stat_spec_ptr->num_column_ids;
+      row_ptr->columns_ptr = columns_address;
+
+      for (size_t column_index = 0;
+           column_index < stat_spec_ptr->num_column_ids; column_index++) {
+        X_USER_STATS_COLUMN* column_ptr = columns_ptr + column_index;
+
+        column_ptr->column_id = stat_spec_ptr->column_ids[column_index];
+
+        column_ptr->value.type = X_USER_DATA_TYPE::INT32;
+        column_ptr->value.data.u32 = 0;
+      }
+    }
+  }
+
   X_USER_STATS_READ_RESULTS* results = e->AppendItem();
 
-  // Games expect 1 view, 0 causes issues.
-  // 58410A70, 58411259, 425607D9, 434D0838
-  results->num_views = views;
+  results->num_views = num_stats_specs.value();
   results->views_ptr = view_address;
 
-  *buffer_size_ptr =
-      sizeof(X_USER_STATS_READ_RESULTS) + (views * sizeof(X_USER_STATS_VIEW));
+  *buffer_size_ptr = sizeof(X_USER_STATS_READ_RESULTS) +
+                     (num_stats_specs * sizeof(X_USER_STATS_VIEW)) +
+                     total_rows_size + total_columns_size;
 
   assert_false(*buffer_size_ptr == 0);
 

--- a/src/xenia/kernel/xam/xdbf/spa_info.h
+++ b/src/xenia/kernel/xam/xdbf/spa_info.h
@@ -77,6 +77,12 @@ enum class ViewFieldEntryFlags : uint32_t {
 
 enum class ViewFieldType : uint8_t { kContextField, kPropertyField };
 
+// System Attribute Ids
+constexpr uint32_t RankAttributeId = 0xFFFF;
+constexpr uint32_t RatingAttributeId = 0xFFFE;
+constexpr uint32_t GamertagAttributeId = 0xFFFD;
+constexpr uint32_t AttachmentSizeAttributeId = 0xFFFA;
+
 constexpr inline std::string GetAggregationTypeName(
     const uint32_t aggregation_type) {
   switch (static_cast<AggregationType>(aggregation_type)) {
@@ -105,15 +111,16 @@ constexpr inline std::string GetViewTypeName(const uint32_t view_type) {
       return "";
   }
 }
+
 constexpr inline std::string AttributeIdToName(const uint16_t id) {
   switch (id) {
-    case std::numeric_limits<uint16_t>::max():
+    case RankAttributeId:
       return "Rank";
-    case 65534:
+    case RatingAttributeId:
       return "Rating";
-    case 65533:
+    case GamertagAttributeId:
       return "Gamertag";
-    case 65530:
+    case AttachmentSizeAttributeId:
       return "Attachment Size";
     default:
       return "";

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -45,6 +45,7 @@ namespace xe {
 #define X_ONLINE_E_SESSION_INSUFFICIENT_BUFFER              static_cast<X_HRESULT>(0x80155207L)
 #define X_ONLINE_E_SESSION_JOIN_ILLEGAL                     static_cast<X_HRESULT>(0x8015520AL)
 #define X_ONLINE_E_SESSION_NOT_FOUND                        static_cast<X_HRESULT>(0x80155200L)
+#define X_ONLINE_E_SESSION_INVALID_FLAGS                    static_cast<X_HRESULT>(0x80155204L)
 #define X_ONLINE_E_SESSION_REQUIRES_ARBITRATION             static_cast<X_HRESULT>(0x80155205L)
 #define X_ONLINE_E_SESSION_NOT_LOGGED_ON                    static_cast<X_HRESULT>(0x80155209L)
 #define X_ONLINE_E_SESSION_FULL                             static_cast<X_HRESULT>(0x80155202L)
@@ -61,6 +62,12 @@ namespace xe {
 #define X_ONLINE_E_ACCOUNTS_USER_OPTED_OUT                  static_cast<X_HRESULT>(0x80154099L)
 #define X_ONLINE_E_ACCOUNTS_USER_GET_ACCOUNT_INFO_ERROR     static_cast<X_HRESULT>(0x80154098L)
 #define X_ONLINE_E_NOTIFICATION_TOO_MANY_SUBS               static_cast<X_HRESULT>(0x8015200EL)
+#define X_ONLINE_E_STAT_INVALID_TITLE_OR_LEADERBOARD        static_cast<X_HRESULT>(0x80159002L)
+#define X_ONLINE_E_STAT_USER_NOT_FOUND                      static_cast<X_HRESULT>(0x80159003L)
+#define X_ONLINE_E_STAT_TOO_MANY_SPECS                      static_cast<X_HRESULT>(0x80159004L)
+#define X_ONLINE_E_STAT_TOO_MANY_STATS                      static_cast<X_HRESULT>(0x80159005L)
+#define X_ONLINE_E_STAT_INVALID_ATTACHMENT                  static_cast<X_HRESULT>(0x80159202L)
+#define X_ONLINE_S_STAT_CAN_UPLOAD_ATTACHMENT               static_cast<X_HRESULT>(0x00159203L)
 
 #define X_PARTY_E_NOT_IN_PARTY                              static_cast<X_HRESULT>(0x807D0003L)
 
@@ -123,6 +130,23 @@ namespace xe {
 #define X_PARTY_USER_ISINPARTYVOICE                         0x00000002
 #define X_PARTY_USER_ISTALKING                              0x00000004
 #define X_PARTY_USER_ISINGAMESESSION                        0x00000008
+
+#define X_USER_STATS_ATTRIBUTES_IN_SPEC                     64
+
+#define X_STATS_MAX_VIEWS                                   64
+#define X_STATS_MAX_PROPERTIES_IN_VIEW                      64
+#define X_STATS_MAX_USER_COUNT                              101
+#define X_STATS_MAX_ROW_COUNT                               100
+
+// System defined TrueSkill leaderboard columns
+#define X_STATS_COLUMN_SKILL_SKILL                          61
+#define X_STATS_COLUMN_SKILL_GAMESPLAYED                    62
+#define X_STATS_COLUMN_SKILL_MU                             63
+#define X_STATS_COLUMN_SKILL_SIGMA                          64
+
+#define X_STATS_SKILL_SKILL_DEFAULT                         1
+#define X_STATS_SKILL_MU_DEFAULT                            3.0
+#define X_STATS_SKILL_SIGMA_DEFAULT                         1.0
 
 #define X_MARKETPLACE_CONTENT_ID_LEN                        20
 #define X_MARKETPLACE_ASSET_SIGNATURE_SIZE                  256
@@ -205,7 +229,7 @@ enum PropertyID : uint32_t {
   XPROPERTY_RANK =
       PropertyID(true, kernel::xam::X_USER_DATA_TYPE::INT32, 0x001), // 0x10008001
   XPROPERTY_GAMERNAME =
-      PropertyID(true, kernel::xam::X_USER_DATA_TYPE::WSTRING, 0x002), // 0x40008002
+      PropertyID(true, kernel::xam::X_USER_DATA_TYPE::WSTRING, 0x002), // 0x40008002 (Displayed in XSession Search)
   XPROPERTY_SESSION_ID =
       PropertyID(true, kernel::xam::X_USER_DATA_TYPE::INT64, 0x003), // 0x20008003
   XPROPERTY_GAMER_ZONE =
@@ -225,7 +249,7 @@ enum PropertyID : uint32_t {
   XPROPERTY_AFFILIATE_VALUE =
       PropertyID(true, kernel::xam::X_USER_DATA_TYPE::INT64, 0x108), // 0x20008108
   XPROPERTY_GAMER_HOSTNAME =
-      PropertyID(true, kernel::xam::X_USER_DATA_TYPE::WSTRING, 0x109), // 0x40008109
+      PropertyID(true, kernel::xam::X_USER_DATA_TYPE::WSTRING, 0x109), // 0x40008109 (Displayed in Leaderboards)
   XPROPERTY_PLATFORM_TYPE =
       PropertyID(true, kernel::xam::X_USER_DATA_TYPE::INT32, 0x201), // 0x10008201
   XPROPERTY_PLATFORM_LOCK =
@@ -288,11 +312,39 @@ constexpr uint32_t XEX_PRIVILEGE_PII_ACCESS = 13;
 constexpr uint32_t XEX_PRIVILEGE_CROSSPLATFORM_SYSTEM_LINK = 14;
 
 // 4D5307EA, 5841089F, 5841089F
-constexpr uint32_t kTrueSkillViewId = 0xFFFF0000;
+constexpr uint32_t RankedTrueSkillViewIdMask = 0xFFFF0000;
+constexpr uint32_t StandardTrueSkillViewIdMask = 0xFFFE0000;
 
-constexpr uint32_t kXUserMaxStatsRows = 100;
-constexpr uint32_t kXUserMaxStatsAttributes = 64;
-constexpr uint32_t kXUserMaxReadStatsViews = 5;
+constexpr uint32_t XUserMaxReadStatsViews = 5;
+
+inline bool IsRankedTrueSkillViewID(const uint32_t view_id) {
+  return (view_id & RankedTrueSkillViewIdMask) == RankedTrueSkillViewIdMask;
+}
+
+inline bool IsStandardTrueSkillViewID(const uint32_t view_id) {
+  return (view_id & StandardTrueSkillViewIdMask) == StandardTrueSkillViewIdMask;
+}
+
+inline bool IsTrueSkillViewID(const uint32_t view_id) {
+  return IsRankedTrueSkillViewID(view_id) || IsStandardTrueSkillViewID(view_id);
+}
+
+inline xam::X_USER_DATA_TYPE GetTrueSkillColumnType(const uint32_t column_id) {
+  switch (column_id) {
+    case X_STATS_COLUMN_SKILL_SKILL:
+      // 494707E4, 545107D1 expect INT64
+      return xam::X_USER_DATA_TYPE::INT64;
+    case X_STATS_COLUMN_SKILL_GAMESPLAYED:
+      // or INT32?
+      return xam::X_USER_DATA_TYPE::INT64;
+    case X_STATS_COLUMN_SKILL_MU:
+      return xam::X_USER_DATA_TYPE::DOUBLE;
+    case X_STATS_COLUMN_SKILL_SIGMA:
+      return xam::X_USER_DATA_TYPE::DOUBLE;
+    default:
+      return xam::X_USER_DATA_TYPE::CONTEXT;
+  }
+}
 
 // XUIDs -> Views -> Property IDs -> Property
 using view_properties_unordered_map = std::unordered_map<
@@ -567,7 +619,7 @@ struct X_PARTY_USER_LIST_INTERNAL {
 static_assert_size(X_PARTY_USER_LIST_INTERNAL, 0x1008);
 
 struct XGI_XUSER_READ_STATS {
-  xe::be<uint32_t> titleId;
+  xe::be<uint32_t> title_id;
   xe::be<uint32_t> xuids_count;
   xe::be<uint32_t> xuids_ptr;
   xe::be<uint32_t> specs_count;
@@ -610,9 +662,9 @@ static_assert_size(X_USER_STATS_READ_RESULTS, 0x8);
 struct X_USER_STATS_SPEC {
   xe::be<uint32_t> view_id;
   xe::be<uint32_t> num_column_ids;
-  xe::be<uint16_t> column_ids[kXUserMaxStatsAttributes];
+  xe::be<uint16_t> column_ids[X_USER_STATS_ATTRIBUTES_IN_SPEC];
 };
-static_assert_size(X_USER_STATS_SPEC, 8 + kXUserMaxStatsAttributes * 2);
+static_assert_size(X_USER_STATS_SPEC, 8 + X_USER_STATS_ATTRIBUTES_IN_SPEC * 2);
 
 struct X_USER_ESTIMATE_RANK_RESULTS {
   xe::be<uint32_t> num_ranks;

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -14,7 +14,7 @@
 
 #include "xenia/base/byte_order.h"
 #include "xenia/kernel/util/xfiletime.h"
-#include "xenia/kernel/xam/user_data.h"
+#include "xenia/kernel/xam/user_property.h"
 
 #ifdef XE_PLATFORM_WIN32
 #define _WINSOCK_DEPRECATED_NO_WARNINGS  // inet_addr
@@ -290,9 +290,14 @@ constexpr uint32_t XEX_PRIVILEGE_CROSSPLATFORM_SYSTEM_LINK = 14;
 // 4D5307EA, 5841089F, 5841089F
 constexpr uint32_t kTrueSkillViewId = 0xFFFF0000;
 
-constexpr uint8_t kXUserMaxStatsRows = 100;
-constexpr uint8_t kXUserMaxStatsAttributes = 64;
+constexpr uint32_t kXUserMaxStatsRows = 100;
+constexpr uint32_t kXUserMaxStatsAttributes = 64;
 constexpr uint32_t kXUserMaxReadStatsViews = 5;
+
+// XUIDs -> Views -> Property IDs -> Property
+using view_properties_unordered_map = std::unordered_map<
+    uint64_t,
+    std::unordered_map<uint32_t, std::unordered_map<uint32_t, xam::Property>>>;
 
 constexpr uint32_t kTMSUserMaxSize = 8192;          // 8 KB
 constexpr uint32_t kTMSTitleMaxSize = 1048576 * 5;  // 5 MB

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -287,9 +287,12 @@ constexpr uint16_t XNET_SYSTEMLINK_PORT = 3074;
 constexpr uint32_t XEX_PRIVILEGE_PII_ACCESS = 13;
 constexpr uint32_t XEX_PRIVILEGE_CROSSPLATFORM_SYSTEM_LINK = 14;
 
-constexpr uint8_t kXUserMaxStatsRows = 100;
+// 4D5307EA, 5841089F, 5841089F
+constexpr uint32_t kTrueSkillViewId = 0xFFFF0000;
 
+constexpr uint8_t kXUserMaxStatsRows = 100;
 constexpr uint8_t kXUserMaxStatsAttributes = 64;
+constexpr uint32_t kXUserMaxReadStatsViews = 5;
 
 constexpr uint32_t kTMSUserMaxSize = 8192;          // 8 KB
 constexpr uint32_t kTMSTitleMaxSize = 1048576 * 5;  // 5 MB
@@ -557,6 +560,17 @@ struct X_PARTY_USER_LIST_INTERNAL {
   X_PARTY_USER_INFO_INTERNAL users[X_PARTY_MAX_USERS];
 };
 static_assert_size(X_PARTY_USER_LIST_INTERNAL, 0x1008);
+
+struct XGI_XUSER_READ_STATS {
+  xe::be<uint32_t> titleId;
+  xe::be<uint32_t> xuids_count;
+  xe::be<uint32_t> xuids_ptr;
+  xe::be<uint32_t> specs_count;
+  xe::be<uint32_t> specs_ptr;
+  xe::be<uint32_t> results_size;
+  xe::be<uint32_t> results_ptr;
+};
+static_assert_size(XGI_XUSER_READ_STATS, 0x1C);
 
 struct X_USER_STATS_VIEW {
   xe::be<uint32_t> view_id;

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -559,39 +559,39 @@ struct X_PARTY_USER_LIST_INTERNAL {
 static_assert_size(X_PARTY_USER_LIST_INTERNAL, 0x1008);
 
 struct X_USER_STATS_VIEW {
-  xe::be<uint32_t> ViewId;
-  xe::be<uint32_t> TotalViewRows;
-  xe::be<uint32_t> NumRows;
-  xe::be<uint32_t> pRows;
+  xe::be<uint32_t> view_id;
+  xe::be<uint32_t> total_view_rows;
+  xe::be<uint32_t> num_rows;
+  xe::be<uint32_t> rows_ptr;  // X_USER_STATS_ROW*
 };
 static_assert_size(X_USER_STATS_VIEW, 0x10);
 
 struct X_USER_STATS_COLUMN {
-  xe::be<uint16_t> ColumnId;
-  xam::X_USER_DATA Value;
+  xe::be<uint16_t> column_id;  // Column ordinal
+  xam::X_USER_DATA value;
 };
 static_assert_size(X_USER_STATS_COLUMN, 0x18);
 
 struct X_USER_STATS_ROW {
   xe::be<uint64_t> xuid;
-  xe::be<uint32_t> Rank;
+  xe::be<uint32_t> rank;
   xe::be<uint64_t> i64Rating;
-  CHAR szGamertag[16];
-  xe::be<uint32_t> NumColumns;
-  xe::be<uint32_t> pColumns;
+  char gamertag[16];
+  xe::be<uint32_t> num_columns;
+  xe::be<uint32_t> columns_ptr;  // X_USER_STATS_COLUMN*
 };
 static_assert_size(X_USER_STATS_ROW, 0x30);
 
 struct X_USER_STATS_READ_RESULTS {
   xe::be<uint32_t> num_views;
-  xe::be<uint32_t> views_ptr;
+  xe::be<uint32_t> views_ptr;  // X_USER_STATS_VIEW*
 };
 static_assert_size(X_USER_STATS_READ_RESULTS, 0x8);
 
 struct X_USER_STATS_SPEC {
   xe::be<uint32_t> view_id;
   xe::be<uint32_t> num_column_ids;
-  xe::be<uint16_t> column_Ids[kXUserMaxStatsAttributes];
+  xe::be<uint16_t> column_ids[kXUserMaxStatsAttributes];
 };
 static_assert_size(X_USER_STATS_SPEC, 8 + kXUserMaxStatsAttributes * 2);
 

--- a/src/xenia/kernel/xsession.cc
+++ b/src/xenia/kernel/xsession.cc
@@ -673,8 +673,6 @@ X_RESULT XSession::MigrateHost(XGI_SESSION_MIGRATE* data) {
   return X_ERROR_SUCCESS;
 }
 
-// Server dependancy can be removed if we calculate remote machine id from
-// remote mac address.
 X_RESULT XSession::RegisterArbitration(XGI_SESSION_ARBITRATION* data) {
   XSESSION_REGISTRATION_RESULTS* results_ptr =
       kernel_state_->memory()->TranslateVirtual<XSESSION_REGISTRATION_RESULTS*>(
@@ -728,10 +726,34 @@ X_RESULT XSession::ModifySkill(XGI_SESSION_MODIFYSKILL* data) {
       kernel_state_->memory()->TranslateVirtual<xe::be<uint64_t>*>(
           data->xuid_array_ptr);
 
-  for (uint32_t i = 0; i < data->array_count; i++) {
-    const auto& xuid = xuid_array[i];
+  const bool is_matchmaking_session = HasSessionFlag(
+      static_cast<SessionFlags>((uint32_t)local_details_.Flags), MATCHMAKING);
 
-    XELOGI("ModifySkill XUID: {:016X}", xuid.get());
+  if (!is_matchmaking_session) {
+    return X_ONLINE_E_SESSION_INVALID_FLAGS;
+  }
+
+  const uint32_t game_mode = local_details_.GameMode;
+  const uint32_t game_type = local_details_.GameType;
+  const uint32_t skill_view_id =
+      xam::GetSkillLeaderboardId(game_type, game_mode);
+
+  X_USER_STATS_SPEC spec = {};
+
+  spec.view_id = skill_view_id;
+  spec.num_column_ids = 2;
+  spec.column_ids[0] = X_STATS_COLUMN_SKILL_MU;
+  spec.column_ids[1] = X_STATS_COLUMN_SKILL_SIGMA;
+
+  // XUserReadStats(0, data->array_count, data->xuid_array_ptr, 1, spec,
+  //                results_size, results_ptr, nullptr);
+
+  // TODO: Calculate aggregate skill from skill leaderboard results
+
+  for (uint32_t i = 0; i < data->array_count; i++) {
+    const uint64_t xuid = xuid_array[i];
+
+    XELOGI("ModifySkill XUID: {:016X}", xuid);
   }
 
   return X_ERROR_SUCCESS;
@@ -756,76 +778,142 @@ X_RESULT XSession::WriteStats(XGI_STATS_WRITE* data) {
 
   const uint64_t xuid = data->xuid;
 
+  if (!data->xuid) {
+    // TODO: How does TrueSkill system overrides work?
+    //
+    // XPROPERTY_SESSION_SKILL_DRAW_PROBABILITY
+    // XPROPERTY_SESSION_SKILL_BETA
+    // XPROPERTY_SESSION_SKILL_TAU
+
+    XELOGI("{}: TrueSkill System Overrides", __func__);
+    assert_always();
+    return X_ERROR_SUCCESS;
+  }
+
+  const bool is_arbitrated_session = HasSessionFlag(
+      static_cast<SessionFlags>((uint32_t)local_details_.Flags), ARBITRATION);
+
   const XSESSION_VIEW_PROPERTIES* views_properties_ptr =
       kernel_state()->memory()->TranslateVirtual<XSESSION_VIEW_PROPERTIES*>(
           data->views_ptr);
 
-  std::vector<XSESSION_VIEW_PROPERTIES> views_properties(
-      views_properties_ptr, views_properties_ptr + data->num_views);
+  assert_false(data->num_views > X_STATS_MAX_VIEWS);
 
-  for (uint32_t view_index = 0; const auto& view : views_properties) {
+  const uint32_t view_properties_count =
+      std::min<uint32_t>(data->num_views, X_STATS_MAX_VIEWS);
+
+  const std::vector<XSESSION_VIEW_PROPERTIES> views_properties(
+      views_properties_ptr, views_properties_ptr + view_properties_count);
+
+  for (const auto& view : views_properties) {
     const uint32_t view_id = view.view_id;
+
+    const auto spa_stats_view =
+        emulator()->game_info_database()->GetStatsView(view_id);
+
+    // TrueSkill leaderboards are not defined in SPA?
+    if (!IsTrueSkillViewID(view_id) && !spa_stats_view.has_value()) {
+      XELOGI("{} invalid leaderboard view id {:08X}", __func__);
+      return X_ONLINE_E_STAT_INVALID_TITLE_OR_LEADERBOARD;
+    }
+
+    const bool is_view_arbitrated =
+        spa_stats_view.has_value() && spa_stats_view.value().view.arbitrated;
+
+    // If session attempts to write arbitrated leaderboards from a
+    // non-arbitrated session, then XSessionWriteStats will fail.
+    if (IsTrueSkillViewID(view_id) && !is_arbitrated_session) {
+      XELOGI("{} requires session arbitration", __func__);
+      return X_ONLINE_E_SESSION_REQUIRES_ARBITRATION;
+    } else if (!is_arbitrated_session && is_view_arbitrated) {
+      XELOGI("{} requires session arbitration", __func__);
+      return X_ONLINE_E_SESSION_REQUIRES_ARBITRATION;
+    }
 
     const xam::XUSER_PROPERTY* properties_ptr =
         kernel_state()->memory()->TranslateVirtual<xam::XUSER_PROPERTY*>(
             view.properties_ptr);
 
-    const size_t properties_count =
-        std::min<uint32_t>(view.properties_count, kXUserMaxStatsAttributes);
+    assert_false(view.properties_count > X_STATS_MAX_PROPERTIES_IN_VIEW);
 
-    for (uint32_t property_index = 0; property_index < properties_count;
-         property_index++) {
-      const xam::XUSER_PROPERTY& property_guest =
-          properties_ptr[property_index];
+    const uint32_t properties_count = std::min<uint32_t>(
+        view.properties_count, X_STATS_MAX_PROPERTIES_IN_VIEW);
 
-      const uint32_t property_id = property_guest.property_id;
+    const std::vector<xam::XUSER_PROPERTY> properties(
+        properties_ptr, properties_ptr + properties_count);
 
-      auto& cached_properties = stats_properties_[xuid][view_id];
+    for (const auto& property_info : properties) {
+      const uint32_t property_id = property_info.property_id;
+      const uint8_t* data_ptr =
+          reinterpret_cast<const uint8_t*>(&property_info.data.data);
 
-      uint8_t* data_ptr = new uint8_t[sizeof(xam::X_USER_DATA_UNION)];
-      memcpy(data_ptr, &property_guest.data.data,
-             sizeof(xam::X_USER_DATA_UNION));
-
-      // Get size
       const uint32_t property_data_size =
           xam::UserData::get_valid_data_size(property_id, 0);
 
-      const xam::Property property_host =
-          xam::Property(property_id, property_data_size, data_ptr);
+      const xam::Property property = xam::Property(
+          property_id, property_data_size, const_cast<uint8_t*>(data_ptr));
 
-      cached_properties[property_id] = property_host;
+      cached_stats_properties_[xuid][view_id][property_id] = property;
     }
-
-    view_index++;
   }
 
   return X_ERROR_SUCCESS;
 }
 
-// Write leaderboard stats to the backend server
-// Flushes only non-skill leaderboards
-// What are non-arbitrated, arbitrated and skill leaderboards?
+// Flush cached leaderboard stats to the backend
 X_RESULT XSession::FlushStats() {
   if (!HasSessionFlag(static_cast<SessionFlags>((uint32_t)local_details_.Flags),
                       STATS)) {
     XELOGW("Session does not support stats.");
-    return X_ERROR_FUNCTION_FAILED;
+    return X_ONLINE_E_SESSION_WRONG_STATE;
   }
 
   if (local_details_.eState != XSESSION_STATE::INGAME) {
-    XELOGW("Writing stats outside of gameplay.");
-    return X_ERROR_FUNCTION_FAILED;
+    XELOGW("Flushing stats outside of gameplay.");
+    return X_ONLINE_E_SESSION_WRONG_STATE;
   }
 
-  if (HasSessionFlag(static_cast<SessionFlags>((uint32_t)local_details_.Flags),
-                     ARBITRATION)) {
-    // Flushes only the session's non-arbitrated leaderboards
+  const bool is_arbitrated = HasSessionFlag(
+      static_cast<SessionFlags>((uint32_t)local_details_.Flags), ARBITRATION);
+
+  view_properties_unordered_map stats_to_flush = {};
+
+  for (const auto& [xuid, views] : cached_stats_properties_) {
+    for (const auto& [view_id, view] : views) {
+      const auto spa_stats_view =
+          emulator()->game_info_database()->GetStatsView(view_id);
+
+      if (is_arbitrated) {
+        const bool is_view_arbitrated = spa_stats_view.has_value() &&
+                                        spa_stats_view.value().view.arbitrated;
+
+        // Flush only non-arbitrated and non-skilled leaderboards
+        if (!IsTrueSkillViewID(view_id) && !is_view_arbitrated) {
+          stats_to_flush[xuid][view_id] = view;
+        }
+      } else {
+        // Flush only non-skilled leaderboards
+        if (!IsTrueSkillViewID(view_id)) {
+          stats_to_flush[xuid][view_id] = view;
+        }
+      }
+    }
   }
 
-  XLiveAPI::SessionFlushStats(session_id_, stats_properties_);
+  // TODO: Check who flushes stats each peer or just host?
+  if (IsHost()) {
+    const bool flushed =
+        XLiveAPI::SessionFlushStats(session_id_, stats_to_flush);
 
-  // TODO: Determine which view ids to not clear.
-  stats_properties_.clear();
+    // If flush is successful then remove cached stats
+    if (flushed) {
+      for (const auto& [xuid, views] : stats_to_flush) {
+        for (const auto& [view_id, view] : views) {
+          cached_stats_properties_.erase(xuid);
+        }
+      }
+    }
+  }
 
   return X_ERROR_SUCCESS;
 }
@@ -837,9 +925,22 @@ X_RESULT XSession::StartSession(XGI_SESSION_STATE* state) {
 }
 
 X_RESULT XSession::EndSession(XGI_SESSION_STATE* state) {
-  FlushStats();
-
   local_details_.eState = XSESSION_STATE::REPORTING;
+
+  const bool stats_enabled = HasSessionFlag(
+      static_cast<SessionFlags>((uint32_t)local_details_.Flags), STATS);
+
+  // The host will report TrueSkill statistics for all players in a session?
+
+  // Post the remaining cached stats
+  if (stats_enabled) {
+    const bool flushed =
+        XLiveAPI::SessionFlushStats(session_id_, cached_stats_properties_);
+
+    if (flushed) {
+      cached_stats_properties_.clear();
+    }
+  }
 
   return X_ERROR_SUCCESS;
 }

--- a/src/xenia/kernel/xsession.cc
+++ b/src/xenia/kernel/xsession.cc
@@ -754,7 +754,78 @@ X_RESULT XSession::WriteStats(XGI_STATS_WRITE* data) {
     return X_ERROR_SUCCESS;
   }
 
-  XLiveAPI::SessionWriteStats(session_id_, *data);
+  const uint64_t xuid = data->xuid;
+
+  const XSESSION_VIEW_PROPERTIES* views_properties_ptr =
+      kernel_state()->memory()->TranslateVirtual<XSESSION_VIEW_PROPERTIES*>(
+          data->views_ptr);
+
+  std::vector<XSESSION_VIEW_PROPERTIES> views_properties(
+      views_properties_ptr, views_properties_ptr + data->num_views);
+
+  for (uint32_t view_index = 0; const auto& view : views_properties) {
+    const uint32_t view_id = view.view_id;
+
+    const xam::XUSER_PROPERTY* properties_ptr =
+        kernel_state()->memory()->TranslateVirtual<xam::XUSER_PROPERTY*>(
+            view.properties_ptr);
+
+    const size_t properties_count =
+        std::min<uint32_t>(view.properties_count, kXUserMaxStatsAttributes);
+
+    for (uint32_t property_index = 0; property_index < properties_count;
+         property_index++) {
+      const xam::XUSER_PROPERTY& property_guest =
+          properties_ptr[property_index];
+
+      const uint32_t property_id = property_guest.property_id;
+
+      auto& cached_properties = stats_properties_[xuid][view_id];
+
+      uint8_t* data_ptr = new uint8_t[sizeof(xam::X_USER_DATA_UNION)];
+      memcpy(data_ptr, &property_guest.data.data,
+             sizeof(xam::X_USER_DATA_UNION));
+
+      // Get size
+      const uint32_t property_data_size =
+          xam::UserData::get_valid_data_size(property_id, 0);
+
+      const xam::Property property_host =
+          xam::Property(property_id, property_data_size, data_ptr);
+
+      cached_properties[property_id] = property_host;
+    }
+
+    view_index++;
+  }
+
+  return X_ERROR_SUCCESS;
+}
+
+// Write leaderboard stats to the backend server
+// Flushes only non-skill leaderboards
+// What are non-arbitrated, arbitrated and skill leaderboards?
+X_RESULT XSession::FlushStats() {
+  if (!HasSessionFlag(static_cast<SessionFlags>((uint32_t)local_details_.Flags),
+                      STATS)) {
+    XELOGW("Session does not support stats.");
+    return X_ERROR_FUNCTION_FAILED;
+  }
+
+  if (local_details_.eState != XSESSION_STATE::INGAME) {
+    XELOGW("Writing stats outside of gameplay.");
+    return X_ERROR_FUNCTION_FAILED;
+  }
+
+  if (HasSessionFlag(static_cast<SessionFlags>((uint32_t)local_details_.Flags),
+                     ARBITRATION)) {
+    // Flushes only the session's non-arbitrated leaderboards
+  }
+
+  XLiveAPI::SessionFlushStats(session_id_, stats_properties_);
+
+  // TODO: Determine which view ids to not clear.
+  stats_properties_.clear();
 
   return X_ERROR_SUCCESS;
 }
@@ -766,6 +837,8 @@ X_RESULT XSession::StartSession(XGI_SESSION_STATE* state) {
 }
 
 X_RESULT XSession::EndSession(XGI_SESSION_STATE* state) {
+  FlushStats();
+
   local_details_.eState = XSESSION_STATE::REPORTING;
 
   return X_ERROR_SUCCESS;

--- a/src/xenia/kernel/xsession.h
+++ b/src/xenia/kernel/xsession.h
@@ -266,6 +266,7 @@ class XSession : public XObject {
   X_RESULT RegisterArbitration(XGI_SESSION_ARBITRATION* data);
   X_RESULT ModifySkill(XGI_SESSION_MODIFYSKILL* data);
   X_RESULT WriteStats(XGI_STATS_WRITE* data);
+  X_RESULT FlushStats();
 
   X_RESULT StartSession(XGI_SESSION_STATE* state);
   X_RESULT EndSession(XGI_SESSION_STATE* state);
@@ -413,8 +414,8 @@ class XSession : public XObject {
   std::map<uint64_t, XSESSION_MEMBER> local_members_{};
   std::map<uint64_t, XSESSION_MEMBER> remote_members_{};
 
-  // TODO!
-  std::vector<uint8_t> stats_;
+  // Cached stats
+  view_properties_unordered_map stats_properties_ = {};
 };
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xsession.h
+++ b/src/xenia/kernel/xsession.h
@@ -415,7 +415,7 @@ class XSession : public XObject {
   std::map<uint64_t, XSESSION_MEMBER> remote_members_{};
 
   // Cached stats
-  view_properties_unordered_map stats_properties_ = {};
+  view_properties_unordered_map cached_stats_properties_ = {};
 };
 }  // namespace kernel
 }  // namespace xe


### PR DESCRIPTION
**XamUserCreateStatsEnumerator**:
Fixed Dead or Alive 5 Ultimate, Saints Row, The Simpsons Arcade and SpongeBob UnderPants! leaderbords crashing.

**XUserReadStats**:
Fixed Gears of War 2 horde systemlink session crashing after countdown.
Fixed Midnight Club Los Angeles crashing after completing ranked race.
Fixed Forza Motorsport 2 crashing after a race while not connected to the backend server.
Fixed GTA IV crashing during prologue while not connected to the backend server.
Fixed Gears of War Judgment crashing when loading mission while not connected to the backend server.

**XSessionWriteStats**:
Written stats are now cached and updated throughout the session life span. Previously each call would send the stats to the backend.

**XSessionFlushStats**:
Stats are now only sent to the backend if **XSessionFlushStats** or **XSessionEnd**  are called.