### PR TITLE
[XAM] Implemented Periodic Maintenance

### DIFF
--- a/src/xenia/app/profile_dialogs.cc
+++ b/src/xenia/app/profile_dialogs.cc
@@ -440,23 +440,6 @@ void ManagerDialog::OnDraw(ImGuiIO& io) {
       ImGui::SetTooltip("Delete profiles to fix XUID mismatch error.");
     }
 
-    ImGui::SameLine();
-
-    ImGui::BeginDisabled(is_profile_signed_in);
-    if (ImGui::Button("Refresh Presence", btn_size)) {
-      emulator_window_->emulator()->kernel_state()->BroadcastNotification(
-          kXNotificationFriendsPresenceChanged, user_index);
-
-      emulator_window_->emulator()
-          ->display_window()
-          ->app_context()
-          .CallInUIThread([&]() {
-            new xe::ui::HostNotificationWindow(
-                imgui_drawer(), "Refreshed Presence", "Success", 0);
-          });
-    }
-    ImGui::EndDisabled();
-
     ImGui::SetWindowFontScale(1.0f);
 
     if (!friends_args.friends_open) {

--- a/src/xenia/base/threading.cc
+++ b/src/xenia/base/threading.cc
@@ -29,5 +29,9 @@ uint32_t current_thread_id() {
 
 void set_current_thread_id(uint32_t id) { current_thread_id_ = id; }
 
+std::stop_source PeriodicCallback::GetStopSource() {
+  return periodic_stop_source_;
+}
+
 }  // namespace threading
 }  // namespace xe

--- a/src/xenia/base/threading.h
+++ b/src/xenia/base/threading.h
@@ -179,6 +179,43 @@ class HighResolutionTimer {
   std::weak_ptr<TimerQueueWaitItem> wait_item_;
 };
 
+class PeriodicCallback {
+ public:
+  PeriodicCallback(std::chrono::milliseconds interval,
+                   std::function<void()> callback, std::string thread_name) {
+    assert_not_null(callback);
+    std::jthread worker =
+        std::jthread([interval, callback = std::move(callback),
+                      thread_name](std::stop_token stoken) {
+          xe::threading::set_name(thread_name);
+
+          while (!stoken.stop_requested()) {
+            callback();
+            std::this_thread::sleep_for(interval);
+          }
+        });
+
+    periodic_stop_source_ = worker.get_stop_source();
+
+    worker.detach();
+  }
+
+ public:
+  std::stop_source GetStopSource();
+
+  ~PeriodicCallback() { periodic_stop_source_.request_stop(); }
+
+  static std::unique_ptr<PeriodicCallback> CreateRepeating(
+      std::chrono::milliseconds period, std::function<void()> callback,
+      std::string thread_name) {
+    return std::unique_ptr<PeriodicCallback>(
+        new PeriodicCallback(period, std::move(callback), thread_name));
+  }
+
+ private:
+  std::stop_source periodic_stop_source_;
+};
+
 // Results for a WaitHandle operation.
 enum class WaitResult {
   // The state of the specified object is signaled.

--- a/src/xenia/emulator.cc
+++ b/src/xenia/emulator.cc
@@ -1341,6 +1341,7 @@ bool Emulator::ExceptionCallback(Exception* ex) {
   }
 
   xe::kernel::XLiveAPI::DeleteAllSessionsByMac();
+  kernel_state()->xam_state()->StopPeriodicMaintenance();
 
   // Now suspend ourself (we should be a guest thread).
   current_thread->Suspend(nullptr);
@@ -1679,6 +1680,8 @@ X_STATUS Emulator::CompleteLaunch(const std::filesystem::path& path,
                                        module->hash().value());
     }
   }
+
+  kernel_state()->xam_state()->StartPeriodicMaintenance();
 
   return X_STATUS_SUCCESS;
 }

--- a/src/xenia/gpu/graphics_system.cc
+++ b/src/xenia/gpu/graphics_system.cc
@@ -270,6 +270,7 @@ void GraphicsSystem::OnHostGpuLossFromAnyThread(
     return;
   }
   xe::kernel::XLiveAPI::DeleteAllSessionsByMac();
+  kernel_state()->xam_state()->StopPeriodicMaintenance();
   xe::FatalError("Graphics device lost (probably due to an internal error)");
 }
 

--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -824,18 +824,18 @@ std::unique_ptr<SessionObjectJSON> XLiveAPI::XSessionMigration(
   Document doc;
   doc.SetObject();
 
-  xe::be<uint64_t> xuid = 0;
+  uint64_t xuid = 0;
 
-  if (kernel_state()->xam_state()->IsUserSignedIn(data->user_index)) {
-    const auto& profile =
-        kernel_state()->xam_state()->GetUserProfile(data->user_index);
+  const auto profile =
+      kernel_state()->xam_state()->GetUserProfile(data->user_index);
 
+  if (profile) {
     xuid = profile->GetOnlineXUID();
   } else {
     XELOGI("New host is remote.");
   }
 
-  const std::string xuid_str = fmt::format("{:016X}", xuid.get());
+  const std::string xuid_str = fmt::format("{:016X}", xuid);
 
   doc.AddMember("xuid", xuid_str, doc.GetAllocator());
   doc.AddMember("hostAddress", OnlineIP_str(), doc.GetAllocator());
@@ -1054,15 +1054,14 @@ void XLiveAPI::XSessionCreate(uint64_t sessionId, XGI_SESSION_CREATE* data) {
   XELOGI("XSessionCreate POST Success");
 }
 
-void XLiveAPI::SessionPropertiesSet(uint64_t session_id, uint32_t user_index) {
+bool XLiveAPI::SessionPropertiesSet(uint64_t session_id, uint64_t xuid) {
   std::string endpoint = fmt::format("title/{:08X}/sessions/{:016x}/properties",
                                      kernel_state()->title_id(), session_id);
 
   std::unique_ptr<PropertiesObjectJSON> properties_json =
       std::make_unique<PropertiesObjectJSON>();
 
-  const auto user_profile =
-      kernel_state()->xam_state()->GetUserProfile(user_index);
+  const auto user_profile = kernel_state()->xam_state()->GetUserProfile(xuid);
 
   const auto propertie_ids =
       kernel_state()->xam_state()->user_tracker()->GetUserPropertyIds(
@@ -1111,7 +1110,10 @@ void XLiveAPI::SessionPropertiesSet(uint64_t session_id, uint32_t user_index) {
   if (response->StatusCode() != HTTP_STATUS_CODE::HTTP_CREATED) {
     XELOGE("SessionPropertiesAdd error message: {}", response->Message());
     assert_always();
+    return false;
   }
+
+  return true;
 }
 
 const std::vector<xam::Property> XLiveAPI::SessionPropertiesGet(
@@ -1320,7 +1322,7 @@ void XLiveAPI::SessionPreJoin(uint64_t sessionId,
 }
 
 std::unique_ptr<FriendsPresenceObjectJSON> XLiveAPI::GetFriendsPresence(
-    const std::vector<uint64_t>& xuids) {
+    const std::set<uint64_t>& xuids) {
   const std::string endpoint = "players/presence";
 
   std::unique_ptr<FriendsPresenceObjectJSON> friends =
@@ -1552,15 +1554,12 @@ std::unique_ptr<FindUsersObjectJSON> XLiveAPI::GetFindUsers(
   return find_users;
 }
 
-void XLiveAPI::SetPresence() {
-  const std::string endpoint = "players/setpresence";
+PresenceObjectJSON XLiveAPI::BuildRichPresenceRequest(
+    std::set<uint64_t> xuids) {
+  PresenceObjectJSON presence = PresenceObjectJSON();
 
-  std::unique_ptr<PresenceObjectJSON> presence =
-      std::make_unique<PresenceObjectJSON>();
-
-  // Update presence for all signed in xbox live enabled profiles
-  for (uint32_t i = 0; i < XUserMaxUserCount; i++) {
-    const auto user_profile = kernel_state()->xam_state()->GetUserProfile(i);
+  for (const auto& xuid : xuids) {
+    const auto user_profile = kernel_state()->xam_state()->GetUserProfile(xuid);
 
     if (user_profile) {
       FriendPresenceObjectJSON profile_presence = FriendPresenceObjectJSON();
@@ -1570,12 +1569,18 @@ void XLiveAPI::SetPresence() {
         profile_presence.RichPresence(user_profile->GetPresenceString());
       }
 
-      presence->AddPresence(profile_presence);
+      presence.AddPresence(profile_presence);
     }
   }
 
+  return presence;
+}
+
+void XLiveAPI::SetPresence(std::set<uint64_t> xuids) {
+  const std::string endpoint = "players/setpresence";
+
   std::string player_presence;
-  bool valid = presence->Serialize(player_presence);
+  bool valid = BuildRichPresenceRequest(xuids).Serialize(player_presence);
   assert_true(valid);
 
   const uint8_t* player_presence_data =

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -97,7 +97,7 @@ class XLiveAPI {
   static const std::vector<std::unique_ptr<SessionObjectJSON>> SessionSearch(
       XGI_SESSION_SEARCH* data, uint32_t num_users);
 
-  static void SessionPropertiesSet(uint64_t session_id, uint32_t user_index);
+  static bool SessionPropertiesSet(uint64_t session_id, const uint64_t xuid);
 
   static const std::vector<xam::Property> SessionPropertiesGet(
       uint64_t session_id);
@@ -141,7 +141,7 @@ class XLiveAPI {
                              const std::set<uint64_t>& xuids);
 
   static std::unique_ptr<FriendsPresenceObjectJSON> GetFriendsPresence(
-      const std::vector<uint64_t>& xuids);
+      const std::set<uint64_t>& xuids);
 
   static X_STORAGE_BUILD_SERVER_PATH_RESULT XStorageBuildServerPath(
       std::string server_path);
@@ -159,7 +159,10 @@ class XLiveAPI {
   static std::unique_ptr<FindUsersObjectJSON> GetFindUsers(
       const std::vector<FIND_USER_INFO>& find_users_info);
 
-  static void SetPresence();
+  static PresenceObjectJSON BuildRichPresenceRequest(
+      const std::set<uint64_t> xuids);
+
+  static void SetPresence(const std::set<uint64_t> xuids);
 
   static std::unique_ptr<HTTPResponseObjectJSON> PraseResponse(
       response_data response);

--- a/src/xenia/kernel/json/friend_presence_object_json.cc
+++ b/src/xenia/kernel/json/friend_presence_object_json.cc
@@ -128,7 +128,7 @@ X_ONLINE_FRIEND FriendPresenceObjectJSON::GetFriendPresence() const {
   return peer;
 }
 
-FriendsPresenceObjectJSON::FriendsPresenceObjectJSON() : xuids_(0) {}
+FriendsPresenceObjectJSON::FriendsPresenceObjectJSON() : xuids_({}) {}
 
 FriendsPresenceObjectJSON::~FriendsPresenceObjectJSON() {}
 

--- a/src/xenia/kernel/json/friend_presence_object_json.h
+++ b/src/xenia/kernel/json/friend_presence_object_json.h
@@ -10,6 +10,7 @@
 #ifndef XENIA_KERNEL_FRIEND_PRESENCE_OBJECT_JSON_H_
 #define XENIA_KERNEL_FRIEND_PRESENCE_OBJECT_JSON_H_
 
+#include <set>
 #include <vector>
 
 #include "xenia/base/string_util.h"
@@ -113,17 +114,17 @@ class FriendsPresenceObjectJSON : public BaseObjectJSON {
   virtual bool Serialize(
       rapidjson::PrettyWriter<rapidjson::StringBuffer>* writer) const;
 
-  const void AddXUID(uint64_t xuid) { xuids_.push_back(xuid); }
+  const void AddXUID(uint64_t xuid) { xuids_.insert(xuid); }
 
-  const std::vector<uint64_t>& XUIDs() const { return xuids_; }
-  void XUIDs(const std::vector<uint64_t>& xuids) { xuids_ = xuids; }
+  const std::set<uint64_t>& XUIDs() const { return xuids_; }
+  void XUIDs(const std::set<uint64_t>& xuids) { xuids_ = xuids; }
 
   const std::vector<FriendPresenceObjectJSON>& PlayersPresence() const {
     return players_presence_;
   }
 
  private:
-  std::vector<uint64_t> xuids_;
+  std::set<uint64_t> xuids_;
   std::vector<FriendPresenceObjectJSON> players_presence_;
 };
 

--- a/src/xenia/kernel/upnp.cc
+++ b/src/xenia/kernel/upnp.cc
@@ -271,19 +271,16 @@ void UPnP::RefreshPorts(std::string_view addr) {
 }
 
 // Update the UPnP lease time every 45 minutes
-// Not using HighResolutionTimer because it's only used for small tasks.
 void UPnP::RefreshPortsTimer() {
   // Only setup timer once
   if (active_) {
     return;
   }
 
-  const auto interval = std::chrono::minutes(45);
+  auto run = [=]() { RefreshPorts(GetLocalIP()); };
 
-  auto run = [&](void*) { RefreshPorts(GetLocalIP()); };
-
-  wait_item_ = QueueTimerRecurring(run, nullptr,
-                                   TimerQueueWaitItem::clock::now(), interval);
+  refresh_ports_timer_ = PeriodicCallback::CreateRepeating(
+      refresh_ports_interval_, run, "UPnP Refresh Ports");
 }
 
 uint16_t UPnP::GetMappedConnectPort(uint16_t external_port) {

--- a/src/xenia/kernel/upnp.h
+++ b/src/xenia/kernel/upnp.h
@@ -15,7 +15,9 @@
 
 #include <third_party/miniupnp/miniupnpc/include/miniupnpc.h>
 
-#include "xenia/base/threading_timer_queue.h"
+#include "xenia/base/threading.h"
+
+using namespace std::chrono_literals;
 
 namespace xe {
 namespace kernel {
@@ -87,7 +89,8 @@ class UPnP {
   IGDdatas* igd_data_ = new IGDdatas();
   UPNPUrls* igd_urls_ = new UPNPUrls();
 
-  std::weak_ptr<xe::threading::TimerQueueWaitItem> wait_item_;
+  const std::chrono::minutes refresh_ports_interval_ = 45min;
+  std::unique_ptr<xe::threading::PeriodicCallback> refresh_ports_timer_;
 
   std::map<std::string, port_binding> port_bindings_;
   std::map<std::string, std::map<uint16_t, int32_t>> port_binding_results_;

--- a/src/xenia/kernel/xam/apps/xgi_app.cc
+++ b/src/xenia/kernel/xam/apps/xgi_app.cc
@@ -305,8 +305,6 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
             user->xuid(), xgi_context->context.context_id,
             xgi_context->context.value);
 
-        user->UpdatePresence();
-
         std::u16string context_desc =
             kernel_state()->xam_state()->user_tracker()->GetContextDescription(
                 user->xuid(), xgi_context->context.context_id);
@@ -356,8 +354,6 @@ X_HRESULT XgiApp::DispatchMessageSync(uint32_t message, uint32_t buffer_ptr,
 
         kernel_state_->xam_state()->user_tracker()->AddProperty(user->xuid(),
                                                                 &property);
-
-        user->UpdatePresence();
 
         std::u16string property_desc =
             kernel_state_->xam_state()->user_tracker()->GetPropertyDescription(

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -630,8 +630,6 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
   const auto peer_xuids =
       std::vector<uint64_t>(peer_xuids_ptr, peer_xuids_ptr + num_peers);
 
-  UpdatePresenceXUIDs(peer_xuids, user_index);
-
   for (auto i = starting_index; i < e->items_per_enumerate(); i++) {
     const xe::be<uint64_t> xuid = peer_xuids[i];
 
@@ -932,8 +930,6 @@ X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr,
     return result;
   }
 
-  UpdateFriendPresence(user_index);
-
   for (auto i = friends_starting_index; i < e->items_per_enumerate(); i++) {
     X_ONLINE_FRIEND peer = {};
 
@@ -953,49 +949,6 @@ X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr,
 
   *handle_ptr = xe::byte_swap<uint32_t>(e->handle());
   return X_E_SUCCESS;
-}
-
-void XLiveBaseApp::UpdateFriendPresence(const uint32_t user_index) {
-  if (!kernel_state()->xam_state()->IsUserSignedIn(user_index)) {
-    return;
-  }
-
-  auto const profile = kernel_state()->xam_state()->GetUserProfile(user_index);
-
-  const std::vector<uint64_t> peer_xuids = profile->GetFriendsXUIDs();
-
-  UpdatePresenceXUIDs(peer_xuids, user_index);
-}
-
-void XLiveBaseApp::UpdatePresenceXUIDs(const std::vector<uint64_t>& xuids,
-                                       const uint32_t user_index) {
-  if (!kernel_state()->xam_state()->IsUserSignedIn(user_index)) {
-    return;
-  }
-
-  auto const profile = kernel_state()->xam_state()->GetUserProfile(user_index);
-
-  const auto presences = XLiveAPI::GetFriendsPresence(xuids);
-
-  for (const auto& player : presences->PlayersPresence()) {
-    const uint64_t xuid = player.XUID();
-
-    if (!profile->IsFriend(xuid) && !profile->IsSubscribed(xuid)) {
-      XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
-             xuid);
-      continue;
-    }
-
-    if (profile->IsFriend(xuid)) {
-      X_ONLINE_FRIEND peer = player.GetFriendPresence();
-
-      profile->SetFriend(peer);
-    } else if (profile->IsSubscribed(xuid)) {
-      X_ONLINE_PRESENCE presence = player.ToOnlineRichPresence();
-
-      profile->SetSubscriptionFromXUID(xuid, &presence);
-    }
-  }
 }
 
 X_HRESULT XLiveBaseApp::XInviteSend(uint32_t buffer_ptr) {
@@ -1058,9 +1011,8 @@ X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_ptr,
   memcpy(invite_info, user_profile->GetSelfInvite(), sizeof(X_INVITE_INFO));
   memset(user_profile->GetSelfInvite(), 0, sizeof(X_INVITE_INFO));
 
-  const std::vector<uint64_t> xuids = {invite_info->xuid_inviter};
-
-  const auto presence = XLiveAPI::GetFriendsPresence(xuids);
+  const auto presence =
+      XLiveAPI::GetFriendsPresence({invite_info->xuid_inviter});
 
   uint64_t session_id = 0;
 

--- a/src/xenia/kernel/xam/apps/xlivebase_app.h
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.h
@@ -36,9 +36,6 @@ class XLiveBaseApp : public App {
 
   X_HRESULT XFriendsCreateEnumerator(uint32_t buffer_ptr,
                                      uint32_t buffer_length);
-  void UpdateFriendPresence(const uint32_t user_index);
-  void UpdatePresenceXUIDs(const std::vector<uint64_t>& xuids,
-                           const uint32_t user_index);
   X_HRESULT XInviteSend(uint32_t buffer_ptr);
   X_HRESULT XInviteGetAcceptedInfo(uint32_t buffer_ptr, uint32_t buffer_length);
   X_HRESULT GenericMarshalled(uint32_t buffer_ptr);

--- a/src/xenia/kernel/xam/profile_manager.cc
+++ b/src/xenia/kernel/xam/profile_manager.cc
@@ -338,6 +338,8 @@ void ProfileManager::Logout(const uint8_t user_index, bool notify) {
     return;
   }
 
+  user_tracker_->StopPeriodicMaintenance(profile->second->xuid());
+  user_tracker_->CleanupOwnedSessions(profile->second->xuid());
   kernel_state_->xam_state()->user_tracker()->RemoveUser(
       profile->second->xuid());
   DismountProfile(profile->second->xuid());

--- a/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
+++ b/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
@@ -54,8 +54,7 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
       }
     }
   } else {
-    std::vector<uint64_t> player_xuid = {xuid_};
-    const auto presences = XLiveAPI::GetFriendsPresence(player_xuid);
+    const auto presences = XLiveAPI::GetFriendsPresence({xuid_});
 
     if (!presences->PlayersPresence().empty()) {
       presence_ = presences->PlayersPresence().front();

--- a/src/xenia/kernel/xam/user_data.h
+++ b/src/xenia/kernel/xam/user_data.h
@@ -78,6 +78,12 @@ struct alignas(8) X_USER_DATA {
   X_USER_DATA(const X_USER_DATA& other) : type(other.type) {
     std::memcpy(&data, &other.data, sizeof(X_USER_DATA_UNION));
   };
+
+  // Does not validate additional data such as binary or unicode.
+  bool operator==(const X_USER_DATA& other) const {
+    return type == other.type &&
+           std::memcmp(&data, &other.data, sizeof(X_USER_DATA_UNION)) == 0;
+  }
 };
 static_assert_size(X_USER_DATA, 16);
 

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -19,8 +19,6 @@
 
 #include "xenia/kernel/XLiveAPI.h"
 
-DECLARE_int32(discord_presence_user_index);
-
 namespace xe {
 namespace kernel {
 namespace xam {
@@ -400,12 +398,11 @@ bool UserProfile::IsFriend(const uint64_t xuid, X_ONLINE_FRIEND* peer) {
   return true;
 }
 
-const std::vector<uint64_t> UserProfile::GetFriendsXUIDs() const {
-  std::vector<uint64_t> xuids;
-  xuids.reserve(friends_.size());
+const std::set<uint64_t> UserProfile::GetFriendsXUIDs() const {
+  std::set<uint64_t> xuids;
 
   for (const auto& peer : friends_) {
-    xuids.push_back(peer.xuid);
+    xuids.insert(peer.xuid);
   }
 
   return xuids;
@@ -471,11 +468,11 @@ void UserProfile::SetSelfInvite(X_INVITE_INFO* invite_info) {
   memcpy(&self_invite, invite_info, sizeof(X_INVITE_INFO));
 }
 
-const std::vector<uint64_t> UserProfile::GetSubscribedXUIDs() const {
-  std::vector<uint64_t> subscribed_xuids;
+const std::set<uint64_t> UserProfile::GetSubscribedXUIDs() const {
+  std::set<uint64_t> subscribed_xuids;
 
   for (const auto& [key, _] : subscriptions_) {
-    subscribed_xuids.push_back(key);
+    subscribed_xuids.insert(key);
   }
 
   return subscribed_xuids;
@@ -511,41 +508,19 @@ std::u16string UserProfile::GetPresenceString() const {
   return online_presence_desc_;
 }
 
-bool UserProfile::UpdatePresence() {
-  const auto current_presence = GetPresenceString();
+bool UserProfile::IsPresenceStringUpdateAvailable() {
+  const std::u16string current_presence = GetPresenceString();
+  std::u16string updated_presence = u"";
 
-  bool updated = false;
-
-  if (BuildPresenceString()) {
-    const auto updated_presence = GetPresenceString();
-
-    updated = current_presence != updated_presence;
-
-    if (!updated) {
-      return false;
-    }
-
-    XELOGI("{}: {} - {}", __func__, name(), xe::to_utf8(updated_presence));
-
-    const uint32_t user_index =
-        kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(
-            xuid_);
-
-    if (cvars::discord_presence_user_index == user_index) {
-      kernel_state()->emulator()->on_presence_change(
-          kernel_state()->emulator()->title_name(), updated_presence);
-    }
-
-    auto run = [] { XLiveAPI::SetPresence(); };
-
-    std::thread update_presence(run);
-    update_presence.detach();
+  if (!BuildPresenceString(false, &updated_presence)) {
+    return false;
   }
 
-  return updated;
+  return current_presence != updated_presence;
 }
 
-bool UserProfile::BuildPresenceString() {
+bool UserProfile::BuildPresenceString(bool update,
+                                      std::u16string* presence_string) {
   bool completed = false;
 
   const xam::Property* presence_prop =
@@ -568,16 +543,19 @@ bool UserProfile::BuildPresenceString() {
       xlast->GetPresenceRawString(presence_prop);
 
   const auto presence_string_formatter =
-      util::AttributeStringFormatter::AttributeStringFormatter(raw_presence,
-                                                               xlast, xuid_);
+      util::AttributeStringFormatter(raw_presence, xlast, xuid_);
+
+  completed = presence_string_formatter.IsComplete();
 
   const auto presence_parsed = presence_string_formatter.GetPresenceString();
 
-  if (online_presence_desc_ != presence_parsed) {
+  if (completed && update) {
     online_presence_desc_ = presence_parsed;
   }
 
-  completed = presence_string_formatter.IsComplete();
+  if (completed && presence_string) {
+    *presence_string = presence_parsed;
+  }
 
   return completed;
 }

--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -23,6 +23,7 @@
 #include "xenia/kernel/xam/xdbf/gpd_info_profile.h"
 #include "xenia/kernel/xam/xdbf/gpd_info_title.h"
 #include "xenia/kernel/xnet.h"
+#include "xenia/kernel/xsession.h"
 #include "xenia/xbox.h"
 
 DECLARE_int32(network_mode);
@@ -189,7 +190,7 @@ class UserProfile {
   bool IsFriend(const uint64_t xuid, X_ONLINE_FRIEND* peer = nullptr);
 
   const std::vector<X_ONLINE_FRIEND> GetFriends() const { return friends_; }
-  const std::vector<uint64_t> GetFriendsXUIDs() const;
+  const std::set<uint64_t> GetFriendsXUIDs() const;
 
   const uint32_t GetFriendsCount() const;
 
@@ -202,20 +203,62 @@ class UserProfile {
   void SetSelfInvite(X_INVITE_INFO* invite_info);
   X_INVITE_INFO* GetSelfInvite() { return &self_invite; };
 
-  const std::vector<uint64_t> GetSubscribedXUIDs() const;
+  const std::set<uint64_t> GetSubscribedXUIDs() const;
 
   bool MutePlayer(uint64_t xuid);
   bool UnmutePlayer(uint64_t xuid);
   bool IsPlayerMuted(uint64_t xuid) const;
 
   std::u16string GetPresenceString() const;
-  bool UpdatePresence();
-  bool BuildPresenceString();
+  bool IsPresenceStringUpdateAvailable();
+  bool BuildPresenceString(bool update, std::u16string* presence_string);
+
+  void AddOwnedSession(object_ref<XSession> owned_session) {
+    const auto& session_obj_ref =
+        std::find_if(owned_sessions_.cbegin(), owned_sessions_.cend(),
+                     [owned_session](object_ref<XSession> object) {
+                       return object->handle() == owned_session->handle();
+                     });
+
+    if (session_obj_ref != owned_sessions_.cend()) {
+      return;
+    }
+
+    owned_session->RetainHandle();
+    owned_sessions_.push_back(owned_session);
+  };
+
+  void RemoveOwnedSession(object_ref<XSession> owned_session) {
+    const bool erased = std::erase_if(
+        owned_sessions_, [owned_session](object_ref<XSession> object) {
+          return object->handle() == owned_session->handle();
+        });
+
+    if (erased) {
+      owned_session->ReleaseHandle();
+    }
+  };
+
+  std::vector<object_ref<XSession>> GetOwnedSessions() {
+    return owned_sessions_;
+  };
+
+  xe::threading::PeriodicCallback* GetPeriodicMaintenanceTask() const {
+    return periodic_maintenance_task_.get();
+  };
+
+  void SetPeriodicMaintenanceTask(
+      std::unique_ptr<xe::threading::PeriodicCallback> task) {
+    periodic_maintenance_task_ = std::move(task);
+  };
 
  private:
   uint64_t xuid_;
   X_XAMACCOUNTINFO account_info_;
   X_INVITE_INFO self_invite;
+
+  std::vector<object_ref<XSession>> owned_sessions_;
+  std::unique_ptr<xe::threading::PeriodicCallback> periodic_maintenance_task_;
 
   GpdInfoProfile dashboard_gpd_;
   std::map<uint32_t, GpdInfoTitle> games_gpd_;

--- a/src/xenia/kernel/xam/user_property.h
+++ b/src/xenia/kernel/xam/user_property.h
@@ -66,6 +66,10 @@ class Property : public UserData {
   void WriteToGuest(XUSER_PROPERTY* property) const;
   std::vector<uint8_t> Serialize() const;
 
+  bool operator==(const Property& other) const {
+    return data_ == other.data_ && extended_data_ == other.extended_data_;
+  }
+
  private:
   AttributeKey property_id_ = {};
 };

--- a/src/xenia/kernel/xam/user_tracker.cc
+++ b/src/xenia/kernel/xam/user_tracker.cc
@@ -7,11 +7,15 @@
  ******************************************************************************
  */
 
+#include <algorithm>
+
 #include "xenia/emulator.h"
 #include "xenia/kernel/xam/user_profile.h"
 
 #include "third_party/fmt/include/fmt/format.h"
 #include "third_party/stb/stb_image.h"
+#include "xenia/base/threading.h"
+#include "xenia/kernel/XLiveAPI.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/user_data.h"
@@ -23,6 +27,8 @@
 DECLARE_int32(user_language);
 
 DECLARE_int32(user_country);
+
+DECLARE_int32(discord_presence_user_index);
 
 namespace xe {
 namespace kernel {
@@ -41,6 +47,11 @@ bool UserTracker::AddUser(uint64_t xuid) {
     AddDefaultProperties(xuid);
     AddDefaultContexts(xuid);
   }
+
+  if (kernel_state()->emulator()->is_title_open()) {
+    StartPeriodicMaintenance(xuid);
+  }
+
   return true;
 }
 
@@ -988,6 +999,24 @@ std::optional<uint32_t> UserTracker::GetUserContext(uint64_t xuid,
   return entry->get_data()->data.u32;
 }
 
+uint32_t UserTracker::GetContextValue(uint64_t xuid, uint32_t id) const {
+  const xam::Property* context = GetProperty(xuid, id);
+
+  if (context) {
+    return context->get_data()->data.u32.get();
+  }
+
+  return 0;
+}
+
+uint32_t UserTracker::GetGameModeValue(uint64_t xuid) const {
+  return GetContextValue(xuid, XCONTEXT_GAME_MODE);
+}
+
+uint32_t UserTracker::GetGameTypeValue(uint64_t xuid) const {
+  return GetContextValue(xuid, XCONTEXT_GAME_TYPE);
+}
+
 std::vector<AttributeKey> UserTracker::GetUserContextIds(uint64_t xuid) const {
   if (!IsUserTracked(xuid)) {
     return {};
@@ -1198,6 +1227,296 @@ void UserTracker::RefreshTitleSummary(uint64_t xuid, uint32_t title_id) {
   title_data->gamerscore_earned = title_gpd->GetGamerscore();
 
   user->WriteGpd(kDashboardID);
+}
+
+PresenceSyncState UserTracker::IsPresenceOutOfSync(
+    uint64_t xuid, std::vector<FriendPresenceObjectJSON> presence_info) const {
+  PresenceSyncState sync_state = {};
+
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return sync_state;
+  }
+
+  if (presence_info.empty()) {
+    return sync_state;
+  }
+
+  for (const auto& player : presence_info) {
+    const uint64_t xuid = player.XUID();
+
+    if (!user->IsFriend(xuid) && !user->IsSubscribed(xuid)) {
+      XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
+             xuid);
+      continue;
+    }
+
+    if (sync_state.friends && sync_state.peers) {
+      break;
+    }
+
+    if (user->IsFriend(xuid) && !sync_state.friends) {
+      X_ONLINE_FRIEND peer = {};
+
+      if (user->GetFriendFromXUID(xuid, &peer)) {
+        const X_ONLINE_FRIEND updated_peer_presence =
+            player.GetFriendPresence();
+
+        if (std::memcmp(&peer, &updated_peer_presence,
+                        sizeof(X_ONLINE_FRIEND)) != 0) {
+          sync_state.friends = true;
+        }
+      }
+    } else if (user->IsSubscribed(xuid) && !sync_state.peers) {
+      X_ONLINE_PRESENCE peer = {};
+
+      if (user->GetSubscriptionFromXUID(xuid, &peer)) {
+        const X_ONLINE_PRESENCE updated_peer_presence =
+            player.ToOnlineRichPresence();
+
+        if (std::memcmp(&peer, &updated_peer_presence,
+                        sizeof(X_ONLINE_PRESENCE)) != 0) {
+          sync_state.peers = true;
+        }
+      }
+    }
+  }
+
+  return sync_state;
+}
+
+void UserTracker::RefershFriendsAndSubscribersPresence(uint64_t xuid) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  const auto friends_xuids = user->GetFriendsXUIDs();
+  const auto subscribed_xuids = user->GetSubscribedXUIDs();
+  std::set<uint64_t> friends_and_subscribed_xuids = {};
+
+  std::set_union(friends_xuids.cbegin(), friends_xuids.cend(),
+                 subscribed_xuids.cbegin(), subscribed_xuids.cend(),
+                 std::inserter(friends_and_subscribed_xuids,
+                               friends_and_subscribed_xuids.cbegin()));
+
+  const auto presences =
+      XLiveAPI::GetFriendsPresence(friends_and_subscribed_xuids);
+
+  const auto presence_sync_state =
+      IsPresenceOutOfSync(xuid, presences->PlayersPresence());
+
+  if (!presence_sync_state.IsOutOfSync()) {
+    return;
+  }
+
+  XELOGD("Friends/Subscribed peers presence state changed.");
+
+  for (const auto& player : presences->PlayersPresence()) {
+    const uint64_t xuid = player.XUID();
+
+    if (user->IsFriend(xuid)) {
+      X_ONLINE_FRIEND friend_presence = player.GetFriendPresence();
+      user->SetFriend(friend_presence);
+    } else if (user->IsSubscribed(xuid)) {
+      X_ONLINE_PRESENCE presence = player.ToOnlineRichPresence();
+      user->SetSubscriptionFromXUID(xuid, &presence);
+    }
+  }
+
+  if (presence_sync_state.friends) {
+    const uint32_t user_index =
+        kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(
+            xuid);
+
+    kernel_state()->BroadcastNotification(kXNotificationFriendsPresenceChanged,
+                                          user_index);
+  }
+
+  if (presence_sync_state.peers) {
+    kernel_state()->BroadcastNotification(kXNotificationLivePresenceChanged, 0);
+  }
+}
+
+void UserTracker::AddOwnedSession(uint64_t xuid,
+                                  uint32_t session_handle) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  auto object =
+      kernel_state()->object_table()->LookupObject<XSession>(session_handle);
+  if (!object) {
+    return;
+  }
+
+  user->AddOwnedSession(object);
+}
+
+void UserTracker::RemoveOwnedSession(uint64_t xuid,
+                                     uint32_t session_handle) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  const auto sessions = user->GetOwnedSessions();
+
+  const auto& session_obj_ref =
+      std::find_if(sessions.cbegin(), sessions.cend(),
+                   [session_handle](object_ref<XSession> object) {
+                     return object->handle() == session_handle;
+                   });
+
+  if (session_obj_ref == sessions.cend()) {
+    return;
+  }
+
+  user->RemoveOwnedSession(*session_obj_ref);
+}
+
+bool UserTracker::HasOwnedSessions(uint64_t xuid) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return false;
+  }
+
+  return user->GetOwnedSessions().size();
+}
+
+void UserTracker::CleanupOwnedSessions(uint64_t xuid) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  for (const auto& session : user->GetOwnedSessions()) {
+    RemoveOwnedSession(xuid, session->handle());
+  }
+}
+
+// Should periodic maintenance be per-user or all users?
+void UserTracker::PeriodicMaintenance(uint64_t xuid,
+                                      size_t iteration_count) const {
+  if (!kernel_state()->emulator()->is_title_open()) {
+    return;
+  }
+
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  // Check if presence string needs updating.
+  const bool presence_string_update_available =
+      user->IsPresenceStringUpdateAvailable();
+
+  // Update discord rich presence before checking live state.
+  if (presence_string_update_available) {
+    user->BuildPresenceString(true, nullptr);
+
+    const std::u16string updated_presence = user->GetPresenceString();
+
+    XELOGI("Periodic Maintenance (Presence): {} - {}", user->name(),
+           xe::to_utf8(updated_presence));
+
+    const uint32_t user_index =
+        kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(
+            xuid);
+
+    if (cvars::discord_presence_user_index == user_index) {
+      kernel_state()->emulator()->on_presence_change(
+          kernel_state()->emulator()->title_name(), updated_presence);
+    }
+  }
+
+  if (user->signin_state() != X_USER_SIGNIN_STATE::SignedInToLive ||
+      XLiveAPI::GetInitState() != XLiveAPI::InitState::Success) {
+    return;
+  }
+
+  // Check every 3nd iteration to reduce backend requests.
+  if (!(iteration_count % 3)) {
+    RefershFriendsAndSubscribersPresence(xuid);
+  }
+
+  if (presence_string_update_available) {
+    XLiveAPI::SetPresence({user->xuid()});
+  }
+
+  if (HasOwnedSessions(xuid)) {
+    for (const auto& session : user->GetOwnedSessions()) {
+      // 1. Check we are host of the session, only the host sends properties to
+      // the backend.
+      // 2. Check session is created so we have a valid session id and ensure
+      // session is already created on backend before updating properties.
+      // 3. Check if session has live features we don't want to POST properties
+      // for offline session.
+      if (session->IsHost() && session->IsCreated() &&
+          session->HasXboxLiveFeatureFlags()) {
+        if (session->GetCachedLiveProperties() == user->properties_) {
+          continue;
+        }
+
+        if (XLiveAPI::SessionPropertiesSet(session->GetSessionID(),
+                                           user->xuid())) {
+          session->CacheLiveProperties(user->properties_);
+        }
+      }
+    }
+  }
+}
+
+void UserTracker::StartPeriodicMaintenance(uint64_t xuid) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  const auto user_index = kernel_state()
+                              ->xam_state()
+                              ->profile_manager()
+                              ->GetUserIndexAssignedToProfile(xuid);
+
+  // TODO(Adrian):
+  // Netplay doesn't support multiple local profiles too well.
+  // We only register user index 0 on backend therefore start periodic
+  // maintenance only for that user for now.
+  if (user_index > 0) {
+    XELOGI(fmt::format("Skip Starting Periodic Maintenance for {:016X}", xuid));
+    return;
+  }
+
+  if (user->GetPeriodicMaintenanceTask()) {
+    return;
+  }
+
+  auto run = [iteration_count = size_t(0), xuid]() mutable {
+    kernel_state()->xam_state()->user_tracker()->PeriodicMaintenance(
+        xuid, iteration_count);
+    iteration_count++;
+  };
+
+  XELOGD(fmt::format("Started Periodic Maintenance:: {:016X}", xuid));
+
+  auto periodic_task = xe::threading::PeriodicCallback::CreateRepeating(
+      periodic_maintenance_interval_, run,
+      fmt::format("Periodic Maintenance: {}", user->name()).c_str());
+
+  user->SetPeriodicMaintenanceTask(std::move(periodic_task));
+}
+
+void UserTracker::StopPeriodicMaintenance(uint64_t xuid) const {
+  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
+  if (!user) {
+    return;
+  }
+
+  if (user->GetPeriodicMaintenanceTask()) {
+    XELOGD(fmt::format("Stopped Periodic Maintenance: {:016X}", xuid));
+    user->SetPeriodicMaintenanceTask({});
+  }
 }
 
 }  // namespace xam

--- a/src/xenia/kernel/xam/user_tracker.h
+++ b/src/xenia/kernel/xam/user_tracker.h
@@ -16,7 +16,10 @@
 
 #include "xenia/xbox.h"
 
+#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/xam/user_settings.h"
+
+using namespace std::chrono_literals;
 
 namespace xe {
 namespace kernel {
@@ -43,6 +46,13 @@ struct TitleInfo {
   }
 };
 
+struct PresenceSyncState {
+  bool friends;
+  bool peers;
+
+  bool IsOutOfSync() const { return friends || peers; }
+};
+
 class UserTracker {
  public:
   UserTracker() = default;
@@ -59,9 +69,33 @@ class UserTracker {
   bool UnlockAchievement(uint64_t xuid, uint32_t achievement_id);
   void RefreshTitleSummary(uint64_t xuid, uint32_t title_id);
 
+  PresenceSyncState IsPresenceOutOfSync(
+      const uint64_t xuid,
+      const std::vector<FriendPresenceObjectJSON> presence_info) const;
+
+  // XFriendsCreateEnumerator & XPresenceCreateEnumerator
+  void RefershFriendsAndSubscribersPresence(const uint64_t xuid) const;
+
+  // XSessions
+  void AddOwnedSession(const uint64_t xuid,
+                       const uint32_t session_handle) const;
+  void RemoveOwnedSession(const uint64_t xuid,
+                          const uint32_t session_handle) const;
+  bool HasOwnedSessions(const uint64_t xuid) const;
+  void CleanupOwnedSessions(const uint64_t xuid) const;
+
+  // Periodic Maintenance
+  void PeriodicMaintenance(const uint64_t xuid,
+                           const size_t iteration_count) const;
+  void StartPeriodicMaintenance(const uint64_t xuid) const;
+  void StopPeriodicMaintenance(const uint64_t xuid) const;
+
   // Context
   void UpdateContext(uint64_t xuid, uint32_t id, uint32_t value);
   std::optional<uint32_t> GetUserContext(uint64_t xuid, uint32_t id) const;
+  uint32_t GetContextValue(const uint64_t xuid, const uint32_t id) const;
+  uint32_t GetGameModeValue(const uint64_t xuid) const;
+  uint32_t GetGameTypeValue(const uint64_t xuid) const;
   std::vector<AttributeKey> GetUserContextIds(uint64_t xuid) const;
   std::u16string GetContextLocalizedString(uint64_t xuid, uint32_t id) const;
   std::u16string GetContextGameModeLocalizedString(uint64_t xuid) const;
@@ -127,6 +161,8 @@ class UserTracker {
   SpaInfo* spa_data_ = nullptr;
 
   std::set<uint64_t> tracked_xuids_;
+
+  const std::chrono::seconds periodic_maintenance_interval_ = 5s;
 
   struct CompareEqualString {
     bool operator()(std::u16string a, std::u16string b) const {

--- a/src/xenia/kernel/xam/xam_state.cc
+++ b/src/xenia/kernel/xam/xam_state.cc
@@ -103,6 +103,26 @@ void XamState::LoadSpaInfo(const SpaInfo* info) {
   user_tracker_->UpdateSpaInfo(spa_info_.get());
 }
 
+void XamState::StartPeriodicMaintenance() const {
+  for (uint32_t user_index = 0; user_index < XUserMaxUserCount; user_index++) {
+    const auto profile = GetUserProfile(user_index);
+
+    if (profile) {
+      user_tracker()->StartPeriodicMaintenance(profile->xuid());
+    }
+  }
+}
+
+void XamState::StopPeriodicMaintenance() const {
+  for (uint32_t user_index = 0; user_index < XUserMaxUserCount; user_index++) {
+    const auto profile = GetUserProfile(user_index);
+
+    if (profile) {
+      user_tracker()->StopPeriodicMaintenance(profile->xuid());
+    }
+  }
+}
+
 }  // namespace xam
 }  // namespace kernel
 }  // namespace xe

--- a/src/xenia/kernel/xam/xam_state.h
+++ b/src/xenia/kernel/xam/xam_state.h
@@ -61,6 +61,9 @@ class XamState {
   //
   void LoadSpaInfo(const SpaInfo* info);
 
+  void StartPeriodicMaintenance() const;
+  void StopPeriodicMaintenance() const;
+
   X_DASH_APP_INFO dash_app_info_ = {};
   uint32_t dash_backstack_nodes_count_ = 0;
   X_DASH_BACKSTACK_DATA dash_backstack_data_[2] = {};

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -1425,7 +1425,7 @@ bool xeDrawFriendsContent(xe::ui::ImGuiDrawer* imgui_drawer,
     if (args.refresh_presence || args.refresh_presence_sync ||
         args.add_friend_args.added_friend) {
       auto run = [presences, user_index]() {
-        *presences = kernel::XLiveAPI::GetAllFriendsPresence(user_index);
+        *presences = XLiveAPI::GetAllFriendsPresence(user_index);
       };
 
       if (args.refresh_presence_sync) {

--- a/src/xenia/kernel/xsession.cc
+++ b/src/xenia/kernel/xsession.cc
@@ -24,6 +24,7 @@ namespace kernel {
 XSession::XSession(KernelState* kernel_state)
     : XObject(kernel_state, Type::Session) {
   session_id_ = -1;
+  owner_xuid_ = 0;
 }
 
 X_STATUS XSession::Initialize() {
@@ -53,6 +54,12 @@ X_RESULT XSession::CreateSession(uint32_t user_index, uint8_t public_slots,
     return X_ERROR_FUNCTION_FAILED;
   }
 
+  owner_xuid_ = user_profile->xuid();
+
+  const auto user_tracker = kernel_state()->xam_state()->user_tracker();
+
+  user_tracker->AddOwnedSession(user_profile->xuid(), handle());
+
   // Mutually exclusive
   if (flags & JOIN_VIA_PRESENCE_DISABLED &&
       flags & JOIN_VIA_PRESENCE_FRIENDS_ONLY) {
@@ -65,7 +72,8 @@ X_RESULT XSession::CreateSession(uint32_t user_index, uint8_t public_slots,
   }
 
   // Session type is ranked but ARBITRATION flag isn't set
-  if (GetGameTypeValue(user_profile->xuid()) == X_CONTEXT_GAME_TYPE_RANKED &&
+  if (user_tracker->GetGameTypeValue(user_profile->xuid()) ==
+          X_CONTEXT_GAME_TYPE_RANKED &&
       !(flags & ARBITRATION)) {
     return X_ONLINE_E_SESSION_REQUIRES_ARBITRATION;
   }
@@ -127,8 +135,10 @@ X_RESULT XSession::CreateSession(uint32_t user_index, uint8_t public_slots,
     JoinExistingSession(SessionInfo_ptr);
   }
 
-  local_details_.GameType = GetGameTypeValue(user_profile->xuid());
-  local_details_.GameMode = GetGameModeValue(user_profile->xuid());
+  local_details_.GameType =
+      user_tracker->GetGameTypeValue(user_profile->xuid());
+  local_details_.GameMode =
+      user_tracker->GetGameModeValue(user_profile->xuid());
   local_details_.MaxPublicSlots = public_slots;
   local_details_.MaxPrivateSlots = private_slots;
   local_details_.AvailablePublicSlots = public_slots;
@@ -192,11 +202,7 @@ X_RESULT XSession::CreateHostSession(XSESSION_INFO* session_info,
 
     NotifySessionCreationWarning(user_index);
 
-    // 58410821 adds properties after session creation
-    // Properties are ad-hoc therefore should be updated on backend, only
-    // update if value changed to reduce POST requests.
     XLiveAPI::XSessionCreate(session_id_, &session_data);
-    XLiveAPI::SessionPropertiesSet(session_id_, session_data.user_index);
   } else {
     assert_always();
   }
@@ -250,13 +256,20 @@ X_RESULT XSession::JoinExistingSession(XSESSION_INFO* session_info) {
 X_RESULT XSession::DeleteSession(XGI_SESSION_STATE* state) {
   // Begin XNetUnregisterKey?
 
+  if (IsDeleted()) {
+    return X_ERROR_SUCCESS;
+  }
+
   state_ |= STATE_FLAGS_DELETED;
 
   if (IsHost() && HasXboxLiveFeatureFlags()) {
     XLiveAPI::DeleteSession(session_id_);
   }
 
-  session_id_ = 0;
+  kernel_state()->xam_state()->user_tracker()->RemoveOwnedSession(
+      GetOwnerXUID(), handle());
+
+  session_id_ = -1;
 
   // Multiple sessions cause issues
   // XLiveAPI::systemlink_id = session_id_;
@@ -396,7 +409,7 @@ X_RESULT XSession::JoinSession(XGI_SESSION_MANAGE* data) {
     XLiveAPI::SessionPreJoin(session_id_, xuids);
   }
 
-  // XamUserAddRecentPlayer
+  // XamUserAddRecentPlayer -> XPresenceSubscribe
 
   return X_ERROR_SUCCESS;
 }
@@ -649,12 +662,10 @@ X_RESULT XSession::MigrateHost(XGI_SESSION_MIGRATE* data) {
   }
 
   if (data->user_index == XUserIndexNone) {
-    XELOGI("Session migration we're not host!");
-  }
-
-  if (kernel_state()->xam_state()->IsUserSignedIn(data->user_index)) {
-    // Update properties, what if they're changed after migration?
-    XLiveAPI::SessionPropertiesSet(result->SessionID_UInt(), data->user_index);
+    XELOGI("Session migration we are not host.");
+  } else {
+    XELOGI("Session migration we are new host.");
+    state_ |= STATE_FLAGS_HOST;
   }
 
   memset(SessionInfo_ptr, 0, sizeof(XSESSION_INFO));
@@ -666,7 +677,6 @@ X_RESULT XSession::MigrateHost(XGI_SESSION_MIGRATE* data) {
   // Update session id to migrated session id
   session_id_ = result->SessionID_UInt();
 
-  state_ |= STATE_FLAGS_HOST;
   state_ |= STATE_FLAGS_MIGRATED;
 
   local_details_.UserIndexHost = data->user_index;

--- a/src/xenia/kernel/xsession.h
+++ b/src/xenia/kernel/xsession.h
@@ -12,9 +12,9 @@
 
 #include "xenia/base/byte_order.h"
 #include "xenia/kernel/json/session_object_json.h"
-#include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/xlast.h"
 #include "xenia/kernel/xam/user_property.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/kernel/xobject.h"
 
 namespace xe {
@@ -327,30 +327,6 @@ class XSession : public XObject {
     return members_size;
   }
 
-  const xe::be<uint32_t> GetGameModeValue(uint64_t xuid) {
-    const xam::Property* gamemode =
-        kernel_state()->xam_state()->user_tracker()->GetProperty(
-            xuid, XCONTEXT_GAME_MODE);
-
-    if (gamemode) {
-      return gamemode->get_data()->data.u32;
-    }
-
-    return 0;
-  }
-
-  const xe::be<uint32_t> GetGameTypeValue(uint64_t xuid) {
-    const xam::Property* game_type =
-        kernel_state()->xam_state()->user_tracker()->GetProperty(
-            xuid, XCONTEXT_GAME_TYPE);
-
-    if (game_type) {
-      return game_type->get_data()->data.u32;
-    }
-
-    return 0;
-  }
-
   const bool IsCreated() const {
     return (state_ & STATE_FLAGS_CREATED) == STATE_FLAGS_CREATED;
   }
@@ -366,6 +342,20 @@ class XSession : public XObject {
   const bool IsDeleted() const {
     return (state_ & STATE_FLAGS_DELETED) == STATE_FLAGS_DELETED;
   }
+
+  uint64_t GetSessionID() const { return session_id_; };
+
+  // Gets XUID of the owner managing the local session
+  uint64_t GetOwnerXUID() const { return owner_xuid_; };
+
+  // Cache latest properties sent to backend
+  void CacheLiveProperties(std::vector<xam::Property> properties) {
+    live_properties_ = properties;
+  };
+
+  std::vector<xam::Property> GetCachedLiveProperties() {
+    return live_properties_;
+  };
 
  private:
   void PrintSessionDetails();
@@ -406,6 +396,10 @@ class XSession : public XObject {
       XSESSION_SEARCHRESULT* result);
 
   void NotifySessionCreationWarning(uint32_t user_index) const;
+
+  uint64_t owner_xuid_;
+
+  std::vector<xam::Property> live_properties_;
 
   // uint64_t migrated_session_id_;
   uint64_t session_id_ = 0;


### PR DESCRIPTION
PR in conjunction with https://github.com/AdrianCassar/Xenia-WebServices/pull/63.

Fixed discovering sessions:

- Beautiful Katamari
- Viva Piñata: Trouble in Paradise

Fixed requirement to restart session twice so it becomes discoverable or joinable:

- BlazBlue Calamity
- Commanders: Attack of the Genos
- Gears of War
- Persona 4 Arena
- Puzzle Chronicles
- Universe at War: Earth Assault

Fixed lag spikes caused by requesting friends presence:

- Dead or Alive 4

Fixed automatically discovering session via friends presence:

- Terraria