### PR TITLE
[Util] Detect VPN network adapters

### DIFF
--- a/src/xenia/kernel/util/network_adapter_manager.cc
+++ b/src/xenia/kernel/util/network_adapter_manager.cc
@@ -174,7 +174,9 @@ NetworkAdapterManager::DiscoverNetworkAdapters() {
        adapter_ptr = adapter_ptr->Next) {
     if (adapter_ptr->OperStatus == IfOperStatusUp &&
         (adapter_ptr->IfType == IF_TYPE_IEEE80211 ||
-         adapter_ptr->IfType == IF_TYPE_ETHERNET_CSMACD)) {
+         adapter_ptr->IfType == IF_TYPE_ETHERNET_CSMACD ||
+         adapter_ptr->IfType == IF_TYPE_PROP_VIRTUAL ||
+         adapter_ptr->IfType == IF_TYPE_TUNNEL)) {
       if (adapter_ptr->PhysicalAddress != nullptr) {
         for (PIP_ADAPTER_UNICAST_ADDRESS_LH adapter_address =
                  adapter_ptr->FirstUnicastAddress;


### PR DESCRIPTION
I am using OpenVPN for Systemlink multiplayer (without the server), but ran into the problem that the OpenVPN network adapter doesn't get detected by Netplay, [unlike others like Radmin](https://github.com/AdrianCassar/xenia-canary/wiki/Systemlink#netplay-network-interfaces-radmin-vpn).

This is because OpenVPN's TAP adapter uses `IF_TYPE_PROP_VIRTUAL` (which is not currently detected by Netplay): https://github.com/OpenVPN/tap-windows6/blob/0cad8664c2a51832df61f2e1853b6da317d1c129/src/constants.h#L104

According to Microsoft:

> Suitable values for VPN adapters are:
>
> `IF_TYPE_PROP_VIRTUAL 53 (0x35) Proprietary virtual/internal`
>
> `IF_TYPE_TUNNEL 131 (0x83) Encapsulation interface`

- https://learn.microsoft.com/en-us/troubleshoot/windows-client/networking/windows-connection-manager-disconnects-wlan#more-information

Before my patch:

<img width="851" height="228" alt="Screenshot 2025-12-19 133136" src="https://github.com/user-attachments/assets/701f1c7b-a8fe-4078-ab82-4940ebcf2ce3" />

After my patch:

<img width="889" height="233" alt="Screenshot 2025-12-19 133707" src="https://github.com/user-attachments/assets/7db610f5-cd12-4b91-aebb-a4513296e121" />

Note that you must have an _**active**_ OpenVPN connection on that adapter in order for it to show up in Netplay.

Let me know if you have further questions.