### PR TITLE
[Netplay] Use launch-unique MAC identity for sessions

### DIFF
--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -105,7 +105,7 @@ void XLiveAPI::IpGetConsoleXnAddr(XNADDR* XnAddr_ptr) {
 
   XnAddr_ptr->abOnline.platform_type = PLATFORM_TYPE::Xbox360;
 
-  memcpy(XnAddr_ptr->abEnet, GetConsoleMacAddress().raw(),
+  memcpy(XnAddr_ptr->abEnet, GetSessionMacAddress().raw(),
          MacAddress::MacAddressSize);
 }
 
@@ -723,7 +723,7 @@ std::unique_ptr<HTTPResponseObjectJSON> XLiveAPI::RegisterPlayer(
     return response;
   }
 
-  if (GetConsoleMacAddress().to_uint64() == 0) {
+  if (GetSessionMacAddress().to_uint64() == 0) {
     XELOGE("Cancelled registering profile!");
     return response;
   }
@@ -779,7 +779,7 @@ std::unique_ptr<HTTPResponseObjectJSON> XLiveAPI::RegisterPlayer(
 
   PlayerObjectJSON player = PlayerObjectJSON();
 
-  MacAddress mac_address = GetConsoleMacAddress();
+  MacAddress mac_address = GetSessionMacAddress();
 
   player.XUID(registered_xuid);
   player.Gamertag(user_profile->name());
@@ -1098,7 +1098,7 @@ std::unique_ptr<SessionObjectJSON> XLiveAPI::XSessionMigration(
 
   doc.AddMember("xuid", xuid_str, doc.GetAllocator());
   doc.AddMember("hostAddress", OnlineIP_str(), doc.GetAllocator());
-  doc.AddMember("macAddress", GetConsoleMacAddress().to_string(),
+  doc.AddMember("macAddress", GetSessionMacAddress().to_string(),
                 doc.GetAllocator());
   doc.AddMember("port", GetPlayerPort(), doc.GetAllocator());
 
@@ -1233,7 +1233,7 @@ void XLiveAPI::DeleteSession(uint64_t sessionId) {
 
 void XLiveAPI::DeleteAllSessionsByMac() {
   const std::string endpoint = BuildEndpoint(
-      fmt::format("DeleteSessions/{}", GetConsoleMacAddress().to_string()));
+      fmt::format("DeleteSessions/{}", GetSessionMacAddress().to_string()));
 
   std::unique_ptr<HTTPResponseObjectJSON> response = Delete(endpoint);
 
@@ -1290,7 +1290,7 @@ void XLiveAPI::XSessionCreate(uint64_t sessionId, XGI_SESSION_CREATE* data) {
   session.PrivateSlotsCount(data->num_slots_private);
   session.UserIndex(data->user_index);
   session.HostAddress(OnlineIP_str());
-  session.MacAddress(GetConsoleMacAddress().to_string());
+  session.MacAddress(GetSessionMacAddress().to_string());
   session.Port(GetPlayerPort());
 
   std::string session_output;

--- a/src/xenia/kernel/util/net_utils.cc
+++ b/src/xenia/kernel/util/net_utils.cc
@@ -156,6 +156,11 @@ MacAddress GetConsoleMacAddress() {
   return MacAddress(mac_address);
 }
 
+MacAddress GetSessionMacAddress() {
+  static const MacAddress session_mac_address = GenerateMacAddress();
+  return session_mac_address;
+}
+
 MacAddress GenerateMacAddress() {
   uint8_t mac_address[MacAddress::MacAddressSize] = {};
 

--- a/src/xenia/kernel/util/net_utils.h
+++ b/src/xenia/kernel/util/net_utils.h
@@ -77,6 +77,8 @@ uint64_t GetLocalMachineId(const MacAddress mac_address);
 
 MacAddress GetConsoleMacAddress();
 
+MacAddress GetSessionMacAddress();
+
 MacAddress GenerateMacAddress();
 
 }  // namespace kernel

--- a/src/xenia/kernel/xam/xam_net.cc
+++ b/src/xenia/kernel/xam/xam_net.cc
@@ -273,7 +273,7 @@ dword_result_t NetDll_XNetCleanup_entry(dword_t caller) {
 DECLARE_XAM_EXPORT1(NetDll_XNetCleanup, kNetworking, kImplemented);
 
 dword_result_t XNetLogonGetMachineID_entry(lpqword_t machine_id_ptr) {
-  *machine_id_ptr = GetLocalMachineId(GetConsoleMacAddress());
+  *machine_id_ptr = GetLocalMachineId(GetSessionMacAddress());
 
   // if (XLiveAPI::GetInitState() != XLiveAPI::InitState::Success) {
   //   *machine_id_ptr = 0;
@@ -863,19 +863,32 @@ dword_result_t NetDll_XNetXnAddrToInAddr_entry(dword_t caller,
   in_addr.Zero();
 
   // 494707E4, 4E4D07D1
-  if (GetConsoleMacAddress() == MacAddress(xn_addr->abEnet)) {
-    XELOGI("Resolving XNetXnAddrToInAddr to LOOPBACK!");
+  if (GetSessionMacAddress() == MacAddress(xn_addr->abEnet)) {
+    const auto network_adapter =
+        kernel_state()->emulator()->GetNetworkAdapterManager();
+    const auto local_addr =
+        network_adapter->GetSelectedAdapterLocalIP().sin_addr;
+    const bool is_local_addr =
+        !xn_addr->ina.s_addr || xn_addr->ina.s_addr == xe::byte_swap(LOOPBACK) ||
+        xn_addr->ina.s_addr == local_addr.s_addr;
 
-    if (cvars::bind_interface) {
-      const auto network_adapter =
-          kernel_state()->emulator()->GetNetworkAdapterManager();
+    if (is_local_addr) {
+      XELOGI("Resolving XNetXnAddrToInAddr to LOOPBACK!");
 
-      in_addr->s_addr =
-          network_adapter->GetSelectedAdapterLocalIP().sin_addr.s_addr;
-    } else {
-      in_addr->s_addr = xe::byte_swap(LOOPBACK);
+      if (cvars::bind_interface) {
+        in_addr->s_addr = local_addr.s_addr;
+      } else {
+        in_addr->s_addr = xe::byte_swap(LOOPBACK);
+      }
+
+      return X_ERROR_SUCCESS;
     }
 
+    XELOGW(
+        "XNetXnAddrToInAddr: remote XNADDR uses this console's MAC, but has "
+        "a different IP; treating it as a remote peer.");
+    in_addr->s_addr =
+        xn_addr->ina.s_addr ? xn_addr->ina.s_addr : xn_addr->inaOnline.s_addr;
     return X_ERROR_SUCCESS;
   }
 

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -1617,7 +1617,7 @@ bool xeDrawSessionContent(xe::ui::ImGuiDrawer* imgui_drawer,
   const std::string join_label =
       std::format("Join Session##{}", session->SessionID());
 
-  bool caller = MacAddress(session->MacAddress()) == GetConsoleMacAddress();
+  bool caller = MacAddress(session->MacAddress()) == GetSessionMacAddress();
 
   std::string version_text = "Version mismatch!";
   std::string media_text = "Media ID mismatch!";
@@ -1741,7 +1741,7 @@ bool xeDrawSessionsContent(
     }
 
     for (auto& session : *sessions) {
-      bool caller = MacAddress(session->MacAddress()) == GetConsoleMacAddress();
+      bool caller = MacAddress(session->MacAddress()) == GetSessionMacAddress();
       if (sessions_args.filter_own && caller) {
         continue;
       }


### PR DESCRIPTION
## Summary
- add a process-local session MAC generated once per emulator launch
- use the session MAC for advertised XNADDR/session/player identity instead of the persistent console xconfig MAC
- keep loopback self-resolution only for the current launch identity, and avoid resolving remote peers with matching MAC but different IP as loopback

## Reasoning
System Link peers running identical builds can expose the same emulated MAC/XNADDR identity. Some titles and the XNet resolver treat a matching MAC as the local console, causing same-build peers to be resolved as loopback/self and fail to connect. A launch-unique but run-stable MAC prevents deterministic identity collisions while keeping all per-session values consistent during the emulator process lifetime.

## Testing
- Built release successfully with `xb.ps1 build --config=release`
- User verified the resulting build connects successfully in the previously failing same-build System Link case