### PR TITLE
[XAM] Refactored friends functions into friends manager

### DIFF
--- a/src/xenia/app/gamerpic_browser.cc
+++ b/src/xenia/app/gamerpic_browser.cc
@@ -21,7 +21,7 @@
 #include "xenia/base/png_utils.h"
 #include "xenia/base/system.h"
 #include "xenia/kernel/XLiveAPI.h"
-#include "xenia/kernel/xam/friends_util.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/xam/user_data.h"
 
 using namespace std::chrono_literals;

--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -22,8 +22,8 @@
 #include "xenia/emulator.h"
 #include "xenia/kernel/XLiveAPI.h"
 #include "xenia/kernel/user_module.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/util/shim_utils.h"
-#include "xenia/kernel/xam/friends_util.h"
 
 DEFINE_string(api_address, "192.168.0.1:36000/",
               "Xenia Server Address e.g. IP:PORT", "Live");
@@ -320,7 +320,9 @@ void XLiveAPI::Init() {
     std::unique_ptr<HTTPResponseObjectJSON> register_responce =
         RegisterPlayer(profile->xuid());
 
-    profile->AddDummyFriends(dummy_friends_count_);
+    // Add dummy friends here so we can use the title_id.
+    kernel_state()->friends_manager()->AddDummyFriends(profile->xuid(),
+                                                       dummy_friends_count_);
   }
 
   initialized_ = InitState::Success;
@@ -2360,15 +2362,17 @@ XLiveAPI::GetFriendsGamerpicsAsync(uint64_t xuid,
     return {};
   }
 
-  return std::async(std::launch::async, [this, user_profile, imgui_drawer]() {
-    const auto gamerpics =
-        GetMultiGamerpicsFromXUIDs(user_profile->GetFriendsXUIDs());
+  return std::async(std::launch::async, [this, xuid, imgui_drawer]() {
+    const auto friends_xuids =
+        kernel_state()->friends_manager()->GetFriendsXUIDs(xuid);
+
+    const auto gamerpics = GetMultiGamerpicsFromXUIDs(friends_xuids);
 
     std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>
         immediate_gamerpics = {};
 
-    for (const auto& [xuid, gamerpic] : gamerpics) {
-      immediate_gamerpics[xuid] =
+    for (const auto& [friend_xuid, gamerpic] : gamerpics) {
+      immediate_gamerpics[friend_xuid] =
           std::move(imgui_drawer->LoadImGuiIcon({gamerpic}));
     }
 
@@ -2462,7 +2466,10 @@ XLiveAPI::GetOfflineFriendsPresence(uint64_t xuid) {
 
   std::map<uint64_t, FriendPresenceObjectJSON> peer_presences = {};
 
-  for (uint32_t count = 1; const auto& xuid : user_profile->GetFriendsXUIDs()) {
+  const auto friends_xuids =
+      kernel_state()->friends_manager()->GetFriendsXUIDs(user_profile->xuid());
+
+  for (uint32_t count = 1; const auto& xuid : friends_xuids) {
     FriendPresenceObjectJSON peer = {};
     peer.Gamertag(std::format("Friend {}", count));
     peer.XUID(xuid);
@@ -2483,8 +2490,10 @@ std::map<uint64_t, FriendPresenceObjectJSON> XLiveAPI::GetOnlineFriendsPresence(
   }
   std::map<uint64_t, FriendPresenceObjectJSON> peer_presences = {};
 
-  const auto friends_presence_responce =
-      GetFriendsPresence(user_profile->GetFriendsXUIDs());
+  const auto friends_xuids =
+      kernel_state()->friends_manager()->GetFriendsXUIDs(user_profile->xuid());
+
+  const auto friends_presence_responce = GetFriendsPresence(friends_xuids);
 
   const auto& friends_presence = friends_presence_responce->PlayersPresence();
 

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -258,7 +258,7 @@ class XLiveAPI {
 
   void SetXUIDMismatch(bool state) { xuid_mismatch_ = state; };
 
-  bool GetDummyFriendsCount() const { return dummy_friends_count_; };
+  uint32_t GetDummyFriendsCount() const { return dummy_friends_count_; };
 
   void SetDummyFriendsCount(const uint32_t count) {
     dummy_friends_count_ = count;

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -29,6 +29,7 @@
 #include "xenia/kernel/xam/achievement_manager.h"
 #include "xenia/kernel/xam/app_manager.h"
 #include "xenia/kernel/xam/content_manager.h"
+#include "xenia/kernel/xam/friends_manager.h"
 #include "xenia/kernel/xam/user_profile.h"
 #include "xenia/kernel/xam/xam_state.h"
 #include "xenia/kernel/xam/xdbf/spa_info.h"
@@ -193,6 +194,9 @@ class KernelState {
   xam::AppManager* app_manager() const { return xam_state()->app_manager(); }
   xam::ContentManager* content_manager() const {
     return xam_state()->content_manager();
+  }
+  xam::FriendsManager* friends_manager() const {
+    return xam_state()->friends_manager();
   }
 
   XmpVolumePatch* xmp_volume_patch() const { return xmp_volume_patch_.get(); }

--- a/src/xenia/kernel/util/friends_util.cc
+++ b/src/xenia/kernel/util/friends_util.cc
@@ -13,8 +13,8 @@
 #include "xenia/base/cvar.h"
 #include "xenia/base/logging.h"
 #include "xenia/kernel/XLiveAPI.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/util/shim_utils.h"
-#include "xenia/kernel/xam/friends_util.h"
 #include "xenia/kernel/xnet.h"
 
 DEFINE_string(friends_xuids, "", "Comma delimited list of XUIDs. (Max 100)",
@@ -75,13 +75,13 @@ std::string BuildCSVFromVector(std::vector<std::string>& data, uint32_t count) {
   return xe::string_util::trim(csv.str());
 }
 
-std::vector<std::uint64_t> ParseFriendsXUIDs() {
+std::set<uint64_t> ParseFriendsXUIDs() {
   const auto& xuids = cvars::friends_xuids;
 
   const std::vector<std::string> friends_xuids =
       ParseDelimitedList(xuids, X_ONLINE_MAX_FRIENDS);
 
-  std::vector<std::uint64_t> xuids_parsed;
+  std::set<uint64_t> xuids_parsed;
 
   uint32_t index = 0;
   for (const auto& friend_xuid : friends_xuids) {
@@ -101,7 +101,7 @@ std::vector<std::uint64_t> ParseFriendsXUIDs() {
       continue;
     }
 
-    xuids_parsed.push_back(xuid);
+    xuids_parsed.insert(xuid);
 
     index++;
   }

--- a/src/xenia/kernel/util/friends_util.h
+++ b/src/xenia/kernel/util/friends_util.h
@@ -7,8 +7,8 @@
  ******************************************************************************
  */
 
-#ifndef XENIA_KERNEL_XAM_FRIENDS_UTIL
-#define XENIA_KERNEL_XAM_FRIENDS_UTIL
+#ifndef XENIA_KERNEL_UTIL_FRIENDS_UTIL
+#define XENIA_KERNEL_UTIL_FRIENDS_UTIL
 
 #include <cstdint>
 #include <vector>
@@ -22,7 +22,7 @@ std::vector<std::string> ParseDelimitedList(std::string_view csv,
 std::string BuildCSVFromVector(std::vector<std::string>& data,
                                uint32_t count = 0);
 
-std::vector<std::uint64_t> ParseFriendsXUIDs();
+std::set<uint64_t> ParseFriendsXUIDs();
 
 void AddFriendToConfig(uint64_t xuid);
 
@@ -31,4 +31,4 @@ void RemoveFriendFromConfig(uint64_t xuid);
 }  // namespace kernel
 }  // namespace xe
 
-#endif  // XENIA_KERNEL_XAM_FRIENDS_UTIL
+#endif  // XENIA_KERNEL_UTIL_FRIENDS_UTIL

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -430,20 +430,21 @@ X_HRESULT XLiveBaseApp::XPresenceSubscribe(uint32_t buffer_ptr,
   const auto profile = kernel_state_->xam_state()->GetUserProfile(user_index);
 
   for (uint32_t i = 0; i < num_peers; i++) {
-    const xe::be<uint64_t> xuid = peer_xuids[i];
+    const xe::be<uint64_t> peer_xuid = peer_xuids[i];
 
-    if (!xuid) {
+    if (!peer_xuid) {
       continue;
     }
 
-    if (profile->IsFriend(xuid)) {
+    if (kernel_state_->friends_manager()->IsFriend(profile->xuid(),
+                                                   peer_xuid)) {
       continue;
     }
 
     if (ACTIVE_TITLE_SUBSCRIPTIONS <= MAX_TITLE_SUBSCRIPTIONS) {
       ACTIVE_TITLE_SUBSCRIPTIONS++;
 
-      profile->SubscribeFromXUID(xuid);
+      profile->SubscribeFromXUID(peer_xuid);
     } else {
       XELOGI("Max subscriptions reached");
     }
@@ -502,20 +503,21 @@ X_HRESULT XLiveBaseApp::XPresenceUnsubscribe(uint32_t buffer_ptr,
   const auto profile = kernel_state_->xam_state()->GetUserProfile(user_index);
 
   for (uint32_t i = 0; i < num_peers; i++) {
-    const xe::be<uint64_t> xuid = peer_xuids[i];
+    const xe::be<uint64_t> peer_xuid = peer_xuids[i];
 
-    if (!xuid) {
+    if (!peer_xuid) {
       continue;
     }
 
-    if (profile->IsFriend(xuid)) {
+    if (kernel_state_->friends_manager()->IsFriend(profile->xuid(),
+                                                   peer_xuid)) {
       continue;
     }
 
     if (ACTIVE_TITLE_SUBSCRIPTIONS > 0) {
       ACTIVE_TITLE_SUBSCRIPTIONS--;
 
-      profile->UnsubscribeFromXUID(xuid);
+      profile->UnsubscribeFromXUID(peer_xuid);
     }
   }
 
@@ -620,10 +622,17 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
       continue;
     }
 
-    if (profile->IsFriend(xuid)) {
-      auto item = e->AppendItem();
+    const auto friends_manager = kernel_state_->friends_manager();
 
-      profile->GetFriendPresenceFromXUID(xuid, item);
+    if (friends_manager->IsFriend(profile->xuid(), xuid)) {
+      const auto presence =
+          friends_manager->GetFriendPresence(profile->xuid(), xuid);
+
+      if (presence.has_value()) {
+        auto item = e->AppendItem();
+        *item = presence.value();
+      }
+
     } else if (profile->IsSubscribed(xuid)) {
       auto item = e->AppendItem();
 
@@ -903,12 +912,11 @@ X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr,
   }
 
   for (auto i = friends_starting_index; i < e->items_per_enumerate(); i++) {
-    X_ONLINE_FRIEND peer = {};
+    const auto peer = kernel_state_->friends_manager()->GetFriendFromIndex(
+        profile->xuid(), i);
 
-    const bool is_friend = profile->GetFriendFromIndex(i, &peer);
-
-    if (is_friend) {
-      e->AppendItem(peer);
+    if (peer.has_value()) {
+      e->AppendItem(peer.value());
     }
   }
 

--- a/src/xenia/kernel/xam/friends_manager.cc
+++ b/src/xenia/kernel/xam/friends_manager.cc
@@ -1,0 +1,297 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include "xenia/kernel/xam/friends_manager.h"
+#include "xenia/kernel/kernel_state.h"
+#include "xenia/kernel/util/friends_util.h"
+#include "xenia/kernel/xam/profile_manager.h"
+#include "xenia/kernel/xam/user_profile.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+FriendsManager::FriendsManager(KernelState* kernel_state,
+                               ProfileManager* profile_manager)
+    : kernel_state_(kernel_state), profile_manager_(profile_manager) {}
+
+void FriendsManager::AddFriends(const uint64_t xuid,
+                                const std::set<uint64_t>& xuids) const {
+  for (const auto& friend_xuid : xuids) {
+    AddFriend(xuid, friend_xuid);
+  }
+}
+
+bool FriendsManager::AddFriend(const uint64_t xuid,
+                               const uint64_t friend_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (user->friends_.size() >= X_ONLINE_MAX_FRIENDS) {
+    return false;
+  }
+
+  if (!IsOnlineXUID(friend_xuid)) {
+    return false;
+  }
+
+  if (user->GetOnlineXUID() == friend_xuid) {
+    return false;
+  }
+
+  if (IsFriend(xuid, friend_xuid)) {
+    return false;
+  }
+
+  X_ONLINE_FRIEND peer = {.xuid = friend_xuid};
+
+  const std::string default_gamertag = fmt::format("{:016X}", friend_xuid);
+
+  xe::string_util::copy_truncating(peer.Gamertag, default_gamertag.c_str(),
+                                   xe::countof(peer.Gamertag));
+
+  user->friends_.push_back(peer);
+
+  return true;
+}
+
+bool FriendsManager::AddFriend(const uint64_t xuid,
+                               const X_ONLINE_FRIEND& peer) const {
+  bool added = false;
+
+  if (AddFriend(xuid, peer.xuid)) {
+    added = UpdateFriend(xuid, peer);
+  }
+
+  return added;
+}
+
+bool FriendsManager::UpdateFriend(const uint64_t xuid,
+                                  const X_ONLINE_FRIEND& update_peer) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  auto it = FindFriend(user->friends_, update_peer.xuid);
+
+  if (it == user->friends_.end()) {
+    return false;
+  }
+
+  *it = update_peer;
+
+  return true;
+}
+
+bool FriendsManager::RemoveFriend(const uint64_t xuid,
+                                  const uint64_t friend_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  const auto it = FindFriend(user->friends_, friend_xuid);
+
+  if (it == user->friends_.cend()) {
+    return false;
+  }
+
+  user->friends_.erase(it);
+
+  return true;
+}
+
+bool FriendsManager::IsFriend(const uint64_t xuid,
+                              const uint64_t friend_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  return FindFriend(user->friends_, friend_xuid) != user->friends_.cend();
+}
+
+void FriendsManager::ClearFriends(const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return;
+  }
+
+  for (const auto& peer_xuid : GetFriendsXUIDs(xuid)) {
+    if (RemoveFriend(xuid, peer_xuid)) {
+      RemoveFriendFromConfig(peer_xuid);
+    }
+  }
+}
+
+std::optional<X_ONLINE_FRIEND> FriendsManager::GetFriendFromIndex(
+    const uint64_t xuid, const uint32_t index) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return std::nullopt;
+  }
+
+  if (index >= X_ONLINE_MAX_FRIENDS || index >= user->friends_.size()) {
+    return std::nullopt;
+  }
+
+  return user->friends_[index];
+}
+
+std::optional<X_ONLINE_FRIEND> FriendsManager::GetFriend(
+    const uint64_t xuid, const uint64_t friend_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return std::nullopt;
+  }
+
+  const auto it = FindFriend(user->friends_, friend_xuid);
+
+  if (it == user->friends_.cend()) {
+    return std::nullopt;
+  }
+
+  return *it;
+}
+
+std::optional<std::reference_wrapper<const std::vector<X_ONLINE_FRIEND>>>
+FriendsManager::GetFriends(const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return std::nullopt;
+  }
+
+  return std::cref(user->friends_);
+}
+
+std::set<uint64_t> FriendsManager::GetFriendsXUIDs(const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  std::set<uint64_t> xuids;
+
+  for (const auto& peer : user->friends_) {
+    xuids.insert(peer.xuid);
+  }
+
+  return xuids;
+}
+
+size_t FriendsManager::GetFriendsCount(const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return 0;
+  }
+
+  return user->friends_.size();
+}
+
+std::vector<X_ONLINE_FRIEND>::iterator FriendsManager::FindFriend(
+    std::vector<X_ONLINE_FRIEND>& friends, const uint64_t friend_xuid) const {
+  return std::find_if(friends.begin(), friends.end(),
+                      [&friend_xuid](const X_ONLINE_FRIEND& peer) {
+                        return peer.xuid == friend_xuid;
+                      });
+}
+
+// Convert X_ONLINE_FRIEND to X_ONLINE_PRESENCE
+std::optional<X_ONLINE_PRESENCE> FriendsManager::GetFriendPresence(
+    const uint64_t xuid, const uint64_t friend_xuid) const {
+  const auto peer = GetFriend(xuid, friend_xuid);
+
+  if (!peer.has_value()) {
+    return std::nullopt;
+  }
+
+  X_ONLINE_PRESENCE presence = {};
+
+  presence.title_id = peer->title_id;
+  presence.state = peer->state;
+  presence.xuid = peer->xuid;
+  presence.session_id = peer->session_id;
+
+  const std::u16string rich_presence(
+      reinterpret_cast<const char16_t*>(peer->wszRichPresence));
+  char16_t* rich_presence_ptr =
+      reinterpret_cast<char16_t*>(presence.wszRichPresence);
+
+  presence.cchRichPresence = rich_presence.size();
+
+  xe::string_util::copy_truncating(rich_presence_ptr, rich_presence,
+                                   X_MAX_RICHPRESENCE_SIZE);
+
+  return presence;
+}
+
+X_ONLINE_FRIEND FriendsManager::GenerateDummyFriend() const {
+  std::random_device rnd;
+  std::mt19937_64 gen(rnd());
+  std::uniform_int_distribution<int> dist(0x00, 0xFF);
+
+  X_ONLINE_FRIEND dummy_friend = {};
+
+  // Friend is playing same title
+  dummy_friend.title_id = kernel_state_->title_id();
+
+  const uint32_t player_state = X_ONLINE_FRIENDSTATE_FLAG_ONLINE |
+                                X_ONLINE_FRIENDSTATE_FLAG_JOINABLE |
+                                X_ONLINE_FRIENDSTATE_FLAG_PLAYING;
+
+  const uint32_t user_state = X_ONLINE_FRIENDSTATE_ENUM_ONLINE;
+
+  dummy_friend.xuid = profile_manager_->GenerateXuidOnline();
+  dummy_friend.session_id = XNKID();
+  dummy_friend.state = player_state | user_state;
+
+  xe::be<uint64_t> session_id = 0xAE00FFFFFFFFFFFF;
+  std::memcpy(dummy_friend.session_id.ab, &session_id, sizeof(XNKID));
+
+  // uint64_t xnkidInvite = 0xAE00FFFFFFFFFFFF;
+  // std::memcpy(dummy_friend.xnkidInvite.ab, &xnkidInvite, sizeof(XNKID));
+
+  std::string gamertag = fmt::format("Player {}", dist(gen));
+  std::u16string rich_presence = u"Playing on Xenia";
+
+  xe::string_util::copy_truncating(dummy_friend.Gamertag, gamertag.c_str(),
+                                   xe::countof(dummy_friend.Gamertag));
+
+  dummy_friend.cchRichPresence = rich_presence.size();
+
+  char16_t* rich_presence_ptr =
+      reinterpret_cast<char16_t*>(dummy_friend.wszRichPresence);
+  xe::string_util::copy_and_swap_truncating(rich_presence_ptr, rich_presence,
+                                            X_MAX_RICHPRESENCE_SIZE);
+
+  return dummy_friend;
+}
+
+void FriendsManager::AddDummyFriends(const uint64_t xuid,
+                                     const uint32_t friends_count) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return;
+  }
+
+  if (user->friends_.size() >= X_ONLINE_MAX_FRIENDS) {
+    return;
+  }
+
+  for (uint32_t i = 0; i < friends_count; i++) {
+    AddFriend(xuid, GenerateDummyFriend());
+  }
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/friends_manager.h
+++ b/src/xenia/kernel/xam/friends_manager.h
@@ -1,0 +1,87 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_FRIENDS_MANAGER_H_
+#define XENIA_KERNEL_XAM_FRIENDS_MANAGER_H_
+
+#include <optional>
+#include <set>
+
+#include "xenia/kernel/xnet.h"
+
+namespace xe {
+namespace kernel {
+class KernelState;
+}  // namespace kernel
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace xam {
+class ProfileManager;
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+class FriendsManager {
+ public:
+  FriendsManager(KernelState* kernel_state, ProfileManager* profile_manager);
+
+  ~FriendsManager() = default;
+
+  void AddFriends(const uint64_t xuid, const std::set<uint64_t>& xuids) const;
+
+  bool AddFriend(const uint64_t xuid, const uint64_t friend_xuid) const;
+  bool AddFriend(const uint64_t xuid, const X_ONLINE_FRIEND& peer) const;
+
+  bool UpdateFriend(const uint64_t xuid,
+                    const X_ONLINE_FRIEND& update_peer) const;
+
+  bool RemoveFriend(const uint64_t xuid, const uint64_t friend_xuid) const;
+
+  bool IsFriend(const uint64_t xuid, const uint64_t friend_xuid) const;
+
+  void ClearFriends(const uint64_t xuid) const;
+
+  std::optional<X_ONLINE_FRIEND> GetFriendFromIndex(const uint64_t xuid,
+                                                    const uint32_t index) const;
+  std::optional<X_ONLINE_FRIEND> GetFriend(const uint64_t xuid,
+                                           const uint64_t friend_xuid) const;
+
+  std::optional<std::reference_wrapper<const std::vector<X_ONLINE_FRIEND>>>
+  GetFriends(const uint64_t xuid) const;
+
+  std::set<uint64_t> GetFriendsXUIDs(const uint64_t xuid) const;
+
+  size_t GetFriendsCount(const uint64_t xuid) const;
+
+  std::optional<X_ONLINE_PRESENCE> GetFriendPresence(
+      const uint64_t xuid, const uint64_t friend_xuid) const;
+
+  void AddDummyFriends(const uint64_t xuid, const uint32_t friends_count) const;
+
+ private:
+  std::vector<X_ONLINE_FRIEND>::iterator FindFriend(
+      std::vector<X_ONLINE_FRIEND>& friends, const uint64_t friend_xuid) const;
+
+  X_ONLINE_FRIEND GenerateDummyFriend() const;
+
+  KernelState* kernel_state_;
+  ProfileManager* profile_manager_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_FRIENDS_MANAGER_H_

--- a/src/xenia/kernel/xam/profile_manager.cc
+++ b/src/xenia/kernel/xam/profile_manager.cc
@@ -17,7 +17,7 @@
 #include "xenia/kernel/XLiveAPI.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/crypto_utils.h"
-#include "xenia/kernel/xam/friends_util.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/vfs/devices/host_path_device.h"
 
 DEFINE_string(logged_profile_slot_0_xuid, "",
@@ -144,6 +144,10 @@ void ProfileManager::ReloadProfiles() {
   for (const auto account_xuid : FindProfiles()) {
     LoadAccount(account_xuid);
   }
+}
+
+UserProfile* ProfileManager::GetProfileAny(const uint64_t xuid) const {
+  return GetProfile(xuid) ? GetProfile(xuid) : GetProfileLive(xuid);
 }
 
 UserProfile* ProfileManager::GetProfile(const uint64_t xuid) const {
@@ -331,10 +335,9 @@ void ProfileManager::Login(const uint64_t xuid, const uint8_t user_index,
       std::unique_ptr<HTTPResponseObjectJSON> reg_result =
           kernel_state_->GetXboxLiveAPI()->RegisterPlayer(xuid);
     }
-
-    logged_profiles_[assigned_user_slot]->AddDummyFriends(
-        kernel_state_->GetXboxLiveAPI()->GetDummyFriendsCount());
   }
+
+  logged_profiles_[assigned_user_slot]->LoadFriends();
 }
 
 void ProfileManager::Logout(const uint8_t user_index, bool notify) {

--- a/src/xenia/kernel/xam/profile_manager.h
+++ b/src/xenia/kernel/xam/profile_manager.h
@@ -39,6 +39,14 @@ class UserTracker;
 namespace xe {
 namespace kernel {
 namespace xam {
+class FriendsManager;
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace xam {
 
 inline const std::string kDashboardStringID =
     fmt::format("{:08X}", kDashboardID);
@@ -115,6 +123,7 @@ class ProfileManager {
   void ReloadProfiles();
   void ReloadProfile(const uint64_t xuid);
 
+  UserProfile* GetProfileAny(const uint64_t xuid) const;
   UserProfile* GetProfile(const uint64_t xuid) const;
   UserProfile* GetProfileLive(const uint64_t xuid) const;
   UserProfile* GetProfile(const uint8_t user_index) const;

--- a/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
+++ b/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
@@ -42,15 +42,20 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
       presence_.TitleID(fmt::format("{:08X}", kernel_state()->title_id()));
     } else if (!is_self) {
       // Cached friend presence
-      X_ONLINE_FRIEND friend_info_ = {};
-      are_friends = profile_->IsFriend(xuid_, &friend_info_);
+      const auto friend_info =
+          kernel_state()->friends_manager()->GetFriend(profile_->xuid(), xuid);
 
       presence_.Gamertag("Xenia User");
       presence_.RichPresence(xe::to_utf16("Unknown"));
-      presence_.XUID(friend_info_.xuid);
 
-      if (friend_info_.title_id) {
-        presence_.TitleID(fmt::format("{:08X}", friend_info_.title_id.get()));
+      if (friend_info.has_value()) {
+        are_friends = true;
+
+        presence_.XUID(friend_info->xuid);
+
+        if (friend_info->title_id) {
+          presence_.TitleID(fmt::format("{:08X}", friend_info->title_id.get()));
+        }
       }
     }
   } else {

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -12,10 +12,10 @@
 #include "third_party/fmt/include/fmt/format.h"
 #include "xenia/emulator.h"
 #include "xenia/kernel/XLiveAPI.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/util/presence_string_builder.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/util/xlast.h"
-#include "xenia/kernel/xam/friends_util.h"
 #include "xenia/kernel/xam/xdbf/gpd_info.h"
 
 namespace xe {
@@ -35,14 +35,21 @@ UserProfile::UserProfile(const uint64_t xuid,
 
   LoadProfileIcon(XTileType::kAvatarGamerTile);
   LoadProfileIcon(XTileType::kAvatarGamerTileSmall);
+}
 
-  friends_ = std::vector<X_ONLINE_FRIEND>();
-  subscriptions_ = std::map<uint64_t, X_ONLINE_PRESENCE>();
-  self_invite = {};
+void UserProfile::LoadFriends() {
+  const auto xam_state = kernel_state()->xam_state();
 
-  for (const auto& friend_xuid : ParseFriendsXUIDs()) {
-    AddFriendFromXUID(friend_xuid);
+  if (!xam_state) {
+    return;
   }
+
+  friends_.clear();
+
+  xam_state->friends_manager()->AddFriends(xuid_, ParseFriendsXUIDs());
+
+  xam_state->friends_manager()->AddDummyFriends(
+      xuid_, kernel_state()->GetXboxLiveAPI()->GetDummyFriendsCount());
 }
 
 GpdInfo* UserProfile::GetGpd(const uint32_t title_id) {
@@ -194,224 +201,6 @@ bool UserProfile::WriteGpd(const uint32_t title_id) {
                   &written_bytes);
   file->Destroy();
   return true;
-}
-
-X_ONLINE_FRIEND UserProfile::GenerateDummyFriend() {
-  std::random_device rnd;
-  std::mt19937_64 gen(rnd());
-  std::uniform_int_distribution<int> dist(0x00, 0xFF);
-
-  X_ONLINE_FRIEND dummy_friend = {};
-
-  // Friend is playing same title
-  dummy_friend.title_id = kernel_state()->title_id();
-
-  const uint32_t player_state = X_ONLINE_FRIENDSTATE_FLAG_ONLINE |
-                                X_ONLINE_FRIENDSTATE_FLAG_JOINABLE |
-                                X_ONLINE_FRIENDSTATE_FLAG_PLAYING;
-
-  const uint32_t user_state = X_ONLINE_FRIENDSTATE_ENUM_ONLINE;
-
-  dummy_friend.xuid =
-      kernel_state()->xam_state()->profile_manager()->GenerateXuidOnline();
-  dummy_friend.session_id = XNKID();
-  dummy_friend.state = player_state | user_state;
-
-  xe::be<uint64_t> session_id = 0xAE00FFFFFFFFFFFF;
-  memcpy(dummy_friend.session_id.ab, &session_id, sizeof(XNKID));
-
-  // uint64_t xnkidInvite = 0xAE00FFFFFFFFFFFF;
-  // memcpy(dummy_friend.xnkidInvite.ab, &xnkidInvite, sizeof(XNKID));
-
-  std::string gamertag = fmt::format("Player {}", dist(gen));
-  std::u16string rich_presence = u"Playing on Xenia";
-
-  xe::string_util::copy_truncating(dummy_friend.Gamertag, gamertag.c_str(),
-                                   sizeof(dummy_friend.Gamertag));
-
-  char16_t* rich_presence_ptr =
-      reinterpret_cast<char16_t*>(dummy_friend.wszRichPresence);
-  xe::string_util::copy_and_swap_truncating(
-      rich_presence_ptr, rich_presence, sizeof(dummy_friend.wszRichPresence));
-
-  dummy_friend.cchRichPresence =
-      static_cast<uint32_t>(rich_presence.size() * sizeof(char16_t));
-
-  return dummy_friend;
-}
-
-void UserProfile::AddDummyFriends(const uint32_t friends_count) {
-  if (friends_.size() >= X_ONLINE_MAX_FRIENDS) {
-    return;
-  }
-
-  for (uint32_t i = 0; i < friends_count; i++) {
-    X_ONLINE_FRIEND peer = GenerateDummyFriend();
-
-    AddFriend(&peer);
-  }
-}
-
-bool UserProfile::GetFriendPresenceFromXUID(const uint64_t xuid,
-                                            X_ONLINE_PRESENCE* presence) {
-  if (presence == nullptr) {
-    return false;
-  }
-
-  X_ONLINE_FRIEND peer = {};
-
-  const bool is_friend = GetFriendFromXUID(xuid, &peer);
-
-  if (!is_friend) {
-    return false;
-  }
-
-  presence->title_id = peer.title_id;
-  presence->state = peer.state;
-  presence->xuid = peer.xuid;
-  presence->session_id = peer.session_id;
-  presence->cchRichPresence = peer.cchRichPresence;
-
-  memcpy(presence->wszRichPresence, peer.wszRichPresence,
-         presence->cchRichPresence);
-
-  return true;
-}
-
-bool UserProfile::SetFriend(const X_ONLINE_FRIEND& update_peer) {
-  auto it = std::find_if(
-      friends_.begin(), friends_.end(), [&update_peer](X_ONLINE_FRIEND& peer) {
-        if (peer.xuid == update_peer.xuid) {
-          memcpy(&peer, &update_peer, sizeof(X_ONLINE_FRIEND));
-          return true;
-        }
-
-        return false;
-      });
-
-  if (it != friends_.end()) {
-    return false;
-  }
-
-  return true;
-}
-
-bool UserProfile::AddFriendFromXUID(const uint64_t xuid) {
-  X_ONLINE_FRIEND peer = X_ONLINE_FRIEND();
-  peer.xuid = xuid;
-
-  return AddFriend(&peer);
-}
-
-bool UserProfile::AddFriend(X_ONLINE_FRIEND* peer) {
-  if (friends_.size() >= X_ONLINE_MAX_FRIENDS) {
-    return false;
-  }
-
-  if (GetOnlineXUID() == peer->xuid) {
-    return false;
-  }
-
-  if (peer == nullptr) {
-    return false;
-  }
-
-  if (IsFriend(peer->xuid)) {
-    return true;
-  }
-
-  std::string default_gamertag = fmt::format("{:016X}", peer->xuid.get());
-
-  XELOGI("{}: Added gamertag: {}", __func__, default_gamertag);
-
-  xe::string_util::copy_truncating(peer->Gamertag, default_gamertag.c_str(),
-                                   sizeof(peer->Gamertag));
-
-  friends_.push_back(*peer);
-
-  return true;
-}
-
-bool UserProfile::RemoveFriend(const X_ONLINE_FRIEND& peer) {
-  return RemoveFriend(peer.xuid);
-}
-
-bool UserProfile::RemoveFriend(const uint64_t xuid) {
-  bool removed = false;
-
-  auto it = std::remove_if(
-      friends_.begin(), friends_.end(),
-      [&xuid](const X_ONLINE_FRIEND& peer) { return peer.xuid == xuid; });
-
-  if (it != friends_.end()) {
-    const size_t friends_size = friends_.size();
-
-    friends_.erase(it, friends_.end());
-    removed = friends_.size() != friends_size;
-  }
-
-  return removed;
-}
-
-void UserProfile::RemoveAllFriends() {
-  for (const auto& friend_ : GetFriends()) {
-    RemoveFriend(friend_.xuid);
-    RemoveFriendFromConfig(friend_.xuid);
-  }
-}
-
-bool UserProfile::GetFriendFromIndex(const uint32_t index,
-                                     X_ONLINE_FRIEND* peer) {
-  if (index >= X_ONLINE_MAX_FRIENDS || index >= friends_.size()) {
-    return false;
-  }
-
-  if (peer == nullptr) {
-    return false;
-  }
-
-  memcpy(peer, &friends_[index], sizeof(X_ONLINE_FRIEND));
-
-  return true;
-}
-
-bool UserProfile::GetFriendFromXUID(const uint64_t xuid,
-                                    X_ONLINE_FRIEND* peer) {
-  if (peer == nullptr) {
-    return false;
-  }
-
-  return IsFriend(xuid, peer);
-}
-
-bool UserProfile::IsFriend(const uint64_t xuid, X_ONLINE_FRIEND* peer) {
-  auto it = std::find_if(
-      friends_.begin(), friends_.end(),
-      [&xuid](const X_ONLINE_FRIEND& peer) { return peer.xuid == xuid; });
-
-  if (it == friends_.end()) {
-    return false;
-  }
-
-  if (peer != nullptr) {
-    memcpy(peer, &*it, sizeof(X_ONLINE_FRIEND));
-  }
-
-  return true;
-}
-
-const std::set<uint64_t> UserProfile::GetFriendsXUIDs() const {
-  std::set<uint64_t> xuids;
-
-  for (const auto& peer : friends_) {
-    xuids.insert(peer.xuid);
-  }
-
-  return xuids;
-}
-
-const uint32_t UserProfile::GetFriendsCount() const {
-  return static_cast<uint32_t>(friends_.size());
 }
 
 bool UserProfile::SetSubscriptionFromXUID(const uint64_t xuid,

--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -108,6 +108,8 @@ class UserProfile {
  public:
   UserProfile(const uint64_t xuid, const X_XAMACCOUNTINFO* account_info);
 
+  void LoadFriends();
+
   uint64_t xuid() const { return xuid_; }
   uint64_t GetOnlineXUID() const {
     return IsLiveEnabled() ? static_cast<uint64_t>(account_info_.xuid_online)
@@ -175,29 +177,7 @@ class UserProfile {
 
   friend class UserTracker;
   friend class GpdAchievementBackend;
-
-  static X_ONLINE_FRIEND GenerateDummyFriend();
-
-  void AddDummyFriends(const uint32_t friends_count);
-
-  bool GetFriendPresenceFromXUID(const uint64_t xuid,
-                                 X_ONLINE_PRESENCE* presence);
-
-  bool SetFriend(const X_ONLINE_FRIEND& update_peer);
-  bool AddFriendFromXUID(const uint64_t xuid);
-  bool AddFriend(X_ONLINE_FRIEND* add_friend);
-  bool RemoveFriend(const X_ONLINE_FRIEND& peer);
-  bool RemoveFriend(const uint64_t xuid);
-  void RemoveAllFriends();
-
-  bool GetFriendFromIndex(const uint32_t index, X_ONLINE_FRIEND* peer);
-  bool GetFriendFromXUID(const uint64_t xuid, X_ONLINE_FRIEND* peer);
-  bool IsFriend(const uint64_t xuid, X_ONLINE_FRIEND* peer = nullptr);
-
-  const std::vector<X_ONLINE_FRIEND> GetFriends() const { return friends_; }
-  const std::set<uint64_t> GetFriendsXUIDs() const;
-
-  const uint32_t GetFriendsCount() const;
+  friend class FriendsManager;
 
   bool SetSubscriptionFromXUID(const uint64_t xuid, X_ONLINE_PRESENCE* peer);
   bool GetSubscriptionFromXUID(const uint64_t xuid, X_ONLINE_PRESENCE* peer);
@@ -266,8 +246,8 @@ class UserProfile {
  private:
   uint64_t xuid_;
   X_XAMACCOUNTINFO account_info_;
-  X_INVITE_INFO self_invite;
 
+  X_INVITE_INFO self_invite = {};
   std::vector<object_ref<XSession>> owned_sessions_;
   std::unique_ptr<xe::threading::PeriodicCallback> periodic_maintenance_task_;
 

--- a/src/xenia/kernel/xam/user_tracker.cc
+++ b/src/xenia/kernel/xam/user_tracker.cc
@@ -1415,7 +1415,10 @@ PresenceSyncState UserTracker::IsPresenceOutOfSync(
   for (const auto& player : presence_info) {
     const uint64_t xuid = player.XUID();
 
-    if (!user->IsFriend(xuid) && !user->IsSubscribed(xuid)) {
+    const auto friends_manager = kernel_state()->friends_manager();
+
+    if (!friends_manager->IsFriend(user->xuid(), xuid) &&
+        !user->IsSubscribed(xuid)) {
       XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
              xuid);
       continue;
@@ -1425,17 +1428,15 @@ PresenceSyncState UserTracker::IsPresenceOutOfSync(
       break;
     }
 
-    if (user->IsFriend(xuid) && !sync_state.friends) {
-      X_ONLINE_FRIEND peer = {};
+    const auto online_friend = friends_manager->GetFriend(user->xuid(), xuid);
 
-      if (user->GetFriendFromXUID(xuid, &peer)) {
-        const X_ONLINE_FRIEND updated_peer_presence =
-            player.GetFriendPresence();
+    if (online_friend.has_value()) {
+      const X_ONLINE_FRIEND peer = online_friend.value();
+      const X_ONLINE_FRIEND updated_peer_presence = player.GetFriendPresence();
 
-        if (std::memcmp(&peer, &updated_peer_presence,
-                        sizeof(X_ONLINE_FRIEND)) != 0) {
-          sync_state.friends = true;
-        }
+      if (std::memcmp(&peer, &updated_peer_presence, sizeof(X_ONLINE_FRIEND)) !=
+          0) {
+        sync_state.friends = true;
       }
     } else if (user->IsSubscribed(xuid) && !sync_state.peers) {
       X_ONLINE_PRESENCE peer = {};
@@ -1461,7 +1462,9 @@ void UserTracker::RefershFriendsAndSubscribersPresence(uint64_t xuid) const {
     return;
   }
 
-  const auto friends_xuids = user->GetFriendsXUIDs();
+  const auto friends_manager = kernel_state()->friends_manager();
+
+  const auto friends_xuids = friends_manager->GetFriendsXUIDs(user->xuid());
   const auto subscribed_xuids = user->GetSubscribedXUIDs();
   std::set<uint64_t> friends_and_subscribed_xuids = {};
 
@@ -1485,9 +1488,8 @@ void UserTracker::RefershFriendsAndSubscribersPresence(uint64_t xuid) const {
   for (const auto& player : presences->PlayersPresence()) {
     const uint64_t xuid = player.XUID();
 
-    if (user->IsFriend(xuid)) {
-      X_ONLINE_FRIEND friend_presence = player.GetFriendPresence();
-      user->SetFriend(friend_presence);
+    if (friends_manager->IsFriend(user->xuid(), xuid)) {
+      friends_manager->UpdateFriend(user->xuid(), player.GetFriendPresence());
     } else if (user->IsSubscribed(xuid)) {
       X_ONLINE_PRESENCE presence = player.ToOnlineRichPresence();
       user->SetSubscriptionFromXUID(xuid, &presence);

--- a/src/xenia/kernel/xam/xam_state.cc
+++ b/src/xenia/kernel/xam/xam_state.cc
@@ -10,6 +10,7 @@
 #include "xenia/kernel/xam/xam_state.h"
 #include "xenia/base/logging.h"
 #include "xenia/emulator.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/xam/online_schema.h"
 
 namespace xe {
@@ -30,8 +31,11 @@ XamState::XamState(Emulator* emulator, KernelState* kernel_state)
   user_tracker_ = std::make_unique<UserTracker>();
   profile_manager_ =
       std::make_unique<ProfileManager>(kernel_state, user_tracker_.get());
+  friends_manager_ =
+      std::make_unique<FriendsManager>(kernel_state, profile_manager_.get());
   achievement_manager_ = std::make_unique<AchievementManager>();
 
+  LoadOnlineFriends();
   LoadOnlineSchema();
   LoadLanguageLocaleFallback();
   LoadIptvServiceName();
@@ -100,6 +104,16 @@ void XamState::LoadIptvServiceName() {
   }
 }
 
+void XamState::LoadOnlineFriends() {
+  for (uint32_t user_index = 0; user_index < XUserMaxUserCount; user_index++) {
+    const auto profile = GetUserProfile(user_index);
+
+    if (profile) {
+      friends_manager_->AddFriends(profile->xuid(), ParseFriendsXUIDs());
+    }
+  }
+}
+
 UserProfile* XamState::GetUserProfile(uint32_t user_index) const {
   if (user_index >= XUserMaxUserCount && user_index < XUserIndexLatest) {
     return nullptr;
@@ -122,13 +136,7 @@ UserProfile* XamState::GetUserProfileLive(uint64_t xuid) const {
 }
 
 UserProfile* XamState::GetUserProfileAny(uint64_t xuid) const {
-  auto profile = profile_manager_->GetProfile(xuid);
-
-  if (profile != nullptr) {
-    return profile;
-  }
-
-  return profile_manager_->GetProfileLive(xuid);
+  return profile_manager_->GetProfileAny(xuid);
 }
 
 uint8_t XamState::GetUserIndexAssignedToProfileFromXUID(uint64_t xuid) const {

--- a/src/xenia/kernel/xam/xam_state.h
+++ b/src/xenia/kernel/xam/xam_state.h
@@ -15,6 +15,7 @@
 #include "xenia/kernel/xam/achievement_manager.h"
 #include "xenia/kernel/xam/app_manager.h"
 #include "xenia/kernel/xam/content_manager.h"
+#include "xenia/kernel/xam/friends_manager.h"
 #include "xenia/kernel/xam/profile_manager.h"
 #include "xenia/kernel/xam/user_tracker.h"
 #include "xenia/kernel/xam/xam.h"
@@ -44,6 +45,7 @@ class XamState {
     return achievement_manager_.get();
   }
   ProfileManager* profile_manager() const { return profile_manager_.get(); }
+  FriendsManager* friends_manager() const { return friends_manager_.get(); }
 
   UserTracker* user_tracker() const { return user_tracker_.get(); }
   SpaInfo* spa_info() const { return spa_info_.get(); }
@@ -89,6 +91,7 @@ class XamState {
   void LoadOnlineSchema();
   void LoadLanguageLocaleFallback();
   void LoadIptvServiceName();
+  void LoadOnlineFriends();
 
   KernelState* kernel_state_;
 
@@ -97,6 +100,7 @@ class XamState {
   std::unique_ptr<UserTracker> user_tracker_;
   std::unique_ptr<AchievementManager> achievement_manager_;
   std::unique_ptr<ProfileManager> profile_manager_;
+  std::unique_ptr<FriendsManager> friends_manager_;
 
   std::unique_ptr<SpaInfo> spa_info_;
 

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -15,8 +15,8 @@
 #include "xenia/kernel/XLiveAPI.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/user_module.h"
+#include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/util/shim_utils.h"
-#include "xenia/kernel/xam/friends_util.h"
 #include "xenia/kernel/xam/xam_content_device.h"
 #include "xenia/kernel/xam/xam_private.h"
 #include "xenia/ui/file_picker.h"
@@ -1007,7 +1007,8 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
                     (ImGui::GetStyle().ItemSpacing.x * 0.5f);
   ImVec2 half_width_btn = ImVec2(btn_width, btn_height);
 
-  bool are_friends = profile->IsFriend(friend_xuid, nullptr);
+  bool are_friends =
+      kernel_state()->friends_manager()->IsFriend(profile->xuid(), friend_xuid);
   bool is_self = profile->GetOnlineXUID() == presence.XUID();
 
   const std::string join_label =
@@ -1053,7 +1054,8 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
 
   if (are_friends && !is_self) {
     if (ImGui::Button(remove_label.c_str(), half_width_btn)) {
-      if (profile->RemoveFriend(friend_xuid)) {
+      if (kernel_state()->friends_manager()->RemoveFriend(profile->xuid(),
+                                                          friend_xuid)) {
         if (removed_xuid_) {
           *removed_xuid_ = friend_xuid;
         }
@@ -1082,7 +1084,8 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
 
   if (!are_friends && !is_self) {
     if (ImGui::Button(add_label.c_str(), half_width_btn)) {
-      bool added = profile->AddFriendFromXUID(friend_xuid);
+      bool added = kernel_state()->friends_manager()->AddFriend(profile->xuid(),
+                                                                friend_xuid);
 
       if (added) {
         AddFriendToConfig(friend_xuid);
@@ -1190,7 +1193,8 @@ bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
         kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(
             profile->GetLogonXUID());
 
-    bool max_friends = profile->GetFriendsCount() >= X_ONLINE_MAX_FRIENDS;
+    bool max_friends = kernel_state()->friends_manager()->GetFriendsCount(
+                           profile->xuid()) >= X_ONLINE_MAX_FRIENDS;
 
     if (max_friends) {
       ImGui::Text("Max Friends Reached!");
@@ -1209,7 +1213,8 @@ bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
         xuid = string_util::from_string<uint64_t>(xuid_string, true);
 
         args.valid_xuid = IsOnlineXUID(xuid);
-        args.are_friends = profile->IsFriend(xuid);
+        args.are_friends =
+            kernel_state()->friends_manager()->IsFriend(profile->xuid(), xuid);
       }
 
       if (!args.valid_xuid) {
@@ -1234,13 +1239,15 @@ bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
 
     const float window_width = ImGui::GetContentRegionAvail().x;
 
-    const std::string friends_count =
-        fmt::format("{}/100", profile->GetFriendsCount());
+    const uint32_t friends_count =
+        kernel_state()->friends_manager()->GetFriendsCount(profile->xuid());
+
+    const std::string friends_total = fmt::format("{}/100", friends_count);
 
     ImGui::SetCursorPosX((ImGui::GetCursorPosX() + window_width -
-                          ImGui::CalcTextSize(friends_count.c_str()).x));
+                          ImGui::CalcTextSize(friends_total.c_str()).x));
 
-    ImGui::Text(friends_count.c_str());
+    ImGui::Text(friends_total.c_str());
 
     if (!args.add_friend_first_draw && std::string(args.add_xuid_).empty()) {
       args.add_friend_first_draw = true;
@@ -1287,7 +1294,8 @@ bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
 
     ImGui::BeginDisabled(!args.valid_xuid || args.are_friends || max_friends);
     if (ImGui::Button("Add", btn_size)) {
-      bool added = profile->AddFriendFromXUID(xuid);
+      bool added =
+          kernel_state()->friends_manager()->AddFriend(profile->xuid(), xuid);
 
       if (added) {
         AddFriendToConfig(xuid);
@@ -1416,12 +1424,14 @@ bool xeDrawFriendsContent(
 
     ImGui::SetCursorPos(search_pos_input_end);
 
-    const std::string friends_count =
-        fmt::format("{}/100", profile->GetFriendsCount());
+    const uint32_t friends_count =
+        kernel_state()->friends_manager()->GetFriendsCount(profile->xuid());
+
+    const std::string friends_total = fmt::format("{}/100", friends_count);
 
     ImGui::SetCursorPosX((ImGui::GetCursorPosX() + window_width -
-                          ImGui::CalcTextSize(friends_count.c_str()).x));
-    ImGui::Text(friends_count.c_str());
+                          ImGui::CalcTextSize(friends_total.c_str()).x));
+    ImGui::Text(friends_total.c_str());
 
     ImGui::SetCursorPosY((ImGui::GetCursorPosY() - ImGui::GetTextLineHeight()) -
                          4);
@@ -1443,7 +1453,7 @@ bool xeDrawFriendsContent(
       ImGui::OpenPopup("Add Friend");
     }
 
-    ImGui::BeginDisabled(!profile->GetFriendsCount());
+    ImGui::BeginDisabled(!friends_count);
     if (ImGui::Button("Refresh", half_width_btn)) {
       args.refresh_presence = true;
     }
@@ -1451,7 +1461,7 @@ bool xeDrawFriendsContent(
 
     ImGui::SameLine();
 
-    ImGui::BeginDisabled(!profile->GetFriendsCount());
+    ImGui::BeginDisabled(!friends_count);
     if (ImGui::Button("Remove All", half_width_btn)) {
       ImGui::OpenPopup("Remove All Friends");
     }
@@ -1537,7 +1547,7 @@ bool xeDrawFriendsContent(
       ImGui::Separator();
 
       if (ImGui::Button("Yes", btn_size)) {
-        profile->RemoveAllFriends();
+        kernel_state()->friends_manager()->ClearFriends(profile->xuid());
 
         args.refresh_presence = true;
 

--- a/src/xenia/kernel/xam/xam_user.cc
+++ b/src/xenia/kernel/xam/xam_user.cc
@@ -735,7 +735,8 @@ dword_result_t XamUserAreUsersFriends_entry(
           // xuid is 0 sometimes?
           uint64_t xuid = xuids_ptr[i];
 
-          if (user_profile->IsFriend(xuid)) {
+          if (kernel_state()->friends_manager()->IsFriend(user_profile->xuid(),
+                                                          xuid)) {
             friends_count++;
           }
         }


### PR DESCRIPTION
Netplay supported a basic friends list before Canary supported profiles, due to this most of the friends code was put into `user_profile.cc`.

This PR refactors the current implementation into a friends manager class so it's easier to maintain.