### PR TITLE
[XAM] Refactored presence functions into presence manager

### DIFF
--- a/src/xenia/app/profile_dialogs.cc
+++ b/src/xenia/app/profile_dialogs.cc
@@ -502,20 +502,29 @@ void ManagerDialog::Initialize(ui::ImGuiDrawer* imgui_drawer,
     return;
   }
 
-  friends_presence_ =
-      emulator_->GetXboxLiveAPI()->GetFriendsPresenceAsync(profile->xuid());
-  immediate_gamerpics_ = emulator_->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(
-      profile->xuid(), imgui_drawer);
+  // If title is open we can assume periodic maintenance is running, therefore
+  // presence sync isn't needed.
+  if (!emulator_->is_title_open()) {
+    friends_ui_args_.friends_presence_sync =
+        emulator_->kernel_state()->presence_manager()->SyncPresenceAsync(
+            profile->xuid());
+  } else {
+    friends_ui_args_.friends_presence =
+        emulator_->kernel_state()
+            ->xam_state()
+            ->presence_manager()
+            ->GetFriendsPresenceSorted(profile->xuid());
+  }
+
+  friends_ui_args_.immediate_gamerpics =
+      emulator_->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(profile->xuid(),
+                                                            imgui_drawer);
 }
 
 void ManagerDialog::OnDraw(ImGuiIO& io) {
   if (!manager_opened_) {
     manager_opened_ = true;
     ImGui::OpenPopup("Manager");
-
-    if (emulator_->GetXboxLiveAPI()->IsConnectedToServer()) {
-      friends_args.filter_offline = true;
-    }
 
     sessions_args.filter_own = true;
   }
@@ -545,7 +554,13 @@ void ManagerDialog::OnDraw(ImGuiIO& io) {
 
     ImGui::BeginDisabled(is_profile_signed_in);
     if (ImGui::Button("Friends", btn_size)) {
-      friends_args.friends_open = true;
+      friends_ui_args_.content_args.friends_open = true;
+      friends_ui_args_.content_args.first_draw = true;
+
+      if (emulator_->kernel_state()->GetXboxLiveAPI()->IsConnectedToServer()) {
+        friends_ui_args_.content_args.filter_offline = true;
+      }
+
       ImGui::OpenPopup("Friends");
     }
     ImGui::EndDisabled();
@@ -589,42 +604,13 @@ void ManagerDialog::OnDraw(ImGuiIO& io) {
 
     ImGui::SetWindowFontScale(1.0f);
 
-    if (!friends_args.friends_open) {
-      friends_args.first_draw = false;
-    }
-
     if (!sessions_args.sessions_open) {
       sessions_args.first_draw = false;
       sessions_args.refresh_sessions_sync = true;
       sessions.clear();
     }
 
-    if (friends_presence_.valid()) {
-      if (friends_presence_.wait_for(0s) == std::future_status::ready) {
-        friends_presence_result_ = friends_presence_.get();
-      }
-    }
-
-    if (friends_args.refresh_presence) {
-      friends_presence_result_ = {};
-      friends_args.refresh_presence = false;
-
-      friends_presence_ =
-          emulator_->GetXboxLiveAPI()->GetFriendsPresenceAsync(profile->xuid());
-      immediate_gamerpics_ =
-          emulator_->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(profile->xuid(),
-                                                                imgui_drawer());
-    }
-
-    if (immediate_gamerpics_.valid()) {
-      if (immediate_gamerpics_.wait_for(0s) == std::future_status::ready) {
-        immediate_gamerpics_result_.merge(immediate_gamerpics_.get());
-      }
-    }
-
-    xeDrawFriendsContent(imgui_drawer(), profile, friends_args,
-                         &friends_presence_result_,
-                         immediate_gamerpics_result_);
+    xeDrawFriendsUI(imgui_drawer(), profile, friends_ui_args_);
 
     xeDrawSessionsContent(imgui_drawer(), profile, sessions_args, &sessions);
 

--- a/src/xenia/app/profile_dialogs.h
+++ b/src/xenia/app/profile_dialogs.h
@@ -12,8 +12,8 @@
 
 #include <future>
 
-#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/json/session_object_json.h"
+#include "xenia/kernel/xam/ui/friends_ui.h"
 #include "xenia/kernel/xam/ui/netplay_manager_util.h"
 #include "xenia/kernel/xam/user_profile.h"
 #include "xenia/ui/imgui_dialog.h"
@@ -80,20 +80,13 @@ class ManagerDialog final : public ui::ImGuiDialog {
   uint64_t selected_xuid_ = 0;
   uint64_t removed_xuid_ = 0;
   Emulator* emulator_;
-  xe::kernel::xam::ui::FriendsContentArgs friends_args = {};
+  xe::kernel::xam::ui::FriendsUIArgs friends_ui_args_;
   xe::kernel::xam::ui::SessionsContentArgs sessions_args = {};
   xe::kernel::xam::ui::MyDeletedProfilesArgs deletion_args = {};
   xe::kernel::xam::ui::UPnPAndPortsArgs upnp_and_ports_args = {};
   std::vector<std::unique_ptr<xe::kernel::SessionObjectJSON>> sessions;
   std::map<uint64_t, std::string> deleted_profiles;
   EmulatorWindow* emulator_window_;
-  std::future<std::vector<xe::kernel::FriendPresenceObjectJSON>>
-      friends_presence_;
-  std::vector<xe::kernel::FriendPresenceObjectJSON> friends_presence_result_;
-  std::future<std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>>
-      immediate_gamerpics_;
-  std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>
-      immediate_gamerpics_result_;
 };
 
 }  // namespace app

--- a/src/xenia/kernel/XLiveAPI.cpp
+++ b/src/xenia/kernel/XLiveAPI.cpp
@@ -1668,7 +1668,6 @@ std::unique_ptr<FriendsPresenceObjectJSON> XLiveAPI::GetFriendsPresence(
       std::make_unique<FriendsPresenceObjectJSON>();
 
   if (xuids.empty()) {
-    XELOGI("Skipping friends presence check.");
     return friends;
   }
 
@@ -1892,21 +1891,26 @@ std::unique_ptr<FindUsersObjectJSON> XLiveAPI::GetFindUsers(
 
 PresenceObjectJSON XLiveAPI::BuildRichPresenceRequest(
     std::set<uint64_t> xuids) {
-  PresenceObjectJSON presence = PresenceObjectJSON();
+  PresenceObjectJSON presence = {};
 
   for (const auto& xuid : xuids) {
-    const auto user_profile = kernel_state()->xam_state()->GetUserProfile(xuid);
+    const auto user_profile =
+        kernel_state()->xam_state()->GetUserProfileAny(xuid);
 
-    if (user_profile) {
-      FriendPresenceObjectJSON profile_presence = FriendPresenceObjectJSON();
-
-      if (user_profile->IsLiveEnabled()) {
-        profile_presence.XUID(user_profile->GetOnlineXUID());
-        profile_presence.RichPresence(user_profile->GetPresenceString());
-      }
-
-      presence.AddPresence(profile_presence);
+    if (!user_profile) {
+      continue;
     }
+
+    if (!user_profile->IsLiveEnabled()) {
+      continue;
+    }
+
+    FriendPresenceObjectJSON profile_presence = {};
+
+    profile_presence.XUID(user_profile->GetOnlineXUID());
+    profile_presence.RichPresence(user_profile->GetPresenceString());
+
+    presence.AddPresence(profile_presence);
   }
 
   return presence;
@@ -2408,100 +2412,6 @@ std::unique_ptr<HTTPResponseObjectJSON> XLiveAPI::PraseResponse(
   }
 
   return response;
-}
-
-std::future<std::vector<FriendPresenceObjectJSON>>
-XLiveAPI::GetFriendsPresenceAsync(uint64_t xuid) {
-  return std::async(std::launch::async, &XLiveAPI::GetAllFriendsPresence, this,
-                    xuid);
-}
-
-// TODO(Adrian): Take advantage of periodic maintenance.
-std::vector<FriendPresenceObjectJSON> XLiveAPI::GetAllFriendsPresence(
-    uint64_t xuid) {
-  auto offline_peer_presences = GetOfflineFriendsPresence(xuid);
-  std::map<uint64_t, FriendPresenceObjectJSON> online_peer_presences = {};
-
-  online_peer_presences = GetOnlineFriendsPresence(xuid);
-
-  std::map<uint64_t, FriendPresenceObjectJSON> merged_peer_presences =
-      online_peer_presences;
-
-  merged_peer_presences.merge(offline_peer_presences);
-
-  std::vector<FriendPresenceObjectJSON> peer_presences;
-
-  std::ranges::transform(
-      merged_peer_presences, std::back_inserter(peer_presences),
-      &std::pair<const uint64_t, FriendPresenceObjectJSON>::second);
-
-  std::sort(peer_presences.begin(), peer_presences.end(),
-            [](const FriendPresenceObjectJSON& peer_1,
-               FriendPresenceObjectJSON& peer_2) {
-              uint32_t peer_1_state = peer_1.State() & 0xFF;
-              uint32_t peer_2_state = peer_2.State() & 0xFF;
-
-              if (peer_1_state == peer_2_state &&
-                  (peer_1.SessionID() || peer_2.SessionID())) {
-                if (peer_1.SessionID() && peer_2.SessionID()) {
-                  return true;
-                }
-
-                return peer_1.SessionID() ? true : false;
-              }
-
-              return peer_1_state > peer_2_state;
-            });
-
-  return peer_presences;
-}
-
-std::map<uint64_t, FriendPresenceObjectJSON>
-XLiveAPI::GetOfflineFriendsPresence(uint64_t xuid) {
-  const auto user_profile = kernel_state()->xam_state()->GetUserProfile(xuid);
-
-  if (!user_profile) {
-    return {};
-  }
-
-  std::map<uint64_t, FriendPresenceObjectJSON> peer_presences = {};
-
-  const auto friends_xuids =
-      kernel_state()->friends_manager()->GetFriendsXUIDs(user_profile->xuid());
-
-  for (uint32_t count = 1; const auto& xuid : friends_xuids) {
-    FriendPresenceObjectJSON peer = {};
-    peer.Gamertag(std::format("Friend {}", count));
-    peer.XUID(xuid);
-
-    count++;
-    peer_presences[xuid] = peer;
-  }
-
-  return peer_presences;
-}
-
-std::map<uint64_t, FriendPresenceObjectJSON> XLiveAPI::GetOnlineFriendsPresence(
-    uint64_t xuid) {
-  const auto user_profile = kernel_state()->xam_state()->GetUserProfile(xuid);
-
-  if (!user_profile) {
-    return {};
-  }
-  std::map<uint64_t, FriendPresenceObjectJSON> peer_presences = {};
-
-  const auto friends_xuids =
-      kernel_state()->friends_manager()->GetFriendsXUIDs(user_profile->xuid());
-
-  const auto friends_presence_responce = GetFriendsPresence(friends_xuids);
-
-  const auto& friends_presence = friends_presence_responce->PlayersPresence();
-
-  for (const auto& presence : friends_presence) {
-    peer_presences[presence.XUID()] = presence;
-  }
-
-  return peer_presences;
 }
 
 }  // namespace kernel

--- a/src/xenia/kernel/XLiveAPI.h
+++ b/src/xenia/kernel/XLiveAPI.h
@@ -234,18 +234,6 @@ class XLiveAPI {
 
   std::unique_ptr<HTTPResponseObjectJSON> PraseResponse(response_data response);
 
-  std::future<std::vector<FriendPresenceObjectJSON>> GetFriendsPresenceAsync(
-      const uint64_t xuid);
-
-  std::vector<FriendPresenceObjectJSON> GetAllFriendsPresence(
-      const uint64_t xuid);
-
-  std::map<uint64_t, FriendPresenceObjectJSON> GetOfflineFriendsPresence(
-      const uint64_t xuid);
-
-  std::map<uint64_t, FriendPresenceObjectJSON> GetOnlineFriendsPresence(
-      const uint64_t xuid);
-
   sockaddr_in OnlineIP() const { return online_ip_; };
 
   std::string OnlineIP_str() const { return ip_to_string(online_ip_); };

--- a/src/xenia/kernel/kernel_state.h
+++ b/src/xenia/kernel/kernel_state.h
@@ -198,6 +198,9 @@ class KernelState {
   xam::FriendsManager* friends_manager() const {
     return xam_state()->friends_manager();
   }
+  xam::PresenceManager* presence_manager() const {
+    return xam_state()->presence_manager();
+  }
 
   XmpVolumePatch* xmp_volume_patch() const { return xmp_volume_patch_.get(); }
   void InitXmpVolumePatch();

--- a/src/xenia/kernel/util/xlast.cc
+++ b/src/xenia/kernel/util/xlast.cc
@@ -530,8 +530,8 @@ const std::optional<uint32_t> XLast::GetPresenceStringId(
 }
 
 const std::u16string XLast::GetPresenceRawString(
-    const xam::Property* presence_property) {
-  const uint32_t presence_value = presence_property->get_data()->data.u32;
+    const xam::Property& presence_property) {
+  const uint32_t presence_value = presence_property.get_data()->data.u32;
 
   const std::optional<uint32_t> presence_string_id =
       GetPresenceStringId(presence_value);

--- a/src/xenia/kernel/util/xlast.h
+++ b/src/xenia/kernel/util/xlast.h
@@ -154,7 +154,7 @@ class XLast {
   const std::optional<uint32_t> GetPresenceStringId(const uint32_t context_id);
   const std::optional<uint32_t> GetPropertyStringId(const uint32_t property_id);
   const std::u16string GetPresenceRawString(
-      const xam::Property* presence_property);
+      const xam::Property& presence_property);
   XLastGameModeQuery* GetGameModeQuery() const;
   XLastContextsQuery* GetContextsQuery() const;
   XLastPropertiesQuery* GetPropertiesQuery() const;

--- a/src/xenia/kernel/xam/apps/xlivebase_app.cc
+++ b/src/xenia/kernel/xam/apps/xlivebase_app.cc
@@ -352,9 +352,6 @@ X_HRESULT XLiveBaseApp::ExecuteDispatchMessage(uint32_t message,
   return cvars::stub_xlivebase ? X_E_SUCCESS : X_E_FAIL;
 }
 
-uint32_t MAX_TITLE_SUBSCRIPTIONS = 0;
-uint32_t ACTIVE_TITLE_SUBSCRIPTIONS = 0;
-
 X_HRESULT XLiveBaseApp::XPresenceInitialize(uint32_t buffer_ptr,
                                             uint32_t buffer_length) {
   if (!buffer_ptr || !buffer_length) {
@@ -379,7 +376,7 @@ X_HRESULT XLiveBaseApp::XPresenceInitialize(uint32_t buffer_ptr,
     return X_ONLINE_E_NOTIFICATION_TOO_MANY_SUBS;
   }
 
-  MAX_TITLE_SUBSCRIPTIONS = max_peer_subscriptions;
+  kernel_state_->presence_manager()->Initialize(max_peer_subscriptions);
 
   return X_E_SUCCESS;
 }
@@ -427,26 +424,15 @@ X_HRESULT XLiveBaseApp::XPresenceSubscribe(uint32_t buffer_ptr,
     return X_E_NO_SUCH_USER;
   }
 
-  const auto profile = kernel_state_->xam_state()->GetUserProfile(user_index);
+  const auto user_xuid =
+      kernel_state_->xam_state()->GetUserProfile(user_index)->xuid();
 
   for (uint32_t i = 0; i < num_peers; i++) {
     const xe::be<uint64_t> peer_xuid = peer_xuids[i];
 
-    if (!peer_xuid) {
-      continue;
-    }
-
-    if (kernel_state_->friends_manager()->IsFriend(profile->xuid(),
-                                                   peer_xuid)) {
-      continue;
-    }
-
-    if (ACTIVE_TITLE_SUBSCRIPTIONS <= MAX_TITLE_SUBSCRIPTIONS) {
-      ACTIVE_TITLE_SUBSCRIPTIONS++;
-
-      profile->SubscribeFromXUID(peer_xuid);
-    } else {
-      XELOGI("Max subscriptions reached");
+    if (!kernel_state_->presence_manager()->Subscribe(user_xuid, peer_xuid)) {
+      XELOGI("{}: Failed to subscribe peer: {:016X}", __func__,
+             peer_xuid.get());
     }
   }
 
@@ -500,24 +486,15 @@ X_HRESULT XLiveBaseApp::XPresenceUnsubscribe(uint32_t buffer_ptr,
     return X_E_NO_SUCH_USER;
   }
 
-  const auto profile = kernel_state_->xam_state()->GetUserProfile(user_index);
+  const auto user_xuid =
+      kernel_state_->xam_state()->GetUserProfile(user_index)->xuid();
 
   for (uint32_t i = 0; i < num_peers; i++) {
     const xe::be<uint64_t> peer_xuid = peer_xuids[i];
 
-    if (!peer_xuid) {
-      continue;
-    }
-
-    if (kernel_state_->friends_manager()->IsFriend(profile->xuid(),
-                                                   peer_xuid)) {
-      continue;
-    }
-
-    if (ACTIVE_TITLE_SUBSCRIPTIONS > 0) {
-      ACTIVE_TITLE_SUBSCRIPTIONS--;
-
-      profile->UnsubscribeFromXUID(peer_xuid);
+    if (!kernel_state_->presence_manager()->Unsubscribe(user_xuid, peer_xuid)) {
+      XELOGI("{}: Failed to unsubscribe peer: {:016X}", __func__,
+             peer_xuid.get());
     }
   }
 
@@ -530,6 +507,8 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
   if (!buffer_ptr || !buffer_length) {
     return X_E_INVALIDARG;
   }
+
+  assert_true(kernel_state_->presence_manager()->IsInitialized());
 
   XLivebaseAsyncTask async_task(kernel_state_, buffer_ptr);
 
@@ -578,10 +557,6 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
 
   *buffer_size_ptr = 0;
 
-  if (!kernel_state_->xam_state()->IsUserSignedIn(user_index)) {
-    return X_E_INVALIDARG;
-  }
-
   if (num_peers <= 0) {
     return X_E_INVALIDARG;
   }
@@ -602,7 +577,8 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
     return X_E_NO_SUCH_USER;
   }
 
-  const auto profile = kernel_state_->xam_state()->GetUserProfile(user_index);
+  const auto user_xuid =
+      kernel_state_->xam_state()->GetUserProfile(user_index)->xuid();
 
   auto e = make_object<XStaticEnumerator<X_ONLINE_PRESENCE>>(kernel_state_,
                                                              num_peers);
@@ -616,27 +592,27 @@ X_HRESULT XLiveBaseApp::XPresenceCreateEnumerator(uint32_t buffer_ptr,
       std::vector<uint64_t>(peer_xuids_ptr, peer_xuids_ptr + num_peers);
 
   for (auto i = starting_index; i < e->items_per_enumerate(); i++) {
-    const xe::be<uint64_t> xuid = peer_xuids[i];
-
-    if (!xuid) {
-      continue;
-    }
+    const xe::be<uint64_t> peer_xuid = peer_xuids[i];
 
     const auto friends_manager = kernel_state_->friends_manager();
+    const auto presence_manager = kernel_state_->presence_manager();
 
-    if (friends_manager->IsFriend(profile->xuid(), xuid)) {
+    if (friends_manager->IsFriend(user_xuid, peer_xuid)) {
       const auto presence =
-          friends_manager->GetFriendPresence(profile->xuid(), xuid);
+          friends_manager->GetFriendPresence(user_xuid, peer_xuid);
 
       if (presence.has_value()) {
         auto item = e->AppendItem();
         *item = presence.value();
       }
+    } else if (presence_manager->IsSubscribed(user_xuid, peer_xuid)) {
+      const auto subscription =
+          presence_manager->GetSubscription(user_xuid, peer_xuid);
 
-    } else if (profile->IsSubscribed(xuid)) {
-      auto item = e->AppendItem();
-
-      profile->GetSubscriptionFromXUID(xuid, item);
+      if (subscription.has_value()) {
+        auto item = e->AppendItem();
+        *item = subscription.value();
+      }
     }
   }
 
@@ -842,6 +818,9 @@ X_HRESULT XLiveBaseApp::XFriendsCreateEnumerator(uint32_t buffer_ptr,
     return X_E_INVALIDARG;
   }
 
+  // 5841128F and 58410A57 don't call XPresenceInitialize before
+  // XFriendsCreateEnumerator, maybe it's not mandatory?
+
   XLivebaseAsyncTask async_task(kernel_state_, buffer_ptr);
 
   const X_ARGUMENT_LIST* args_list =
@@ -987,8 +966,8 @@ X_HRESULT XLiveBaseApp::XInviteGetAcceptedInfo(uint32_t buffer_ptr,
   // Reset self invite
   user_profile->SetSelfInvite({});
 
-  const auto presence = kernel_state_->GetXboxLiveAPI()->GetFriendsPresence(
-      {invite_info->xuid_inviter});
+  const auto presence = kernel_state_->presence_manager()->GetFriendsPresence(
+      user_profile->xuid(), {invite_info->xuid_inviter});
 
   uint64_t session_id = 0;
 

--- a/src/xenia/kernel/xam/friends_manager.cc
+++ b/src/xenia/kernel/xam/friends_manager.cc
@@ -8,6 +8,7 @@
  */
 
 #include "xenia/kernel/xam/friends_manager.h"
+#include "xenia/base/logging.h"
 #include "xenia/kernel/kernel_state.h"
 #include "xenia/kernel/util/friends_util.h"
 #include "xenia/kernel/xam/profile_manager.h"
@@ -58,7 +59,8 @@ bool FriendsManager::AddFriend(const uint64_t xuid, const uint64_t friend_xuid,
 
   X_ONLINE_FRIEND peer = {.xuid = friend_xuid};
 
-  const std::string default_gamertag = fmt::format("{:016X}", friend_xuid);
+  const std::string default_gamertag =
+      fmt::format("Friend {}", user->friends_.size() + 1);
 
   xe::string_util::copy_truncating(peer.Gamertag, default_gamertag.c_str(),
                                    xe::countof(peer.Gamertag));
@@ -225,6 +227,46 @@ std::vector<X_ONLINE_FRIEND>::iterator FriendsManager::FindFriend(
                       [&friend_xuid](const X_ONLINE_FRIEND& peer) {
                         return peer.xuid == friend_xuid;
                       });
+}
+
+bool FriendsManager::IsPresenceOutOfSync(
+    uint64_t xuid, std::vector<FriendPresenceObjectJSON> friends) const {
+  if (friends.empty()) {
+    return false;
+  }
+
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  bool sync_state = false;
+
+  for (const auto& player : friends) {
+    const uint64_t friend_xuid = player.XUID();
+
+    if (!IsFriend(xuid, friend_xuid)) {
+      XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
+             friend_xuid);
+      continue;
+    }
+
+    if (sync_state) {
+      break;
+    }
+
+    const auto friend_ = GetFriend(xuid, friend_xuid);
+
+    if (friend_.has_value()) {
+      const X_ONLINE_FRIEND peer = friend_.value();
+      const X_ONLINE_FRIEND updated_peer_presence = player.GetFriendPresence();
+
+      sync_state =
+          std::memcmp(&peer, &updated_peer_presence, sizeof(X_ONLINE_FRIEND));
+    }
+  }
+
+  return sync_state;
 }
 
 // Convert X_ONLINE_FRIEND to X_ONLINE_PRESENCE

--- a/src/xenia/kernel/xam/friends_manager.h
+++ b/src/xenia/kernel/xam/friends_manager.h
@@ -13,6 +13,7 @@
 #include <optional>
 #include <set>
 
+#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/xnet.h"
 
 namespace xe {
@@ -71,6 +72,9 @@ class FriendsManager {
       const uint64_t xuid, const uint64_t friend_xuid) const;
 
   void AddDummyFriends(const uint64_t xuid, const uint32_t friends_count) const;
+
+  bool IsPresenceOutOfSync(uint64_t xuid,
+                           std::vector<FriendPresenceObjectJSON> friends) const;
 
  private:
   std::vector<X_ONLINE_FRIEND>::iterator FindFriend(

--- a/src/xenia/kernel/xam/presence_manager.cc
+++ b/src/xenia/kernel/xam/presence_manager.cc
@@ -1,0 +1,499 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#include <ranges>
+
+#include "xenia/base/logging.h"
+#include "xenia/emulator.h"
+#include "xenia/kernel/util/presence_string_builder.h"
+#include "xenia/kernel/xam/friends_manager.h"
+#include "xenia/kernel/xam/presence_manager.h"
+#include "xenia/kernel/xam/profile_manager.h"
+#include "xenia/kernel/xam/user_profile.h"
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+// TODO(Adrian): How should we differentiate the usage between X_ONLINE_FRIEND
+// and X_ONLINE_PRESENCE?
+
+PresenceManager::PresenceManager(KernelState* kernel_state,
+                                 ProfileManager* profile_manager,
+                                 FriendsManager* friends_manager)
+    : kernel_state_(kernel_state),
+      profile_manager_(profile_manager),
+      friends_manager_(friends_manager) {}
+
+bool PresenceManager::IsInitialized() const { return initialized_; }
+
+std::u16string PresenceManager::GetPresenceString(const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  return user->online_presence_desc_;
+}
+
+std::unique_ptr<FriendsPresenceObjectJSON> PresenceManager::GetFriendsPresence(
+    const uint64_t xuid, const std::set<uint64_t>& xuids) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  for (const auto& friend_xuid : xuids) {
+    const bool is_friend = friends_manager_->IsFriend(xuid, friend_xuid);
+    const bool is_subscribed = IsSubscribed(xuid, friend_xuid);
+
+    if (!is_friend && !is_subscribed) {
+      XELOGI(
+          "{}: Trying to retrieve presence for non-friend and unsubscribed "
+          "peer",
+          __func__);
+    }
+  }
+
+  return kernel_state_->GetXboxLiveAPI()->GetFriendsPresence(xuids);
+}
+
+bool PresenceManager::IsPresenceStringUpdateAvailable(
+    const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  const std::u16string current_presence = user->online_presence_desc_;
+  std::u16string updated_presence = u"";
+
+  if (!BuildPresenceString(xuid, false, &updated_presence)) {
+    return false;
+  }
+
+  return current_presence != updated_presence;
+}
+
+void PresenceManager::UpdateXboxLiveLocalUsersPresence(
+    const std::set<uint64_t>& xuids) const {
+  kernel_state_->GetXboxLiveAPI()->SetPresence(xuids);
+}
+
+bool PresenceManager::UpdatePresence(const uint64_t xuid) const {
+  bool updated = UpdateLocalPresence(xuid);
+
+  if (updated) {
+    UpdateXboxLiveLocalUsersPresence({xuid});
+  }
+
+  return updated;
+}
+
+bool PresenceManager::UpdateLocalPresence(const uint64_t xuid) const {
+  bool updated = false;
+
+  if (IsPresenceStringUpdateAvailable(xuid)) {
+    updated = BuildPresenceString(xuid, true);
+  }
+
+  return updated;
+}
+
+bool PresenceManager::BuildPresenceString(
+    const uint64_t xuid, bool update, std::u16string* presence_string) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  bool completed = false;
+
+  const auto presence_context = std::find_if(
+      user->properties_.cbegin(), user->properties_.cend(),
+      [](const Property& property_data) {
+        return property_data.GetPropertyId().value == XCONTEXT_PRESENCE;
+      });
+
+  if (presence_context == user->properties_.cend()) {
+    return completed;
+  }
+
+  const auto gdb = kernel_state_->emulator()->game_info_database();
+
+  if (!gdb->HasXLast()) {
+    return completed;
+  }
+
+  const auto xlast = gdb->GetXLast();
+
+  const std::u16string raw_presence =
+      xlast->GetPresenceRawString(*presence_context);
+
+  const auto presence_string_formatter =
+      util::AttributeStringFormatter(raw_presence, xlast, xuid);
+
+  completed = presence_string_formatter.IsComplete();
+
+  const auto presence_parsed = presence_string_formatter.GetPresenceString();
+
+  if (completed && update) {
+    user->online_presence_desc_ = presence_parsed;
+  }
+
+  if (completed && presence_string) {
+    *presence_string = presence_parsed;
+  }
+
+  return completed;
+}
+
+bool PresenceManager::UpdateSubscription(const uint64_t xuid,
+                                         const X_ONLINE_PRESENCE& peer) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (!IsSubscribed(xuid, peer.xuid)) {
+    return false;
+  }
+
+  user->subscriptions_[peer.xuid] = peer;
+
+  return true;
+}
+
+std::optional<X_ONLINE_PRESENCE> PresenceManager::GetSubscription(
+    const uint64_t xuid, const uint64_t subscriber_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return std::nullopt;
+  }
+
+  if (!IsSubscribed(xuid, subscriber_xuid)) {
+    return std::nullopt;
+  }
+
+  return user->subscriptions_[subscriber_xuid];
+}
+
+void PresenceManager::Initialize(const uint32_t max_subscriptions) {
+  // We're suppose to allocate memory for max subscriptions.
+  // However we're simply using a map in profile to manage subscriptions.
+
+  const uint32_t alloc_buffer_size =
+      max_subscriptions * sizeof(X_ONLINE_PRESENCE);
+
+  max_subscriptions_ = max_subscriptions;
+  initialized_ = true;
+}
+
+bool PresenceManager::Subscribe(const uint64_t xuid,
+                                const uint64_t subscriber_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (user->subscriptions_.size() >= kMaxUserSubscriptions) {
+    return false;
+  }
+
+  if (!IsOnlineXUID(subscriber_xuid)) {
+    return false;
+  }
+
+  if (user->GetOnlineXUID() == subscriber_xuid) {
+    return false;
+  }
+
+  if (IsSubscribed(xuid, subscriber_xuid)) {
+    return false;
+  }
+
+  // We can access the presence information for friends without subscribing.
+  if (friends_manager_->IsFriend(xuid, subscriber_xuid)) {
+    return true;
+  }
+
+  user->subscriptions_[subscriber_xuid] = {};
+
+  return true;
+}
+
+bool PresenceManager::Unsubscribe(const uint64_t xuid,
+                                  const uint64_t subscriber_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (!IsSubscribed(xuid, subscriber_xuid)) {
+    return true;
+  }
+
+  return user->subscriptions_.erase(xuid);
+}
+
+bool PresenceManager::IsSubscribed(const uint64_t xuid,
+                                   const uint64_t subscriber_xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (!IsOnlineXUID(subscriber_xuid)) {
+    return false;
+  }
+
+  return user->subscriptions_.contains(subscriber_xuid);
+}
+
+std::set<uint64_t> PresenceManager::GetSubscribedXUIDs(
+    const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  const auto subscribed_xuids_view = std::views::keys(user->subscriptions_);
+
+  std::set<uint64_t> subscribed_xuids(subscribed_xuids_view.begin(),
+                                      subscribed_xuids_view.end());
+
+  return subscribed_xuids;
+}
+
+uint32_t PresenceManager::GetMaxPeerSubscriptions() const {
+  return max_subscriptions_;
+}
+
+uint32_t PresenceManager::GetSubscribedPeersTotal() const {
+  uint32_t total_subscribed_peers = 0;
+
+  for (uint8_t user_index = 0; user_index < XUserMaxUserCount; user_index++) {
+    const auto profile = profile_manager_->GetProfile(user_index);
+
+    if (profile) {
+      total_subscribed_peers += profile->subscriptions_.size();
+    }
+  }
+
+  return total_subscribed_peers;
+}
+
+bool PresenceManager::IsPresenceOutOfSync(
+    uint64_t xuid, std::vector<FriendPresenceObjectJSON> subscribers) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return false;
+  }
+
+  if (subscribers.empty()) {
+    return false;
+  }
+
+  bool sync_state = false;
+
+  for (const auto& player : subscribers) {
+    const uint64_t subscribed_xuid = player.XUID();
+
+    if (!IsSubscribed(xuid, subscribed_xuid)) {
+      XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
+             subscribed_xuid);
+      continue;
+    }
+
+    if (sync_state) {
+      break;
+    }
+
+    const auto subscription = GetSubscription(xuid, subscribed_xuid);
+
+    if (subscription.has_value()) {
+      const X_ONLINE_PRESENCE peer = subscription.value();
+      const X_ONLINE_PRESENCE updated_peer_presence =
+          player.ToOnlineRichPresence();
+
+      sync_state =
+          std::memcmp(&peer, &updated_peer_presence, sizeof(X_ONLINE_PRESENCE));
+    }
+  }
+
+  return sync_state;
+}
+
+std::unique_ptr<FriendsPresenceObjectJSON>
+PresenceManager::GetLivePresenceFriends(const uint64_t xuid) const {
+  return GetFriendsPresence(xuid, friends_manager_->GetFriendsXUIDs(xuid));
+}
+
+std::unique_ptr<FriendsPresenceObjectJSON>
+PresenceManager::GetLivePresenceSubscribers(const uint64_t xuid) const {
+  return GetFriendsPresence(xuid, GetSubscribedXUIDs(xuid));
+}
+
+std::unique_ptr<FriendsPresenceObjectJSON> PresenceManager::GetLivePresence(
+    const uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  const auto friends_xuids = friends_manager_->GetFriendsXUIDs(xuid);
+  const auto subscribed_xuids = GetSubscribedXUIDs(xuid);
+
+  std::set<uint64_t> friends_and_subscribed_xuids = {};
+
+  std::set_union(friends_xuids.cbegin(), friends_xuids.cend(),
+                 subscribed_xuids.cbegin(), subscribed_xuids.cend(),
+                 std::inserter(friends_and_subscribed_xuids,
+                               friends_and_subscribed_xuids.cbegin()));
+
+  return GetFriendsPresence(xuid, friends_and_subscribed_xuids);
+}
+
+PresenceSynced PresenceManager::GetPresenceSyncState(uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {{}, {}, {}};
+  }
+
+  const auto live_presences = GetLivePresence(xuid);
+  const auto& presence_players = live_presences->PlayersPresence();
+
+  if (presence_players.empty()) {
+    return {{}, {}, {}};
+  }
+
+  const auto friends_xuids = friends_manager_->GetFriendsXUIDs(xuid);
+  const auto subscribed_xuids = GetSubscribedXUIDs(xuid);
+
+  auto friends_presence_view =
+      presence_players |
+      std::views::filter([&friends_xuids](FriendPresenceObjectJSON presence) {
+        return friends_xuids.contains(presence.XUID());
+      });
+
+  auto subscribed_presence_view =
+      presence_players |
+      std::views::filter(
+          [&subscribed_xuids](FriendPresenceObjectJSON presence) {
+            return subscribed_xuids.contains(presence.XUID());
+          });
+
+  std::vector<FriendPresenceObjectJSON> friends_presence;
+  std::vector<FriendPresenceObjectJSON> subscribed_presence;
+
+  for (const auto& friend_ : friends_presence_view) {
+    friends_presence.push_back(friend_);
+  }
+
+  for (const auto& subscriber : subscribed_presence_view) {
+    subscribed_presence.push_back(subscriber);
+  }
+
+  const bool friends_sync_state =
+      friends_manager_->IsPresenceOutOfSync(xuid, friends_presence);
+  const bool subscribed_sync_state =
+      IsPresenceOutOfSync(xuid, subscribed_presence);
+
+  const PresenceSyncState presence_sync_state = {
+      .friends = friends_sync_state, .subscribers = subscribed_sync_state};
+
+  PresenceSynced presence_synced_data(presence_sync_state, friends_presence,
+                                      subscribed_presence);
+
+  return presence_synced_data;
+}
+
+std::future<void> PresenceManager::SyncPresenceAsync(uint64_t xuid) const {
+  return std::async(std::launch::async, &PresenceManager::SyncPresence, this,
+                    xuid);
+}
+
+void PresenceManager::SyncPresence(uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return;
+  }
+
+  const PresenceSynced presence_synced = GetPresenceSyncState(xuid);
+
+  if (!presence_synced.GetSyncState().IsOutOfSync()) {
+    return;
+  }
+
+  XELOGD("Friends/Subscribed peers presence state changed.");
+
+  for (const auto& player : presence_synced.GetFriendsView()) {
+    friends_manager_->UpdateFriend(xuid, player.GetFriendPresence());
+  }
+
+  for (const auto& player : presence_synced.GetSubscribersView()) {
+    UpdateSubscription(xuid, player.ToOnlineRichPresence());
+  }
+
+  if (presence_synced.GetSyncState().friends) {
+    const uint32_t user_index =
+        profile_manager_->GetUserIndexAssignedToProfile(user->xuid());
+
+    kernel_state_->BroadcastNotification(kXNotificationFriendsPresenceChanged,
+                                         user_index);
+  }
+
+  if (IsInitialized()) {
+    if (presence_synced.GetSyncState().subscribers) {
+      kernel_state_->BroadcastNotification(kXNotificationLivePresenceChanged,
+                                           0);
+    }
+  }
+}
+
+std::vector<X_ONLINE_FRIEND> PresenceManager::GetFriendsPresenceSorted(
+    uint64_t xuid) const {
+  const auto user = profile_manager_->GetProfileAny(xuid);
+  if (!user) {
+    return {};
+  }
+
+  const auto friends_presence_ref = friends_manager_->GetFriends(xuid);
+
+  if (!friends_presence_ref.has_value()) {
+    return {};
+  }
+
+  std::vector<X_ONLINE_FRIEND> friends_presence =
+      friends_presence_ref.value().get();
+
+  std::sort(
+      friends_presence.begin(), friends_presence.end(),
+      [](X_ONLINE_FRIEND& peer_1, X_ONLINE_FRIEND& peer_2) {
+        uint32_t peer_1_state = peer_1.state & 0xFF;
+        uint32_t peer_2_state = peer_2.state & 0xFF;
+
+        if (peer_1_state == peer_2_state &&
+            (peer_1.session_id.as_uint64() || peer_2.session_id.as_uint64())) {
+          if (peer_1.session_id.as_uint64() && peer_2.session_id.as_uint64()) {
+            return true;
+          }
+
+          return peer_1.session_id.as_uint64() ? true : false;
+        }
+
+        return peer_1_state > peer_2_state;
+      });
+
+  return friends_presence;
+}
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe

--- a/src/xenia/kernel/xam/presence_manager.h
+++ b/src/xenia/kernel/xam/presence_manager.h
@@ -1,0 +1,152 @@
+/**
+ ******************************************************************************
+ * Xenia : Xbox 360 Emulator Research Project                                 *
+ ******************************************************************************
+ * Copyright 2026 Xenia Canary. All rights reserved.                          *
+ * Released under the BSD license - see LICENSE in the root for more details. *
+ ******************************************************************************
+ */
+
+#ifndef XENIA_KERNEL_XAM_PRECENSE_MANAGER_H_
+#define XENIA_KERNEL_XAM_PRECENSE_MANAGER_H_
+
+#include <future>
+#include <set>
+
+#include "xenia/kernel/json/friend_presence_object_json.h"
+#include "xenia/kernel/xnet.h"
+
+namespace xe {
+namespace kernel {
+class KernelState;
+}  // namespace kernel
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace xam {
+class ProfileManager;
+class FriendsManager;
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+namespace xe {
+namespace kernel {
+namespace xam {
+
+struct PresenceSyncState {
+  bool friends;
+  bool subscribers;
+
+  bool IsOutOfSync() const { return friends || subscribers; }
+};
+
+class PresenceSynced {
+ public:
+  PresenceSynced(PresenceSyncState sync_state,
+                 std::vector<FriendPresenceObjectJSON> friends,
+                 std::vector<FriendPresenceObjectJSON> subscribers)
+      : sync_state_(sync_state),
+        friends_(friends),
+        subscribers_(subscribers) {};
+
+  const PresenceSyncState GetSyncState() const { return sync_state_; }
+
+  const std::vector<FriendPresenceObjectJSON>& GetFriendsView() const {
+    return friends_;
+  }
+
+  const std::vector<FriendPresenceObjectJSON>& GetSubscribersView() const {
+    return subscribers_;
+  }
+
+ private:
+  PresenceSyncState sync_state_;
+  std::vector<FriendPresenceObjectJSON> friends_;
+  std::vector<FriendPresenceObjectJSON> subscribers_;
+};
+
+class PresenceManager {
+ public:
+  PresenceManager(KernelState* kernel_state, ProfileManager* profile_manager,
+                  FriendsManager* friends_manager);
+
+  ~PresenceManager() = default;
+
+  bool IsInitialized() const;
+
+  std::u16string GetPresenceString(const uint64_t xuid) const;
+
+  void UpdateXboxLiveLocalUsersPresence(const std::set<uint64_t>& xuids) const;
+
+  std::unique_ptr<FriendsPresenceObjectJSON> GetFriendsPresence(
+      const uint64_t xuid, const std::set<uint64_t>& xuids) const;
+
+  bool IsPresenceStringUpdateAvailable(const uint64_t xuid) const;
+
+  bool UpdatePresence(const uint64_t xuid) const;
+
+  bool UpdateLocalPresence(const uint64_t xuid) const;
+
+  bool UpdateSubscription(const uint64_t xuid,
+                          const X_ONLINE_PRESENCE& peer) const;
+
+  std::optional<X_ONLINE_PRESENCE> GetSubscription(
+      const uint64_t xuid, const uint64_t subscriber_xuid) const;
+
+  void Initialize(const uint32_t max_subscriptions);
+
+  bool Subscribe(const uint64_t xuid, const uint64_t subscriber_xuid) const;
+
+  bool Unsubscribe(const uint64_t xuid, const uint64_t subscriber_xuid) const;
+
+  bool IsSubscribed(const uint64_t xuid, const uint64_t subscriber_xuid) const;
+
+  std::set<uint64_t> GetSubscribedXUIDs(const uint64_t xuid) const;
+
+  uint32_t GetMaxPeerSubscriptions() const;
+
+  uint32_t GetSubscribedPeersTotal() const;
+
+  bool IsPresenceOutOfSync(
+      uint64_t xuid, std::vector<FriendPresenceObjectJSON> subscribers) const;
+
+  std::unique_ptr<FriendsPresenceObjectJSON> GetLivePresenceFriends(
+      const uint64_t xuid) const;
+
+  std::unique_ptr<FriendsPresenceObjectJSON> GetLivePresenceSubscribers(
+      const uint64_t xuid) const;
+
+  std::unique_ptr<FriendsPresenceObjectJSON> GetLivePresence(
+      const uint64_t xuid) const;
+
+  PresenceSynced GetPresenceSyncState(uint64_t xuid) const;
+
+  std::future<void> SyncPresenceAsync(uint64_t xuid) const;
+
+  // Sync XFriendsCreateEnumerator & XPresenceCreateEnumerator
+  void SyncPresence(uint64_t xuid) const;
+
+  std::vector<X_ONLINE_FRIEND> GetFriendsPresenceSorted(uint64_t xuid) const;
+
+ private:
+  bool BuildPresenceString(const uint64_t xuid, bool update,
+                           std::u16string* presence_string = nullptr) const;
+
+  bool initialized_ = false;
+  uint32_t max_subscriptions_ = 0;
+
+  const uint32_t kMaxUserSubscriptions =
+      X_ONLINE_PEER_SUBSCRIPTIONS / XUserMaxUserCount;
+
+  KernelState* kernel_state_;
+  ProfileManager* profile_manager_;
+  FriendsManager* friends_manager_;
+};
+
+}  // namespace xam
+}  // namespace kernel
+}  // namespace xe
+
+#endif  // XENIA_KERNEL_XAM_PRECENSE_MANAGER_H_

--- a/src/xenia/kernel/xam/ui/friends_ui.cc
+++ b/src/xenia/kernel/xam/ui/friends_ui.cc
@@ -17,55 +17,68 @@ namespace ui {
 
 FriendsUI::FriendsUI(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile)
     : XamDialog(imgui_drawer), profile_(profile) {
-  friends_presence_ = kernel_state()->GetXboxLiveAPI()->GetFriendsPresenceAsync(
-      profile->xuid());
-  immediate_gamerpics_ =
+  friends_ui_args_.friends_presence =
+      kernel_state()->xam_state()->presence_manager()->GetFriendsPresenceSorted(
+          profile_->xuid());
+
+  friends_ui_args_.immediate_gamerpics =
       kernel_state()->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(
           profile->xuid(), imgui_drawer);
 }
 
-// TODO(Adrian): Move into a separate function so draw can be reused with dialog
-// manager to reduce duplication.
 void FriendsUI::OnDraw(ImGuiIO& io) {
-  if (!args.friends_open) {
-    args.first_draw = true;
-    args.friends_open = true;
-
-    ImGui::OpenPopup("Friends");
+  if (!friends_ui_args_.content_args.friends_open) {
+    friends_ui_args_.content_args.first_draw = true;
+    friends_ui_args_.content_args.friends_open = true;
 
     if (kernel_state()->GetXboxLiveAPI()->IsConnectedToServer()) {
-      args.filter_offline = true;
+      friends_ui_args_.content_args.filter_offline = true;
     }
+
+    ImGui::OpenPopup("Friends");
   }
 
-  if (friends_presence_.valid()) {
-    if (friends_presence_.wait_for(0s) == std::future_status::ready) {
-      friends_presence_result_ = friends_presence_.get();
-    }
-  }
-
-  if (args.refresh_presence) {
-    friends_presence_ =
-        kernel_state()->GetXboxLiveAPI()->GetFriendsPresenceAsync(
-            profile_->xuid());
-    immediate_gamerpics_ =
-        kernel_state()->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(
-            profile_->xuid(), imgui_drawer());
-    args.refresh_presence = false;
-  }
-
-  if (immediate_gamerpics_.valid()) {
-    if (immediate_gamerpics_.wait_for(0s) == std::future_status::ready) {
-      immediate_gamerpics_result_.merge(immediate_gamerpics_.get());
-    }
-  }
-
-  xeDrawFriendsContent(imgui_drawer(), profile_, args,
-                       &friends_presence_result_, immediate_gamerpics_result_);
-
-  if (!args.friends_open) {
+  if (!xeDrawFriendsUI(imgui_drawer(), profile_, friends_ui_args_)) {
+    friends_ui_args_.content_args.first_draw = false;
     Close();
   }
+}
+
+bool xeDrawFriendsUI(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
+                     FriendsUIArgs& friends_ui_args) {
+  if (!profile) {
+    return false;
+  }
+
+  // Automatically sync/update friends presence information.
+  friends_ui_args.friends_presence =
+      kernel_state()->xam_state()->presence_manager()->GetFriendsPresenceSorted(
+          profile->xuid());
+
+  if (friends_ui_args.content_args.refresh_presence) {
+    friends_ui_args.content_args.refresh_presence = false;
+
+    friends_ui_args.friends_presence_sync =
+        kernel_state()->presence_manager()->SyncPresenceAsync(profile->xuid());
+
+    friends_ui_args.immediate_gamerpics =
+        kernel_state()->GetXboxLiveAPI()->GetFriendsGamerpicsAsync(
+            profile->xuid(), imgui_drawer);
+  }
+
+  if (friends_ui_args.immediate_gamerpics.valid()) {
+    if (friends_ui_args.immediate_gamerpics.wait_for(0s) ==
+        std::future_status::ready) {
+      friends_ui_args.immediate_gamerpics_result =
+          friends_ui_args.immediate_gamerpics.get();
+    }
+  }
+
+  xeDrawFriendsContent(imgui_drawer, profile, friends_ui_args.content_args,
+                       friends_ui_args.friends_presence,
+                       friends_ui_args.immediate_gamerpics_result);
+
+  return friends_ui_args.content_args.friends_open;
 }
 
 }  // namespace ui

--- a/src/xenia/kernel/xam/ui/friends_ui.h
+++ b/src/xenia/kernel/xam/ui/friends_ui.h
@@ -19,6 +19,16 @@ namespace kernel {
 namespace xam {
 namespace ui {
 
+struct FriendsUIArgs {
+  FriendsContentArgs content_args = {};
+  std::future<void> friends_presence_sync;
+  std::vector<X_ONLINE_FRIEND> friends_presence;
+  std::future<std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>>
+      immediate_gamerpics;
+  std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>
+      immediate_gamerpics_result;
+};
+
 class FriendsUI : public XamDialog {
  public:
   FriendsUI(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile);
@@ -27,14 +37,11 @@ class FriendsUI : public XamDialog {
   void OnDraw(ImGuiIO& io) override;
 
   UserProfile* profile_;
-  ui::FriendsContentArgs args = {};
-  std::future<std::vector<FriendPresenceObjectJSON>> friends_presence_;
-  std::vector<FriendPresenceObjectJSON> friends_presence_result_;
-  std::future<std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>>
-      immediate_gamerpics_;
-  std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>
-      immediate_gamerpics_result_;
+  ui::FriendsUIArgs friends_ui_args_ = {};
 };
+
+bool xeDrawFriendsUI(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
+                     FriendsUIArgs& args);
 
 }  // namespace ui
 }  // namespace xam

--- a/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
+++ b/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.cc
@@ -8,9 +8,7 @@
  */
 
 #include "xenia/kernel/xam/ui/gamercard_from_xuid_ui.h"
-#include "xenia/emulator.h"
 #include "xenia/kernel/XLiveAPI.h"
-#include "xenia/ui/imgui_host_notification.h"
 
 namespace xe {
 namespace kernel {
@@ -20,11 +18,7 @@ namespace ui {
 GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
                                          const uint64_t xuid,
                                          UserProfile* profile)
-    : XamDialog(imgui_drawer),
-      xuid_(xuid),
-      profile_(profile),
-      presence_({}),
-      title_("Gamercard") {
+    : XamDialog(imgui_drawer), xuid_(xuid), profile_(profile) {
   is_self = xuid_ == profile_->xuid() || xuid_ == profile_->GetOnlineXUID();
 
   if (!is_self) {
@@ -34,11 +28,8 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
   if (!kernel_state()->GetXboxLiveAPI()->IsConnectedToServer()) {
     if (is_self) {
       presence_.Gamertag(profile_->name());
-
       presence_.RichPresence(profile_->GetPresenceString());
-
       presence_.XUID(profile_->GetOnlineXUID());
-
       presence_.TitleID(fmt::format("{:08X}", kernel_state()->title_id()));
     } else if (!is_self) {
       // Cached friend presence
@@ -60,7 +51,8 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
     }
   } else {
     const auto presences =
-        kernel_state()->GetXboxLiveAPI()->GetFriendsPresence({xuid_});
+        kernel_state()->presence_manager()->GetFriendsPresence(profile_->xuid(),
+                                                               {xuid_});
 
     immediate_gamerpic_ = std::async(std::launch::async, [xuid,
                                                           imgui_drawer]() {
@@ -72,6 +64,8 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
 
       return shared_gamerpic;
     });
+
+    presence_.XUID(xuid_);
 
     if (!presences->PlayersPresence().empty()) {
       presence_ = presences->PlayersPresence().front();
@@ -98,8 +92,8 @@ GamercardFromXUIDUI::GamercardFromXUIDUI(xe::ui::ImGuiDrawer* imgui_drawer,
 }
 
 void GamercardFromXUIDUI::OnDraw(ImGuiIO& io) {
-  if (!card_opened) {
-    card_opened = true;
+  if (!dialog_open) {
+    dialog_open = true;
     ImGui::OpenPopup(title_.c_str());
   }
 
@@ -115,19 +109,21 @@ void GamercardFromXUIDUI::OnDraw(ImGuiIO& io) {
   }
 
   ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-  if (ImGui::BeginPopupModal(title_.c_str(), &card_opened,
+  if (ImGui::BeginPopupModal(title_.c_str(), &dialog_open,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     if (ImGui::IsKeyPressed(ImGuiKey::ImGuiKey_GamepadFaceRight, false)) {
       ImGui::CloseCurrentPopup();
     }
 
-    xeDrawFriendContent(imgui_drawer(), profile_, gamerpic_texture, presence_,
-                        nullptr, nullptr);
+    friend_presence_ = presence_.GetFriendPresence();
+
+    xeDrawFriendContent(imgui_drawer(), profile_, gamerpic_texture,
+                        friend_presence_, nullptr, nullptr);
 
     ImGui::EndPopup();
   }
 
-  if (!card_opened) {
+  if (!dialog_open) {
     Close();
   }
 }

--- a/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.h
+++ b/src/xenia/kernel/xam/ui/gamercard_from_xuid_ui.h
@@ -12,7 +12,6 @@
 
 #include <future>
 
-#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/xam/xam_ui.h"
 
 namespace xe {
@@ -28,15 +27,16 @@ class GamercardFromXUIDUI : public XamDialog {
  private:
   void OnDraw(ImGuiIO& io) override;
 
-  bool card_opened = false;
+  bool dialog_open = false;
   bool is_self = false;
   bool are_friends = false;
-  std::string title_;
+  std::string title_ = "Gamercard";
   const uint64_t xuid_;
   std::shared_future<std::shared_ptr<xe::ui::ImmediateTexture>>
       immediate_gamerpic_;
   UserProfile* profile_;
   FriendPresenceObjectJSON presence_;
+  X_ONLINE_FRIEND friend_presence_ = {};
 };
 
 }  // namespace ui

--- a/src/xenia/kernel/xam/user_profile.cc
+++ b/src/xenia/kernel/xam/user_profile.cc
@@ -203,70 +203,8 @@ bool UserProfile::WriteGpd(const uint32_t title_id) {
   return true;
 }
 
-bool UserProfile::SetSubscriptionFromXUID(const uint64_t xuid,
-                                          X_ONLINE_PRESENCE* peer) {
-  if (peer == nullptr) {
-    return false;
-  }
-
-  memcpy(&subscriptions_[xuid], &peer, sizeof(X_ONLINE_PRESENCE));
-
-  return true;
-}
-
-bool UserProfile::GetSubscriptionFromXUID(const uint64_t xuid,
-                                          X_ONLINE_PRESENCE* peer) {
-  if (!IsSubscribed(xuid)) {
-    return false;
-  }
-
-  if (peer == nullptr) {
-    return false;
-  }
-
-  memcpy(peer, &subscriptions_[xuid], sizeof(X_ONLINE_PRESENCE));
-
-  return true;
-}
-
-bool UserProfile::SubscribeFromXUID(const uint64_t xuid) {
-  if (subscriptions_.size() >= X_ONLINE_PEER_SUBSCRIPTIONS) {
-    return false;
-  }
-
-  subscriptions_[xuid] = {};
-
-  return true;
-}
-
-bool UserProfile::UnsubscribeFromXUID(const uint64_t xuid) {
-  if (!IsSubscribed(xuid)) {
-    return true;
-  }
-
-  if (subscriptions_.erase(xuid)) {
-    return true;
-  }
-
-  return false;
-}
-
-bool UserProfile::IsSubscribed(const uint64_t xuid) {
-  return subscriptions_.count(xuid) != 0;
-}
-
 void UserProfile::SetSelfInvite(X_INVITE_INFO invite_info) {
   self_invite = invite_info;
-}
-
-const std::set<uint64_t> UserProfile::GetSubscribedXUIDs() const {
-  std::set<uint64_t> subscribed_xuids;
-
-  for (const auto& [key, _] : subscriptions_) {
-    subscribed_xuids.insert(key);
-  }
-
-  return subscribed_xuids;
 }
 
 bool UserProfile::MutePlayer(uint64_t xuid) {
@@ -297,17 +235,6 @@ bool UserProfile::IsPlayerMuted(uint64_t xuid) const {
 
 std::u16string UserProfile::GetPresenceString() const {
   return online_presence_desc_;
-}
-
-bool UserProfile::IsPresenceStringUpdateAvailable() {
-  const std::u16string current_presence = GetPresenceString();
-  std::u16string updated_presence = u"";
-
-  if (!BuildPresenceString(false, &updated_presence)) {
-    return false;
-  }
-
-  return current_presence != updated_presence;
 }
 
 std::optional<object_ref<XSession>> UserProfile::FindValidInviteSession() {
@@ -346,47 +273,6 @@ void UserProfile::SetDiscordInviteSessionDetails(
 
 XSESSION_LOCAL_DETAILS UserProfile::GetDiscordInviteSessionDetails() const {
   return discord_invite_session_details_;
-}
-
-bool UserProfile::BuildPresenceString(bool update,
-                                      std::u16string* presence_string) {
-  bool completed = false;
-
-  const xam::Property* presence_prop =
-      kernel_state()->xam_state()->user_tracker()->GetProperty(
-          xuid_, XCONTEXT_PRESENCE);
-
-  if (!presence_prop) {
-    return completed;
-  }
-
-  const auto gdb = kernel_state()->emulator()->game_info_database();
-
-  if (!gdb->HasXLast()) {
-    return completed;
-  }
-
-  const auto xlast = gdb->GetXLast();
-
-  const std::u16string raw_presence =
-      xlast->GetPresenceRawString(presence_prop);
-
-  const auto presence_string_formatter =
-      util::AttributeStringFormatter(raw_presence, xlast, xuid_);
-
-  completed = presence_string_formatter.IsComplete();
-
-  const auto presence_parsed = presence_string_formatter.GetPresenceString();
-
-  if (completed && update) {
-    online_presence_desc_ = presence_parsed;
-  }
-
-  if (completed && presence_string) {
-    *presence_string = presence_parsed;
-  }
-
-  return completed;
 }
 
 }  // namespace xam

--- a/src/xenia/kernel/xam/user_profile.h
+++ b/src/xenia/kernel/xam/user_profile.h
@@ -178,25 +178,16 @@ class UserProfile {
   friend class UserTracker;
   friend class GpdAchievementBackend;
   friend class FriendsManager;
-
-  bool SetSubscriptionFromXUID(const uint64_t xuid, X_ONLINE_PRESENCE* peer);
-  bool GetSubscriptionFromXUID(const uint64_t xuid, X_ONLINE_PRESENCE* peer);
-  bool SubscribeFromXUID(const uint64_t xuid);
-  bool UnsubscribeFromXUID(const uint64_t xuid);
-  bool IsSubscribed(const uint64_t xuid);
+  friend class PresenceManager;
 
   void SetSelfInvite(X_INVITE_INFO invite_info);
   X_INVITE_INFO GetSelfInvite() { return self_invite; };
-
-  const std::set<uint64_t> GetSubscribedXUIDs() const;
 
   bool MutePlayer(uint64_t xuid);
   bool UnmutePlayer(uint64_t xuid);
   bool IsPlayerMuted(uint64_t xuid) const;
 
   std::u16string GetPresenceString() const;
-  bool IsPresenceStringUpdateAvailable();
-  bool BuildPresenceString(bool update, std::u16string* presence_string);
 
   std::optional<object_ref<XSession>> FindValidInviteSession();
   void SetDiscordInviteSessionDetails(

--- a/src/xenia/kernel/xam/user_tracker.cc
+++ b/src/xenia/kernel/xam/user_tracker.cc
@@ -1399,117 +1399,6 @@ void UserTracker::RefreshTitleSummary(uint64_t xuid, uint32_t title_id) {
   user->WriteGpd(kDashboardID);
 }
 
-PresenceSyncState UserTracker::IsPresenceOutOfSync(
-    uint64_t xuid, std::vector<FriendPresenceObjectJSON> presence_info) const {
-  PresenceSyncState sync_state = {};
-
-  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
-  if (!user) {
-    return sync_state;
-  }
-
-  if (presence_info.empty()) {
-    return sync_state;
-  }
-
-  for (const auto& player : presence_info) {
-    const uint64_t xuid = player.XUID();
-
-    const auto friends_manager = kernel_state()->friends_manager();
-
-    if (!friends_manager->IsFriend(user->xuid(), xuid) &&
-        !user->IsSubscribed(xuid)) {
-      XELOGI("Requested unknown peer presence: {} - {:016X}", player.Gamertag(),
-             xuid);
-      continue;
-    }
-
-    if (sync_state.friends && sync_state.peers) {
-      break;
-    }
-
-    const auto online_friend = friends_manager->GetFriend(user->xuid(), xuid);
-
-    if (online_friend.has_value()) {
-      const X_ONLINE_FRIEND peer = online_friend.value();
-      const X_ONLINE_FRIEND updated_peer_presence = player.GetFriendPresence();
-
-      if (std::memcmp(&peer, &updated_peer_presence, sizeof(X_ONLINE_FRIEND)) !=
-          0) {
-        sync_state.friends = true;
-      }
-    } else if (user->IsSubscribed(xuid) && !sync_state.peers) {
-      X_ONLINE_PRESENCE peer = {};
-
-      if (user->GetSubscriptionFromXUID(xuid, &peer)) {
-        const X_ONLINE_PRESENCE updated_peer_presence =
-            player.ToOnlineRichPresence();
-
-        if (std::memcmp(&peer, &updated_peer_presence,
-                        sizeof(X_ONLINE_PRESENCE)) != 0) {
-          sync_state.peers = true;
-        }
-      }
-    }
-  }
-
-  return sync_state;
-}
-
-void UserTracker::RefershFriendsAndSubscribersPresence(uint64_t xuid) const {
-  auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
-  if (!user) {
-    return;
-  }
-
-  const auto friends_manager = kernel_state()->friends_manager();
-
-  const auto friends_xuids = friends_manager->GetFriendsXUIDs(user->xuid());
-  const auto subscribed_xuids = user->GetSubscribedXUIDs();
-  std::set<uint64_t> friends_and_subscribed_xuids = {};
-
-  std::set_union(friends_xuids.cbegin(), friends_xuids.cend(),
-                 subscribed_xuids.cbegin(), subscribed_xuids.cend(),
-                 std::inserter(friends_and_subscribed_xuids,
-                               friends_and_subscribed_xuids.cbegin()));
-
-  const auto presences = kernel_state()->GetXboxLiveAPI()->GetFriendsPresence(
-      friends_and_subscribed_xuids);
-
-  const auto presence_sync_state =
-      IsPresenceOutOfSync(xuid, presences->PlayersPresence());
-
-  if (!presence_sync_state.IsOutOfSync()) {
-    return;
-  }
-
-  XELOGD("Friends/Subscribed peers presence state changed.");
-
-  for (const auto& player : presences->PlayersPresence()) {
-    const uint64_t xuid = player.XUID();
-
-    if (friends_manager->IsFriend(user->xuid(), xuid)) {
-      friends_manager->UpdateFriend(user->xuid(), player.GetFriendPresence());
-    } else if (user->IsSubscribed(xuid)) {
-      X_ONLINE_PRESENCE presence = player.ToOnlineRichPresence();
-      user->SetSubscriptionFromXUID(xuid, &presence);
-    }
-  }
-
-  if (presence_sync_state.friends) {
-    const uint32_t user_index =
-        kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(
-            xuid);
-
-    kernel_state()->BroadcastNotification(kXNotificationFriendsPresenceChanged,
-                                          user_index);
-  }
-
-  if (presence_sync_state.peers) {
-    kernel_state()->BroadcastNotification(kXNotificationLivePresenceChanged, 0);
-  }
-}
-
 void UserTracker::AddOwnedSession(uint64_t xuid,
                                   uint32_t session_handle) const {
   auto user = kernel_state()->xam_state()->GetUserProfile(xuid);
@@ -1580,14 +1469,13 @@ void UserTracker::PeriodicMaintenance(uint64_t xuid,
     return;
   }
 
-  // Check if presence string needs updating.
-  const bool presence_string_update_available =
-      user->IsPresenceStringUpdateAvailable();
+  const auto presence_manager = kernel_state()->presence_manager();
+
+  const bool updated_presence_string =
+      presence_manager->UpdateLocalPresence(user->xuid());
 
   // Update discord rich presence before checking live state.
-  if (presence_string_update_available) {
-    user->BuildPresenceString(true, nullptr);
-
+  if (updated_presence_string) {
     const std::u16string updated_presence = user->GetPresenceString();
 
     XELOGI("Periodic Maintenance (Presence): {} - {}", user->name(),
@@ -1607,7 +1495,8 @@ void UserTracker::PeriodicMaintenance(uint64_t xuid,
       kernel_state()->xam_state()->GetUserIndexAssignedToProfileFromXUID(xuid);
 
   // Discord invites
-  if (cvars::discord && cvars::discord_presence_user_index == user_index) {
+  if (cvars::discord && cvars::discord_presence_user_index == user_index &&
+      HasOwnedSessions(xuid)) {
     const auto valid_session = user->FindValidInviteSession();
 
     if (valid_session.has_value()) {
@@ -1649,13 +1538,20 @@ void UserTracker::PeriodicMaintenance(uint64_t xuid,
     return;
   }
 
-  // Check every 3nd iteration to reduce backend requests.
+  // 58410826 doesn't initialize presence, but we still want to update presence
+  // information. We want to synchronize for friends UI which is part of Guide
+  // which is independent of game.
+  //
+  // Possibly it's due to not distinguishing between X_ONLINE_FRIEND and
+  // X_ONLINE_PRESENCE?
+
+  //  Check every 3nd iteration to reduce backend requests.
   if (!(iteration_count % 3)) {
-    RefershFriendsAndSubscribersPresence(xuid);
+    presence_manager->SyncPresence(xuid);
   }
 
-  if (presence_string_update_available) {
-    kernel_state()->GetXboxLiveAPI()->SetPresence({user->xuid()});
+  if (updated_presence_string) {
+    presence_manager->UpdateXboxLiveLocalUsersPresence({user->xuid()});
   }
 
   if (HasOwnedSessions(xuid)) {

--- a/src/xenia/kernel/xam/user_tracker.h
+++ b/src/xenia/kernel/xam/user_tracker.h
@@ -16,7 +16,6 @@
 
 #include "xenia/xbox.h"
 
-#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/xam/user_profile.h"
 #include "xenia/kernel/xam/user_settings.h"
 
@@ -47,13 +46,6 @@ struct TitleInfo {
   }
 };
 
-struct PresenceSyncState {
-  bool friends;
-  bool peers;
-
-  bool IsOutOfSync() const { return friends || peers; }
-};
-
 class UserTracker {
  public:
   UserTracker() = default;
@@ -69,13 +61,6 @@ class UserTracker {
   // User related methods
   bool UnlockAchievement(uint64_t xuid, uint32_t achievement_id);
   void RefreshTitleSummary(uint64_t xuid, uint32_t title_id);
-
-  PresenceSyncState IsPresenceOutOfSync(
-      const uint64_t xuid,
-      const std::vector<FriendPresenceObjectJSON> presence_info) const;
-
-  // XFriendsCreateEnumerator & XPresenceCreateEnumerator
-  void RefershFriendsAndSubscribersPresence(const uint64_t xuid) const;
 
   // XSessions
   void AddOwnedSession(const uint64_t xuid,

--- a/src/xenia/kernel/xam/xam_state.cc
+++ b/src/xenia/kernel/xam/xam_state.cc
@@ -34,6 +34,8 @@ XamState::XamState(Emulator* emulator, KernelState* kernel_state)
   friends_manager_ =
       std::make_unique<FriendsManager>(kernel_state, profile_manager_.get());
   achievement_manager_ = std::make_unique<AchievementManager>();
+  presence_manager_ = std::make_unique<PresenceManager>(
+      kernel_state, profile_manager_.get(), friends_manager_.get());
 
   LoadOnlineFriends();
   LoadOnlineSchema();

--- a/src/xenia/kernel/xam/xam_state.h
+++ b/src/xenia/kernel/xam/xam_state.h
@@ -16,6 +16,7 @@
 #include "xenia/kernel/xam/app_manager.h"
 #include "xenia/kernel/xam/content_manager.h"
 #include "xenia/kernel/xam/friends_manager.h"
+#include "xenia/kernel/xam/presence_manager.h"
 #include "xenia/kernel/xam/profile_manager.h"
 #include "xenia/kernel/xam/user_tracker.h"
 #include "xenia/kernel/xam/xam.h"
@@ -46,6 +47,7 @@ class XamState {
   }
   ProfileManager* profile_manager() const { return profile_manager_.get(); }
   FriendsManager* friends_manager() const { return friends_manager_.get(); }
+  PresenceManager* presence_manager() const { return presence_manager_.get(); }
 
   UserTracker* user_tracker() const { return user_tracker_.get(); }
   SpaInfo* spa_info() const { return spa_info_.get(); }
@@ -101,6 +103,7 @@ class XamState {
   std::unique_ptr<AchievementManager> achievement_manager_;
   std::unique_ptr<ProfileManager> profile_manager_;
   std::unique_ptr<FriendsManager> friends_manager_;
+  std::unique_ptr<PresenceManager> presence_manager_;
 
   std::unique_ptr<SpaInfo> spa_info_;
 

--- a/src/xenia/kernel/xam/xam_ui.cc
+++ b/src/xenia/kernel/xam/xam_ui.cc
@@ -925,7 +925,7 @@ bool xeDrawProfileContent(xe::ui::ImGuiDrawer* imgui_drawer,
 bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
                          UserProfile* profile,
                          std::shared_ptr<xe::ui::ImmediateTexture> icon_texture,
-                         FriendPresenceObjectJSON& presence,
+                         const X_ONLINE_FRIEND& presence,
                          uint64_t* selected_xuid_, uint64_t* removed_xuid_) {
   if (icon_texture) {
     ImGui::Image(reinterpret_cast<ImTextureID>(icon_texture.get()),
@@ -940,29 +940,26 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
 
   ImVec2 start_drawing_position = ImGui::GetCursorPos();
 
-  ImGui::TextUnformatted(presence.Gamertag().c_str());
+  ImGui::TextUnformatted(presence.Gamertag);
 
   uint32_t index = 1;
 
-  const uint32_t title_id = presence.TitleIDValue();
+  const uint32_t title_id = presence.title_id.get();
 
-  if (!presence.TitleID().empty()) {
+  if (title_id) {
     ImGui::SameLine();
     ImGui::SetCursorPos(start_drawing_position);
     ImGui::SetCursorPosY(start_drawing_position.y + ImGui::GetTextLineHeight());
 
-    if (title_id) {
-      if (title_id == kernel_state()->title_id()) {
-        ImGui::TextUnformatted(
-            fmt::format("Game: {}", kernel_state()->emulator()->title_name())
-                .c_str());
-      } else {
-        ImGui::TextUnformatted(
-            fmt::format("Title ID: {}", presence.TitleID()).c_str());
-      }
-
-      index++;
+    if (title_id == kernel_state()->title_id()) {
+      ImGui::TextUnformatted(
+          fmt::format("Game: {}", kernel_state()->emulator()->title_name())
+              .c_str());
+    } else {
+      ImGui::TextUnformatted(fmt::format("Title ID: {}", title_id).c_str());
     }
+
+    index++;
   }
 
   ImGui::SameLine();
@@ -970,21 +967,24 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
   ImGui::SetCursorPosY(start_drawing_position.y +
                        index * ImGui::GetTextLineHeight());
 
-  const uint64_t friend_xuid = presence.XUID();
+  const uint64_t friend_xuid = presence.xuid.get();
   const std::string friend_xuid_str = fmt::format("{:016X}", friend_xuid);
 
   ImGui::TextUnformatted(
       fmt::format("Online XUID: {:016X}\n", friend_xuid).c_str());
   index++;
 
-  if (!presence.RichPresence().empty()) {
+  const std::u16string rich_presence = xe::string_util::read_u16string_and_swap(
+      reinterpret_cast<const char16_t*>(presence.wszRichPresence));
+
+  if (!rich_presence.empty()) {
     ImGui::SameLine();
     ImGui::SetCursorPos(start_drawing_position);
     ImGui::SetCursorPosY(start_drawing_position.y +
                          index * ImGui::GetTextLineHeight());
 
     std::string presense_string =
-        xe::string_util::trim(xe::to_utf8(presence.RichPresence()));
+        xe::string_util::trim(xe::to_utf8(rich_presence));
 
     presense_string =
         std::regex_replace(presense_string, std::regex("\\n"), ", ");
@@ -1005,7 +1005,7 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
 
   bool are_friends =
       kernel_state()->friends_manager()->IsFriend(profile->xuid(), friend_xuid);
-  bool is_self = profile->GetOnlineXUID() == presence.XUID();
+  bool is_self = profile->GetOnlineXUID() == presence.xuid.get();
 
   const std::string join_label =
       std::format("Join Session##{}", friend_xuid_str);
@@ -1019,12 +1019,12 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
   if (!is_self) {
     ImGui::Spacing();
 
-    ImGui::BeginDisabled(!presence.SessionID() || !same_title);
+    ImGui::BeginDisabled(!presence.session_id.as_uint64() || !same_title);
     if (ImGui::Button(join_label.c_str(), half_width_btn)) {
       X_INVITE_INFO invite = {};
 
       invite.xuid_invitee = profile->GetOnlineXUID();
-      invite.xuid_inviter = presence.XUID();
+      invite.xuid_inviter = presence.xuid.get();
       invite.title_id = kernel_state()->title_id();
       invite.from_game_invite = false;
 
@@ -1044,7 +1044,7 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
         ImGui::SetTooltip("Join gaming session");
       } else {
         ImGui::SetTooltip(
-            fmt::format("{} is playing a different game", presence.Gamertag())
+            fmt::format("{} is playing a different game", presence.Gamertag)
                 .c_str());
       }
     }
@@ -1060,8 +1060,9 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
           *removed_xuid_ = friend_xuid;
         }
 
-        std::string description =
-            !presence.Gamertag().empty() ? presence.Gamertag() : "Success";
+        const std::string gamertag(presence.Gamertag);
+
+        std::string description = !gamertag.empty() ? gamertag : "Success";
 
         kernel_state()
             ->emulator()
@@ -1083,8 +1084,9 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
       bool added = kernel_state()->friends_manager()->AddFriend(profile->xuid(),
                                                                 friend_xuid);
 
-      std::string description =
-          !presence.Gamertag().empty() ? presence.Gamertag() : "Success";
+      const std::string gamertag(presence.Gamertag);
+
+      std::string description = !gamertag.empty() ? gamertag : "Success";
 
       if (!added) {
         description = "Failed!";
@@ -1134,7 +1136,7 @@ bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
     if (ImGui::BeginPopupContextItem(context_label.c_str())) {
       if (ImGui::BeginMenu("Copy")) {
         if (ImGui::MenuItem("Gamertag")) {
-          ImGui::SetClipboardText(presence.Gamertag().c_str());
+          ImGui::SetClipboardText(presence.Gamertag);
         }
 
         ImGui::Separator();
@@ -1308,11 +1310,10 @@ bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
 
 bool xeDrawFriendsContent(
     xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
-    ui::FriendsContentArgs& args,
-    std::vector<FriendPresenceObjectJSON>* presences,
+    ui::FriendsContentArgs& args, std::vector<X_ONLINE_FRIEND>& presences,
     std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>&
         immediate_gamerpics) {
-  if (!profile || !presences) {
+  if (!profile) {
     return false;
   }
 
@@ -1450,22 +1451,21 @@ bool xeDrawFriendsContent(
     ImGui::Separator();
     ImGui::Spacing();
 
-    for (uint32_t index = 0; auto& presence : *presences) {
-      bool filter_gamertags =
-          args.filter.PassFilter(presence.Gamertag().c_str());
+    for (uint32_t index = 0; auto& presence : presences) {
+      bool filter_gamertags = args.filter.PassFilter(presence.Gamertag);
       bool filter_xuid = args.filter.PassFilter(
-          fmt::format("{:016X}", presence.XUID().get()).c_str());
+          fmt::format("{:016X}", presence.xuid.get()).c_str());
 
       if (filter_gamertags || filter_xuid) {
-        if (profile->GetOnlineXUID() == presence.XUID()) {
+        if (profile->GetOnlineXUID() == presence.xuid.get()) {
           continue;
         }
 
         const bool same_title =
-            presence.TitleIDValue() &&
-            presence.TitleIDValue() == kernel_state()->title_id();
+            presence.title_id.get() == kernel_state()->title_id();
 
-        if (args.filter_joinable && (!presence.SessionID() || !same_title)) {
+        if (args.filter_joinable &&
+            (!presence.session_id.as_uint64() || !same_title)) {
           continue;
         }
 
@@ -1474,14 +1474,14 @@ bool xeDrawFriendsContent(
         }
 
         if (args.filter_offline &&
-            (!presence.State() || !IsValidXUID(presence.XUID()))) {
+            (!presence.state.get() || !IsValidXUID(presence.xuid.get()))) {
           continue;
         }
 
         std::shared_ptr<xe::ui::ImmediateTexture> gamerpic = {};
 
-        if (immediate_gamerpics.contains(presence.XUID())) {
-          gamerpic = immediate_gamerpics.at(presence.XUID());
+        if (immediate_gamerpics.contains(presence.xuid.get())) {
+          gamerpic = immediate_gamerpics.at(presence.xuid.get());
         }
 
         uint64_t selected_xuid_ = 0;
@@ -1490,7 +1490,7 @@ bool xeDrawFriendsContent(
                             &selected_xuid_, &removed_xuid_);
 
         if (removed_xuid_) {
-          presences->erase(presences->begin() + index);
+          presences.erase(presences.begin() + index);
           removed_xuid_ = 0;
         }
 
@@ -1520,8 +1520,6 @@ bool xeDrawFriendsContent(
 
       if (ImGui::Button("Yes", btn_size)) {
         kernel_state()->friends_manager()->ClearFriends(profile->xuid());
-
-        args.refresh_presence = true;
 
         kernel_state()
             ->emulator()

--- a/src/xenia/kernel/xam/xam_ui.h
+++ b/src/xenia/kernel/xam/xam_ui.h
@@ -10,11 +10,11 @@
 #ifndef XENIA_KERNEL_XAM_XAM_UI_H_
 #define XENIA_KERNEL_XAM_XAM_UI_H_
 
-#include "xenia/kernel/json/friend_presence_object_json.h"
 #include "xenia/kernel/json/session_object_json.h"
 #include "xenia/kernel/upnp.h"
 #include "xenia/kernel/util/shim_utils.h"
 #include "xenia/kernel/xam/ui/netplay_manager_util.h"
+#include "xenia/kernel/xnet.h"
 #include "xenia/ui/imgui_dialog.h"
 #include "xenia/ui/imgui_drawer.h"
 
@@ -126,15 +126,14 @@ bool xeDrawProfileContent(xe::ui::ImGuiDrawer* imgui_drawer,
 
 bool xeDrawFriendsContent(
     xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,
-    ui::FriendsContentArgs& args,
-    std::vector<FriendPresenceObjectJSON>* presences,
+    ui::FriendsContentArgs& args, std::vector<X_ONLINE_FRIEND>& presences,
     std::map<uint64_t, std::shared_ptr<xe::ui::ImmediateTexture>>&
         immediate_gamerpics);
 
 bool xeDrawFriendContent(xe::ui::ImGuiDrawer* imgui_drawer,
                          UserProfile* profile,
                          std::shared_ptr<xe::ui::ImmediateTexture> icon_texture,
-                         FriendPresenceObjectJSON& presence,
+                         const X_ONLINE_FRIEND& presence,
                          uint64_t* selected_xuid_, uint64_t* removed_xuid_);
 
 bool xeDrawAddFriend(xe::ui::ImGuiDrawer* imgui_drawer, UserProfile* profile,

--- a/src/xenia/kernel/xnet.h
+++ b/src/xenia/kernel/xnet.h
@@ -461,8 +461,8 @@ static_assert_size(XLIVEBASE_WEBSERVICETASK_GETBUFFERSIZE, 0x14);
 
 struct XNKID {
   uint8_t ab[8];
-  uint64_t as_uint64() { return *reinterpret_cast<uint64_t*>(&ab); }
-  uint64_t as_uintBE64() { return xe::byte_swap(as_uint64()); }
+  uint64_t as_uint64() const { return *reinterpret_cast<const uint64_t*>(&ab); }
+  uint64_t as_uintBE64() const { return xe::byte_swap(as_uint64()); }
 
   bool operator==(const XNKID&) const = default;
 };


### PR DESCRIPTION
We have had basic presence functionality for awhile, this PR refactors presence functions into a presence manager class so it’s easier to maintain.

Friends UI now uses cached presence information which is synchronised using periodic maintenance, therefore requesting friend’s presence isn’t mandatory upon opening the UI anymore. Furthermore, refreshing presence in the Friends UI will now update the cached presence information and trigger relevant broadcast notifications. Lastly, the Friends UI will update itself whenever periodic maintenance synchronises the presence information from the backend.

Friends UI in `Netplay->Manager->Friends` and `XamShowFriendsUI` now use the same ImGUI dialog.
